### PR TITLE
[T002] Initialize root package.json with TypeScript 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,17 @@
     "lint:fix": "pnpm -r lint:fix",
     "format": "pnpm -r format",
     "clean": "pnpm -r clean",
+    "typecheck": "pnpm -r typecheck",
     "// === DEVELOPMENT ===": "",
     "dev": "pnpm -r --parallel dev",
     "// === DOCKER ===": "",
     "docker:up": "docker compose up -d",
     "docker:down": "docker compose down",
     "docker:test": "docker compose -f docker-compose.test.yml up -d"
+  },
+  "devDependencies": {
+    "typescript": "5.7.3",
+    "@types/node": "20.17.12"
   },
   "keywords": [
     "discussion",


### PR DESCRIPTION
## Summary
- Added TypeScript 5.7.3 as shared development dependency
- Added @types/node 20.17.12 for Node.js 20 LTS type definitions
- Added `typecheck` script for workspace-wide type checking

## Test plan
- [ ] Verify `pnpm install` installs TypeScript correctly
- [ ] Verify `tsc --version` shows 5.7.3

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)