### PR TITLE
[T007] Create docker-compose.test.yml for isolated test environment

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,57 @@
+services:
+  postgres-test:
+    image: postgres:16-alpine
+    container_name: unite-discord-postgres-test
+    restart: "no"
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: unite_discord_test
+    ports:
+      - "5433:5432"
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U test -d unite_discord_test"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
+  redis-test:
+    image: redis:7-alpine
+    container_name: unite-discord-redis-test
+    restart: "no"
+    command: redis-server --appendonly no
+    ports:
+      - "6380:6379"
+    tmpfs:
+      - /data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  localstack-test:
+    image: localstack/localstack:3
+    container_name: unite-discord-localstack-test
+    restart: "no"
+    environment:
+      SERVICES: s3,sqs,sns,dynamodb
+      DEBUG: 0
+      PERSISTENCE: 0
+    ports:
+      - "4567:4566"
+    tmpfs:
+      - /var/lib/localstack
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+
+networks:
+  default:
+    name: unite-discord-test-network


### PR DESCRIPTION
## Summary
- Create isolated test infrastructure that can run alongside development environment
- Use different ports, container names, and networks to prevent conflicts
- Use tmpfs for ephemeral data (faster tests, clean state each run)

## Port Mapping
| Service | Dev Port | Test Port |
|---------|----------|-----------|
| PostgreSQL | 5432 | 5433 |
| Redis | 6379 | 6380 |
| LocalStack | 4566 | 4567 |

## Key Design Decisions
- **tmpfs volumes**: Data stored in memory for speed and automatic cleanup
- **No persistence**: Tests start with clean state each run
- **Faster health checks**: Reduced intervals for CI/CD
- **No restart policy**: Containers won't restart on failure (fail-fast for tests)
- **Isolated network**: `unite-discord-test-network` separate from dev

## Usage
```bash
# Start test infrastructure
docker compose -f docker-compose.test.yml up -d

# Run tests
npm test

# Stop and cleanup
docker compose -f docker-compose.test.yml down
```

## Acceptance Criteria
- [x] Implementation complete
- [x] Docker Compose syntax validated
- [ ] Code reviewed

## Dependencies
- Depends on #6 (docker-compose.yml) - resolved

Closes #7

---
Generated with [Claude Code](https://claude.ai/code)