### PR TITLE
[T010] Create packages/common/ with shared types and utilities

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@unite-discord/common",
+  "version": "0.1.0",
+  "description": "Shared types, utilities, and constants for uniteDiscord",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./types": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/types/index.js"
+    },
+    "./utils": {
+      "types": "./dist/utils/index.d.ts",
+      "import": "./dist/utils/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "rm -rf dist .tsbuildinfo",
+    "typecheck": "tsc --noEmit",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "5.7.3"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "restricted"
+  }
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @unite-discord/common
+ *
+ * Shared types, utilities, and constants for the uniteDiscord platform.
+ */
+
+export * from './types/index.js';
+export * from './utils/index.js';

--- a/packages/common/src/types/discussion.ts
+++ b/packages/common/src/types/discussion.ts
@@ -1,0 +1,56 @@
+/**
+ * Discussion-related type definitions
+ */
+
+import type { UserId } from './user.js';
+
+/**
+ * Unique identifier for a discussion
+ */
+export type DiscussionId = string;
+
+/**
+ * Discussion status
+ */
+export type DiscussionStatus = 'draft' | 'active' | 'paused' | 'concluded' | 'archived';
+
+/**
+ * Discussion topic/category
+ */
+export interface DiscussionTopic {
+  id: string;
+  name: string;
+  description: string;
+}
+
+/**
+ * A discussion thread
+ */
+export interface Discussion {
+  id: DiscussionId;
+  title: string;
+  description: string;
+  topic: DiscussionTopic;
+  status: DiscussionStatus;
+  createdBy: UserId;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Unique identifier for a contribution
+ */
+export type ContributionId = string;
+
+/**
+ * A contribution to a discussion
+ */
+export interface Contribution {
+  id: ContributionId;
+  discussionId: DiscussionId;
+  authorId: UserId;
+  content: string;
+  parentId: ContributionId | null;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared type definitions for uniteDiscord
+ */
+
+export * from './result.js';
+export * from './user.js';
+export * from './discussion.js';

--- a/packages/common/src/types/result.ts
+++ b/packages/common/src/types/result.ts
@@ -1,0 +1,36 @@
+/**
+ * Result type for operations that can succeed or fail.
+ * Provides type-safe error handling without exceptions.
+ */
+
+export type Result<T, E = Error> =
+  | { success: true; data: T }
+  | { success: false; error: E };
+
+/**
+ * Create a successful result
+ */
+export function ok<T>(data: T): Result<T, never> {
+  return { success: true, data };
+}
+
+/**
+ * Create a failed result
+ */
+export function err<E>(error: E): Result<never, E> {
+  return { success: false, error };
+}
+
+/**
+ * Check if a result is successful
+ */
+export function isOk<T, E>(result: Result<T, E>): result is { success: true; data: T } {
+  return result.success;
+}
+
+/**
+ * Check if a result is an error
+ */
+export function isErr<T, E>(result: Result<T, E>): result is { success: false; error: E } {
+  return !result.success;
+}

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -1,0 +1,40 @@
+/**
+ * User-related type definitions
+ */
+
+/**
+ * Unique identifier for a user in the system
+ */
+export type UserId = string;
+
+/**
+ * Discord snowflake ID
+ */
+export type DiscordId = string;
+
+/**
+ * User role in the platform
+ */
+export type UserRole = 'participant' | 'moderator' | 'admin';
+
+/**
+ * Base user representation
+ */
+export interface User {
+  id: UserId;
+  discordId: DiscordId;
+  username: string;
+  role: UserRole;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * User profile with additional metadata
+ */
+export interface UserProfile extends User {
+  displayName: string | null;
+  avatarUrl: string | null;
+  bio: string | null;
+  participationScore: number;
+}

--- a/packages/common/src/utils/assert.ts
+++ b/packages/common/src/utils/assert.ts
@@ -1,0 +1,31 @@
+/**
+ * Assertion utilities for runtime checks
+ */
+
+/**
+ * Assert that a condition is true, throw if false
+ */
+export function assert(condition: boolean, message?: string): asserts condition {
+  if (!condition) {
+    throw new Error(message ?? 'Assertion failed');
+  }
+}
+
+/**
+ * Assert that a value is defined (not null or undefined)
+ */
+export function assertDefined<T>(
+  value: T | null | undefined,
+  message?: string,
+): asserts value is T {
+  if (value === null || value === undefined) {
+    throw new Error(message ?? 'Expected value to be defined');
+  }
+}
+
+/**
+ * Assert that a value is never reached (for exhaustive checks)
+ */
+export function assertNever(value: never, message?: string): never {
+  throw new Error(message ?? `Unexpected value: ${JSON.stringify(value)}`);
+}

--- a/packages/common/src/utils/id.ts
+++ b/packages/common/src/utils/id.ts
@@ -1,0 +1,20 @@
+/**
+ * ID generation utilities
+ */
+
+/**
+ * Generate a random ID with optional prefix
+ */
+export function generateId(prefix?: string): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).substring(2, 10);
+  const id = `${timestamp}${random}`;
+  return prefix ? `${prefix}_${id}` : id;
+}
+
+/**
+ * Check if a string is a valid ID format
+ */
+export function isValidId(id: string): boolean {
+  return typeof id === 'string' && id.length > 0 && id.length <= 64;
+}

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared utility functions for uniteDiscord
+ */
+
+export * from './assert.js';
+export * from './id.js';

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Create foundational shared package for the monorepo
- Add common type definitions used across services
- Add utility functions for assertions and ID generation

## Package Structure
```
packages/common/
├── src/
│   ├── index.ts
│   ├── types/
│   │   ├── index.ts
│   │   ├── result.ts      # Result<T,E> type-safe error handling
│   │   ├── user.ts        # User, UserProfile, UserRole types
│   │   └── discussion.ts  # Discussion, Contribution types
│   └── utils/
│       ├── index.ts
│       ├── assert.ts      # Runtime assertions
│       └── id.ts          # ID generation utilities
├── package.json
└── tsconfig.json
```

## Exports
| Path | Contents |
|------|----------|
| `@unite-discord/common` | All types and utilities |
| `@unite-discord/common/types` | Type definitions only |
| `@unite-discord/common/utils` | Utility functions only |

## Usage
```typescript
import { Result, ok, err, User } from '@unite-discord/common';
import { assert, generateId } from '@unite-discord/common/utils';
```

## Acceptance Criteria
- [x] Implementation complete
- [x] TypeScript compiles successfully
- [ ] Code reviewed

## Dependencies
- Depends on #2 (root package.json) - resolved

Closes #10

---
Generated with [Claude Code](https://claude.ai/code)