### PR TITLE
[T013] Create packages/db-models/ with Prisma schema initialization

### DIFF
--- a/packages/db-models/package.json
+++ b/packages/db-models/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@unite-discord/db-models",
+  "version": "0.1.0",
+  "description": "Prisma database models and client for uniteDiscord",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "import": "./dist/client.js"
+    }
+  },
+  "files": [
+    "dist",
+    "prisma"
+  ],
+  "scripts": {
+    "build": "prisma generate && tsc --build",
+    "clean": "rm -rf dist .tsbuildinfo",
+    "typecheck": "tsc --noEmit",
+    "dev": "tsc --watch",
+    "db:generate": "prisma generate",
+    "db:push": "prisma db push",
+    "db:migrate": "prisma migrate dev",
+    "db:migrate:deploy": "prisma migrate deploy",
+    "db:studio": "prisma studio",
+    "db:seed": "tsx prisma/seed.ts"
+  },
+  "dependencies": {
+    "@prisma/client": "6.3.1"
+  },
+  "devDependencies": {
+    "prisma": "6.3.1",
+    "typescript": "5.7.3"
+  },
+  "peerDependencies": {
+    "@unite-discord/common": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@unite-discord/common": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "restricted"
+  }
+}

--- a/packages/db-models/prisma/schema.prisma
+++ b/packages/db-models/prisma/schema.prisma
@@ -1,0 +1,578 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+// ============================================================================
+// USER SERVICE ENTITIES
+// ============================================================================
+
+/// User account with trust scores and verification status
+model User {
+  id                       String   @id @default(uuid()) @db.Uuid
+  email                    String   @unique
+  displayName              String   @map("display_name") @db.VarChar(50)
+  cognitoSub               String   @unique @map("cognito_sub")
+  verificationLevel        VerificationLevel @default(BASIC) @map("verification_level")
+  trustScoreAbility        Decimal  @default(0.50) @map("trust_score_ability") @db.Decimal(3, 2)
+  trustScoreBenevolence    Decimal  @default(0.50) @map("trust_score_benevolence") @db.Decimal(3, 2)
+  trustScoreIntegrity      Decimal  @default(0.50) @map("trust_score_integrity") @db.Decimal(3, 2)
+  moralFoundationProfile   Json?    @map("moral_foundation_profile")
+  positionFingerprint      Json?    @map("position_fingerprint")
+  topicAffinities          Json?    @map("topic_affinities")
+  status                   UserStatus @default(ACTIVE)
+  createdAt                DateTime @default(now()) @map("created_at")
+  updatedAt                DateTime @updatedAt @map("updated_at")
+
+  // Relations
+  verificationRecords      VerificationRecord[]
+  following                UserFollow[] @relation("Follower")
+  followers                UserFollow[] @relation("Followed")
+  createdTopics            DiscussionTopic[]
+  responses                Response[]
+  alignments               Alignment[]
+  proposedTopicLinks       TopicLink[] @relation("LinkProposer")
+  createdPropositions      Proposition[]
+  appeals                  Appeal[]
+  moderationApprovals      ModerationAction[] @relation("ModeratorApproval")
+  appealReviews            Appeal[] @relation("AppealReviewer")
+
+  @@index([cognitoSub])
+  @@index([email])
+  @@index([displayName])
+  @@map("users")
+}
+
+enum VerificationLevel {
+  BASIC
+  ENHANCED
+  VERIFIED_HUMAN
+
+  @@map("verification_level")
+}
+
+enum UserStatus {
+  ACTIVE
+  SUSPENDED
+  BANNED
+
+  @@map("user_status")
+}
+
+/// Tracks user verification records (email, phone, government ID)
+model VerificationRecord {
+  id                String   @id @default(uuid()) @db.Uuid
+  userId            String   @map("user_id") @db.Uuid
+  type              VerificationType
+  status            VerificationStatus @default(PENDING)
+  verifiedAt        DateTime? @map("verified_at")
+  expiresAt         DateTime? @map("expires_at")
+  providerReference String?  @map("provider_reference")
+  createdAt         DateTime @default(now()) @map("created_at")
+
+  // Relations
+  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, type])
+  @@index([status])
+  @@map("verification_records")
+}
+
+enum VerificationType {
+  EMAIL
+  PHONE
+  GOVERNMENT_ID
+
+  @@map("verification_type")
+}
+
+enum VerificationStatus {
+  PENDING
+  VERIFIED
+  REJECTED
+  EXPIRED
+
+  @@map("verification_status")
+}
+
+/// Tracks user follow relationships
+model UserFollow {
+  id          String   @id @default(uuid()) @db.Uuid
+  followerId  String   @map("follower_id") @db.Uuid
+  followedId  String   @map("followed_id") @db.Uuid
+  createdAt   DateTime @default(now()) @map("created_at")
+
+  // Relations
+  follower    User     @relation("Follower", fields: [followerId], references: [id], onDelete: Cascade)
+  followed    User     @relation("Followed", fields: [followedId], references: [id], onDelete: Cascade)
+
+  @@unique([followerId, followedId])
+  @@index([followerId])
+  @@index([followedId])
+  @@map("user_follows")
+}
+
+// ============================================================================
+// DISCUSSION SERVICE ENTITIES
+// ============================================================================
+
+/// A discussion topic with tags and propositions
+model DiscussionTopic {
+  id                      String   @id @default(uuid()) @db.Uuid
+  title                   String   @db.VarChar(200)
+  description             String   @db.Text
+  creatorId               String   @map("creator_id") @db.Uuid
+  status                  TopicStatus @default(SEEDING)
+  evidenceStandards       EvidenceStandard @default(STANDARD) @map("evidence_standards")
+  minimumDiversityScore   Decimal  @default(0.30) @map("minimum_diversity_score") @db.Decimal(3, 2)
+  currentDiversityScore   Decimal? @map("current_diversity_score") @db.Decimal(3, 2)
+  participantCount        Int      @default(0) @map("participant_count")
+  responseCount           Int      @default(0) @map("response_count")
+  crossCuttingThemes      String[] @map("cross_cutting_themes")
+  createdAt               DateTime @default(now()) @map("created_at")
+  activatedAt             DateTime? @map("activated_at")
+  archivedAt              DateTime? @map("archived_at")
+
+  // Relations
+  creator                 User     @relation(fields: [creatorId], references: [id])
+  tags                    TopicTag[]
+  sourceLinks             TopicLink[] @relation("SourceTopic")
+  targetLinks             TopicLink[] @relation("TargetTopic")
+  propositions            Proposition[]
+  responses               Response[]
+  commonGroundAnalyses    CommonGroundAnalysis[]
+
+  @@index([status])
+  @@index([creatorId])
+  @@index([createdAt(sort: Desc)])
+  @@map("discussion_topics")
+}
+
+enum TopicStatus {
+  SEEDING
+  ACTIVE
+  ARCHIVED
+
+  @@map("topic_status")
+}
+
+enum EvidenceStandard {
+  MINIMAL
+  STANDARD
+  RIGOROUS
+
+  @@map("evidence_standard")
+}
+
+/// Tags for categorizing discussion topics
+model Tag {
+  id            String   @id @default(uuid()) @db.Uuid
+  name          String   @unique @db.VarChar(50)
+  slug          String   @unique
+  usageCount    Int      @default(0) @map("usage_count")
+  aiSynonyms    String[] @map("ai_synonyms")
+  parentThemeId String?  @map("parent_theme_id") @db.Uuid
+  createdAt     DateTime @default(now()) @map("created_at")
+
+  // Relations
+  parentTheme   Tag?     @relation("TagHierarchy", fields: [parentThemeId], references: [id])
+  childThemes   Tag[]    @relation("TagHierarchy")
+  topics        TopicTag[]
+
+  @@index([usageCount(sort: Desc)])
+  @@map("tags")
+}
+
+/// Junction table for topic-tag relationships
+model TopicTag {
+  topicId   String   @map("topic_id") @db.Uuid
+  tagId     String   @map("tag_id") @db.Uuid
+  source    TagSource
+  createdAt DateTime @default(now()) @map("created_at")
+
+  // Relations
+  topic     DiscussionTopic @relation(fields: [topicId], references: [id], onDelete: Cascade)
+  tag       Tag             @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@id([topicId, tagId])
+  @@index([tagId])
+  @@map("topic_tags")
+}
+
+enum TagSource {
+  CREATOR
+  AI_SUGGESTED
+  COMMUNITY
+
+  @@map("tag_source")
+}
+
+/// Links between related discussion topics
+model TopicLink {
+  id                  String   @id @default(uuid()) @db.Uuid
+  sourceTopicId       String   @map("source_topic_id") @db.Uuid
+  targetTopicId       String   @map("target_topic_id") @db.Uuid
+  relationshipType    TopicRelationshipType @map("relationship_type")
+  linkSource          LinkSource @map("link_source")
+  proposerId          String?  @map("proposer_id") @db.Uuid
+  confirmationStatus  ConfirmationStatus @default(PENDING) @map("confirmation_status")
+  confirmedByCount    Int      @default(0) @map("confirmed_by_count")
+  rejectedByCount     Int      @default(0) @map("rejected_by_count")
+  createdAt           DateTime @default(now()) @map("created_at")
+
+  // Relations
+  sourceTopic         DiscussionTopic @relation("SourceTopic", fields: [sourceTopicId], references: [id], onDelete: Cascade)
+  targetTopic         DiscussionTopic @relation("TargetTopic", fields: [targetTopicId], references: [id], onDelete: Cascade)
+  proposer            User?    @relation("LinkProposer", fields: [proposerId], references: [id])
+
+  @@unique([sourceTopicId, targetTopicId, relationshipType])
+  @@index([sourceTopicId])
+  @@index([targetTopicId])
+  @@index([relationshipType])
+  @@index([confirmationStatus])
+  @@map("topic_links")
+}
+
+enum TopicRelationshipType {
+  BUILDS_ON
+  RESPONDS_TO
+  CONTRADICTS
+  RELATED
+  SHARES_PROPOSITION
+
+  @@map("topic_relationship_type")
+}
+
+enum LinkSource {
+  AI_SUGGESTED
+  USER_PROPOSED
+
+  @@map("link_source")
+}
+
+enum ConfirmationStatus {
+  PENDING
+  CONFIRMED
+  REJECTED
+
+  @@map("confirmation_status")
+}
+
+/// A proposition/claim within a discussion topic
+model Proposition {
+  id                    String   @id @default(uuid()) @db.Uuid
+  topicId               String   @map("topic_id") @db.Uuid
+  statement             String   @db.VarChar(1000)
+  source                PropositionSource
+  creatorId             String?  @map("creator_id") @db.Uuid
+  parentPropositionId   String?  @map("parent_proposition_id") @db.Uuid
+  supportCount          Int      @default(0) @map("support_count")
+  opposeCount           Int      @default(0) @map("oppose_count")
+  nuancedCount          Int      @default(0) @map("nuanced_count")
+  consensusScore        Decimal? @map("consensus_score") @db.Decimal(3, 2)
+  evidencePool          Json?    @map("evidence_pool")
+  status                PropositionStatus @default(ACTIVE)
+  createdAt             DateTime @default(now()) @map("created_at")
+
+  // Relations
+  topic                 DiscussionTopic @relation(fields: [topicId], references: [id], onDelete: Cascade)
+  creator               User?    @relation(fields: [creatorId], references: [id])
+  parentProposition     Proposition? @relation("PropositionHierarchy", fields: [parentPropositionId], references: [id])
+  childPropositions     Proposition[] @relation("PropositionHierarchy")
+  alignments            Alignment[]
+  responses             ResponseProposition[]
+
+  @@index([topicId])
+  @@index([parentPropositionId])
+  @@index([topicId, consensusScore(sort: Desc)])
+  @@map("propositions")
+}
+
+enum PropositionSource {
+  AI_IDENTIFIED
+  USER_CREATED
+
+  @@map("proposition_source")
+}
+
+enum PropositionStatus {
+  ACTIVE
+  MERGED
+  ARCHIVED
+
+  @@map("proposition_status")
+}
+
+/// A response/comment in a discussion topic
+model Response {
+  id                    String   @id @default(uuid()) @db.Uuid
+  topicId               String   @map("topic_id") @db.Uuid
+  authorId              String   @map("author_id") @db.Uuid
+  content               String   @db.Text
+  citedSources          Json?    @map("cited_sources")
+  containsOpinion       Boolean  @default(false) @map("contains_opinion")
+  containsFactualClaims Boolean  @default(false) @map("contains_factual_claims")
+  status                ResponseStatus @default(VISIBLE)
+  revisionCount         Int      @default(0) @map("revision_count")
+  createdAt             DateTime @default(now()) @map("created_at")
+  updatedAt             DateTime @updatedAt @map("updated_at")
+
+  // Relations
+  topic                 DiscussionTopic @relation(fields: [topicId], references: [id], onDelete: Cascade)
+  author                User     @relation(fields: [authorId], references: [id])
+  propositions          ResponseProposition[]
+  feedback              Feedback[]
+  factCheckResults      FactCheckResult[]
+
+  @@index([topicId])
+  @@index([authorId])
+  @@index([topicId, createdAt(sort: Desc)])
+  @@index([status])
+  @@map("responses")
+}
+
+enum ResponseStatus {
+  VISIBLE
+  HIDDEN
+  REMOVED
+
+  @@map("response_status")
+}
+
+/// Junction table for response-proposition relationships
+model ResponseProposition {
+  responseId      String   @map("response_id") @db.Uuid
+  propositionId   String   @map("proposition_id") @db.Uuid
+  relevanceScore  Decimal? @map("relevance_score") @db.Decimal(3, 2)
+
+  // Relations
+  response        Response    @relation(fields: [responseId], references: [id], onDelete: Cascade)
+  proposition     Proposition @relation(fields: [propositionId], references: [id], onDelete: Cascade)
+
+  @@id([responseId, propositionId])
+  @@map("response_propositions")
+}
+
+/// User alignment (support/oppose/nuanced) on a proposition
+model Alignment {
+  id                  String   @id @default(uuid()) @db.Uuid
+  userId              String   @map("user_id") @db.Uuid
+  propositionId       String   @map("proposition_id") @db.Uuid
+  stance              AlignmentStance
+  nuanceExplanation   String?  @map("nuance_explanation") @db.Text
+  createdAt           DateTime @default(now()) @map("created_at")
+  updatedAt           DateTime @updatedAt @map("updated_at")
+
+  // Relations
+  user                User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  proposition         Proposition @relation(fields: [propositionId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, propositionId])
+  @@index([propositionId])
+  @@map("alignments")
+}
+
+enum AlignmentStance {
+  SUPPORT
+  OPPOSE
+  NUANCED
+
+  @@map("alignment_stance")
+}
+
+/// AI-generated common ground analysis for a topic
+model CommonGroundAnalysis {
+  id                            String   @id @default(uuid()) @db.Uuid
+  topicId                       String   @map("topic_id") @db.Uuid
+  version                       Int
+  agreementZones                Json     @map("agreement_zones")
+  misunderstandings             Json
+  genuineDisagreements          Json     @map("genuine_disagreements")
+  overallConsensusScore         Decimal? @map("overall_consensus_score") @db.Decimal(3, 2)
+  participantCountAtGeneration  Int      @map("participant_count_at_generation")
+  responseCountAtGeneration     Int      @map("response_count_at_generation")
+  modelVersion                  String   @map("model_version")
+  createdAt                     DateTime @default(now()) @map("created_at")
+
+  // Relations
+  topic                         DiscussionTopic @relation(fields: [topicId], references: [id], onDelete: Cascade)
+
+  @@index([topicId])
+  @@index([topicId, version(sort: Desc)])
+  @@map("common_ground_analyses")
+}
+
+// ============================================================================
+// AI SERVICE ENTITIES
+// ============================================================================
+
+/// AI-generated feedback on a response
+model Feedback {
+  id                    String   @id @default(uuid()) @db.Uuid
+  responseId            String   @map("response_id") @db.Uuid
+  type                  FeedbackType
+  subtype               String?
+  suggestionText        String   @map("suggestion_text") @db.Text
+  reasoning             String   @db.Text
+  confidenceScore       Decimal  @map("confidence_score") @db.Decimal(3, 2)
+  educationalResources  Json?    @map("educational_resources")
+  userAcknowledged      Boolean  @default(false) @map("user_acknowledged")
+  userRevised           Boolean  @default(false) @map("user_revised")
+  userHelpfulRating     HelpfulRating? @map("user_helpful_rating")
+  displayedToUser       Boolean  @map("displayed_to_user")
+  createdAt             DateTime @default(now()) @map("created_at")
+
+  // Relations
+  response              Response @relation(fields: [responseId], references: [id], onDelete: Cascade)
+
+  @@index([responseId])
+  @@index([type])
+  @@index([displayedToUser, createdAt])
+  @@map("feedback")
+}
+
+enum FeedbackType {
+  FALLACY
+  INFLAMMATORY
+  UNSOURCED
+  BIAS
+  AFFIRMATION
+
+  @@map("feedback_type")
+}
+
+enum HelpfulRating {
+  HELPFUL
+  NOT_HELPFUL
+
+  @@map("helpful_rating")
+}
+
+// ============================================================================
+// FACT-CHECK SERVICE ENTITIES
+// ============================================================================
+
+/// Fact-check results for claims in responses
+model FactCheckResult {
+  id                    String   @id @default(uuid()) @db.Uuid
+  responseId            String   @map("response_id") @db.Uuid
+  claimText             String   @map("claim_text") @db.Text
+  claimStartOffset      Int      @map("claim_start_offset")
+  claimEndOffset        Int      @map("claim_end_offset")
+  sources               Json
+  hasConflictingSources Boolean  @default(false) @map("has_conflicting_sources")
+  displayedAs           String   @default("Related Context") @map("displayed_as")
+  createdAt             DateTime @default(now()) @map("created_at")
+  expiresAt             DateTime @map("expires_at")
+
+  // Relations
+  response              Response @relation(fields: [responseId], references: [id], onDelete: Cascade)
+
+  @@index([responseId])
+  @@index([expiresAt])
+  @@map("fact_check_results")
+}
+
+// ============================================================================
+// MODERATION SERVICE ENTITIES
+// ============================================================================
+
+/// Moderation actions taken on content or users
+model ModerationAction {
+  id              String   @id @default(uuid()) @db.Uuid
+  targetType      ModerationTargetType @map("target_type")
+  targetId        String   @map("target_id") @db.Uuid
+  actionType      ModerationActionType @map("action_type")
+  severity        ModerationSeverity
+  reasoning       String   @db.Text
+  aiRecommended   Boolean  @default(false) @map("ai_recommended")
+  aiConfidence    Decimal? @map("ai_confidence") @db.Decimal(3, 2)
+  approvedById    String?  @map("approved_by_id") @db.Uuid
+  approvedAt      DateTime? @map("approved_at")
+  status          ModerationStatus @default(PENDING)
+  createdAt       DateTime @default(now()) @map("created_at")
+  executedAt      DateTime? @map("executed_at")
+
+  // Relations
+  approvedBy      User?    @relation("ModeratorApproval", fields: [approvedById], references: [id])
+  appeals         Appeal[]
+
+  @@index([targetType, targetId])
+  @@index([status])
+  @@index([severity])
+  @@map("moderation_actions")
+}
+
+enum ModerationTargetType {
+  RESPONSE
+  USER
+  TOPIC
+
+  @@map("moderation_target_type")
+}
+
+enum ModerationActionType {
+  EDUCATE
+  WARN
+  HIDE
+  REMOVE
+  SUSPEND
+  BAN
+
+  @@map("moderation_action_type")
+}
+
+enum ModerationSeverity {
+  NON_PUNITIVE
+  CONSEQUENTIAL
+
+  @@map("moderation_severity")
+}
+
+enum ModerationStatus {
+  PENDING
+  ACTIVE
+  APPEALED
+  REVERSED
+
+  @@map("moderation_status")
+}
+
+/// Appeals against moderation actions
+model Appeal {
+  id                  String   @id @default(uuid()) @db.Uuid
+  moderationActionId  String   @map("moderation_action_id") @db.Uuid
+  appellantId         String   @map("appellant_id") @db.Uuid
+  reason              String   @db.Text
+  status              AppealStatus @default(PENDING)
+  reviewerId          String?  @map("reviewer_id") @db.Uuid
+  decisionReasoning   String?  @map("decision_reasoning") @db.Text
+  createdAt           DateTime @default(now()) @map("created_at")
+  resolvedAt          DateTime? @map("resolved_at")
+
+  // Relations
+  moderationAction    ModerationAction @relation(fields: [moderationActionId], references: [id], onDelete: Cascade)
+  appellant           User     @relation(fields: [appellantId], references: [id])
+  reviewer            User?    @relation("AppealReviewer", fields: [reviewerId], references: [id])
+
+  @@unique([moderationActionId, appellantId])
+  @@index([moderationActionId])
+  @@index([status])
+  @@map("appeals")
+}
+
+enum AppealStatus {
+  PENDING
+  UNDER_REVIEW
+  UPHELD
+  DENIED
+
+  @@map("appeal_status")
+}

--- a/packages/db-models/src/client.ts
+++ b/packages/db-models/src/client.ts
@@ -1,0 +1,59 @@
+/**
+ * Prisma client singleton and factory functions.
+ *
+ * This module provides:
+ * - A singleton Prisma client instance for typical use
+ * - A factory function for creating isolated clients (useful for testing)
+ * - Graceful disconnect handling
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+// Singleton instance
+let prismaInstance: PrismaClient | null = null;
+
+/**
+ * Get or create the singleton Prisma client instance.
+ * This is the recommended way to access the database in production code.
+ */
+export function getPrismaClient(): PrismaClient {
+  if (!prismaInstance) {
+    prismaInstance = new PrismaClient({
+      log:
+        process.env['NODE_ENV'] === 'development'
+          ? ['query', 'error', 'warn']
+          : ['error'],
+    });
+  }
+  return prismaInstance;
+}
+
+/**
+ * The default singleton Prisma client.
+ * Use this for most database operations.
+ */
+export const prisma = getPrismaClient();
+
+/**
+ * Create a new Prisma client instance.
+ * Useful for:
+ * - Testing with isolated database connections
+ * - Worker processes that need their own connection
+ * - Scenarios requiring different logging configuration
+ */
+export function createPrismaClient(
+  options?: ConstructorParameters<typeof PrismaClient>[0]
+): PrismaClient {
+  return new PrismaClient(options);
+}
+
+/**
+ * Gracefully disconnect the singleton Prisma client.
+ * Call this during application shutdown.
+ */
+export async function disconnectPrisma(): Promise<void> {
+  if (prismaInstance) {
+    await prismaInstance.$disconnect();
+    prismaInstance = null;
+  }
+}

--- a/packages/db-models/src/index.ts
+++ b/packages/db-models/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @unite-discord/db-models
+ *
+ * Prisma database models and client for uniteDiscord.
+ * This package provides the generated Prisma client and re-exports
+ * all model types for use across the monorepo.
+ */
+
+// Re-export all Prisma types and enums
+export * from '@prisma/client';
+
+// Re-export the client factory
+export { prisma, createPrismaClient, disconnectPrisma } from './client.js';

--- a/packages/db-models/tsconfig.json
+++ b/packages/db-models/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,22 @@ importers:
         specifier: 5.7.3
         version: 5.7.3
 
+  packages/db-models:
+    dependencies:
+      '@prisma/client':
+        specifier: 6.3.1
+        version: 6.3.1(prisma@6.3.1(typescript@5.7.3))(typescript@5.7.3)
+      '@unite-discord/common':
+        specifier: workspace:*
+        version: link:../common
+    devDependencies:
+      prisma:
+        specifier: 6.3.1
+        version: 6.3.1(typescript@5.7.3)
+      typescript:
+        specifier: 5.7.3
+        version: 5.7.3
+
   packages/event-schemas:
     devDependencies:
       typescript:
@@ -143,6 +159,33 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@prisma/client@6.3.1':
+    resolution: {integrity: sha512-ARAJaPs+eBkemdky/XU3cvGRl+mIPHCN2lCXsl5Vlb0E2gV+R6IN7aCI8CisRGszEZondwIsW9Iz8EJkTdykyA==}
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+
+  '@prisma/debug@6.3.1':
+    resolution: {integrity: sha512-RrEBkd+HLZx+ydfmYT0jUj7wjLiS95wfTOSQ+8FQbvb6vHh5AeKfEPt/XUQ5+Buljj8hltEfOslEW57/wQIVeA==}
+
+  '@prisma/engines-version@6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0':
+    resolution: {integrity: sha512-R/ZcMuaWZT2UBmgX3Ko6PAV3f8//ZzsjRIG1eKqp3f2rqEqVtCv+mtzuH2rBPUC9ujJ5kCb9wwpxeyCkLcHVyA==}
+
+  '@prisma/engines@6.3.1':
+    resolution: {integrity: sha512-sXdqEVLyGAJ5/iUoG/Ea5AdHMN71m6PzMBWRQnLmhhOejzqAaEr8rUd623ql6OJpED4s/U4vIn4dg1qkF7vGag==}
+
+  '@prisma/fetch-engine@6.3.1':
+    resolution: {integrity: sha512-HOf/0umOgt+/S2xtZze+FHKoxpVg4YpVxROr6g2YG09VsI3Ipyb+rGvD6QGbCqkq5NTWAAZoOGNL+oy7t+IhaQ==}
+
+  '@prisma/get-platform@6.3.1':
+    resolution: {integrity: sha512-AYLq6Hk9xG73JdLWJ3Ip9Wg/vlP7xPvftGBalsPzKDOHr/ImhwJ09eS8xC2vNT12DlzGxhfk8BkL0ve2OriNhQ==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -567,6 +610,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -963,6 +1011,16 @@ packages:
     resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  prisma@6.3.1:
+    resolution: {integrity: sha512-JKCZWvBC3enxk51tY4TWzS4b5iRt4sSU1uHn2I183giZTvonXaQonzVtjLzpOHE7qu9MxY510kAtFGJwryKe3Q==}
+    engines: {node: '>=18.18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1273,6 +1331,32 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@prisma/client@6.3.1(prisma@6.3.1(typescript@5.7.3))(typescript@5.7.3)':
+    optionalDependencies:
+      prisma: 6.3.1(typescript@5.7.3)
+      typescript: 5.7.3
+
+  '@prisma/debug@6.3.1': {}
+
+  '@prisma/engines-version@6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0': {}
+
+  '@prisma/engines@6.3.1':
+    dependencies:
+      '@prisma/debug': 6.3.1
+      '@prisma/engines-version': 6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0
+      '@prisma/fetch-engine': 6.3.1
+      '@prisma/get-platform': 6.3.1
+
+  '@prisma/fetch-engine@6.3.1':
+    dependencies:
+      '@prisma/debug': 6.3.1
+      '@prisma/engines-version': 6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0
+      '@prisma/get-platform': 6.3.1
+
+  '@prisma/get-platform@6.3.1':
+    dependencies:
+      '@prisma/debug': 6.3.1
 
   '@rtsao/scc@1.1.0': {}
 
@@ -1855,6 +1939,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.3:
+    optional: true
+
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -2277,6 +2364,13 @@ snapshots:
       '@jest/schemas': 30.0.5
       ansi-styles: 5.2.0
       react-is: 18.3.1
+
+  prisma@6.3.1(typescript@5.7.3):
+    dependencies:
+      '@prisma/engines': 6.3.1
+    optionalDependencies:
+      fsevents: 2.3.3
+      typescript: 5.7.3
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
## Summary
- Creates `packages/db-models/` package with Prisma ORM setup
- Comprehensive schema covering all 16 entities from data-model.md specification
- TypeScript client with singleton pattern and factory functions
- Proper monorepo integration with workspace dependencies

## Details
This implements issue #13 (T013) from the setup phase. The package includes:

### Prisma Schema
- **User Service**: User, VerificationRecord, UserFollow
- **Discussion Service**: DiscussionTopic, Tag, TopicTag, TopicLink, Proposition, Response, ResponseProposition, Alignment, CommonGroundAnalysis
- **AI Service**: Feedback
- **Fact-Check Service**: FactCheckResult
- **Moderation Service**: ModerationAction, Appeal

### TypeScript Client
- Singleton `prisma` instance for typical use
- `createPrismaClient()` factory for testing/workers
- `disconnectPrisma()` for graceful shutdown

## Test plan
- [x] `pnpm install` completes successfully
- [x] `prisma generate` generates client without errors
- [x] `pnpm run build` compiles TypeScript
- [x] `pnpm run typecheck` passes across all packages

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)