### PR TITLE
chore: Add package-lock.json for packages/common

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "@unite-discord/common",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@unite-discord/common",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "5.7.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "http://localhost:4873/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Include the npm lockfile for the @unite-discord/common package to ensure reproducible dependency installations. The lockfile pins TypeScript at version 5.7.3 as specified in the package.json devDependencies.