### PR TITLE
feat: Scaffold discussion-service with NestJS base (closes #32)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,40 @@ importers:
         specifier: 5.7.3
         version: 5.7.3
 
+  services/discussion-service:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^10.3.0
+        version: 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^10.3.0
+        version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/platform-fastify':
+        specifier: ^10.3.0
+        version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
+      '@unite-discord/db-models':
+        specifier: workspace:*
+        version: link:../../packages/db-models
+      fastify:
+        specifier: ^4.25.2
+        version: 4.29.1
+      reflect-metadata:
+        specifier: ^0.2.1
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.12
+        version: 20.17.12
+      tsx:
+        specifier: ^4.7.0
+        version: 4.21.0
+      typescript:
+        specifier: 5.7.3
+        version: 5.7.3
+
   services/user-service:
     dependencies:
       '@nestjs/common':

--- a/services/discussion-service/README.md
+++ b/services/discussion-service/README.md
@@ -1,0 +1,34 @@
+# Discussion Service
+
+NestJS-based microservice for managing discussion operations in uniteDiscord.
+
+## Features
+
+- NestJS with Fastify adapter
+- Prisma ORM integration via `@unite-discord/db-models`
+- Health check endpoint
+- TypeScript 5.x
+
+## Development
+
+```bash
+# Install dependencies (from monorepo root)
+pnpm install
+
+# Run in development mode
+pnpm --filter @unite-discord/discussion-service dev
+
+# Build
+pnpm --filter @unite-discord/discussion-service build
+
+# Start production build
+pnpm --filter @unite-discord/discussion-service start
+```
+
+## API Endpoints
+
+- `GET /health` - Health check endpoint
+
+## Port
+
+Default: `3002` (configurable via `PORT` environment variable)

--- a/services/discussion-service/package.json
+++ b/services/discussion-service/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@unite-discord/discussion-service",
+  "version": "0.1.0",
+  "description": "Discussion service with NestJS and Prisma",
+  "type": "module",
+  "main": "./dist/main.js",
+  "types": "./dist/main.d.ts",
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "rm -rf dist .tsbuildinfo",
+    "typecheck": "tsc --noEmit",
+    "dev": "tsx watch src/main.ts",
+    "start": "node dist/main.js",
+    "start:dev": "tsx watch src/main.ts",
+    "start:prod": "node dist/main.js",
+    "test": "echo \"No tests yet\" && exit 0"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.3.0",
+    "@nestjs/core": "^10.3.0",
+    "@nestjs/platform-fastify": "^10.3.0",
+    "@unite-discord/db-models": "workspace:*",
+    "fastify": "^4.25.2",
+    "reflect-metadata": "^0.2.1",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.12",
+    "tsx": "^4.7.0",
+    "typescript": "5.7.3"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/services/discussion-service/src/app.module.ts
+++ b/services/discussion-service/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from './prisma/prisma.module.js';
+import { HealthModule } from './health/health.module.js';
+
+@Module({
+  imports: [PrismaModule, HealthModule],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/services/discussion-service/src/health/health.controller.ts
+++ b/services/discussion-service/src/health/health.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('health')
+export class HealthController {
+  @Get()
+  check() {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      service: 'discussion-service',
+    };
+  }
+}

--- a/services/discussion-service/src/health/health.module.ts
+++ b/services/discussion-service/src/health/health.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller.js';
+
+@Module({
+  controllers: [HealthController],
+})
+export class HealthModule {}

--- a/services/discussion-service/src/main.ts
+++ b/services/discussion-service/src/main.ts
@@ -1,0 +1,20 @@
+import { NestFactory } from '@nestjs/core';
+import {
+  FastifyAdapter,
+  type NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { AppModule } from './app.module.js';
+
+async function bootstrap() {
+  const app = await NestFactory.create<NestFastifyApplication>(
+    AppModule,
+    new FastifyAdapter(),
+  );
+
+  const port = process.env['PORT'] || 3002;
+  await app.listen(port, '0.0.0.0');
+
+  console.log(`🚀 Discussion Service is running on: http://localhost:${port}`);
+}
+
+bootstrap();

--- a/services/discussion-service/src/prisma/prisma.module.ts
+++ b/services/discussion-service/src/prisma/prisma.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service.js';
+
+/**
+ * Global Prisma module that makes PrismaService available
+ * throughout the application without needing to import the module
+ * in every feature module.
+ */
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/services/discussion-service/src/prisma/prisma.service.ts
+++ b/services/discussion-service/src/prisma/prisma.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, type OnModuleInit, type OnModuleDestroy } from '@nestjs/common';
+import { PrismaClient } from '@unite-discord/db-models';
+
+/**
+ * Prisma service that provides database access throughout the discussion service.
+ * Implements lifecycle hooks to connect and disconnect gracefully.
+ */
+@Injectable()
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  constructor() {
+    super({
+      log:
+        process.env['NODE_ENV'] === 'development'
+          ? ['query', 'error', 'warn']
+          : ['error'],
+    });
+  }
+
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}

--- a/services/discussion-service/tsconfig.json
+++ b/services/discussion-service/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
Implements T032 by scaffolding a new discussion-service microservice with NestJS foundation, Prisma module integration, and health check endpoint.

## Changes Made
- Created `services/discussion-service/` package with NestJS base setup
- Added Fastify adapter for high-performance HTTP server
- Integrated Prisma module via `@unite-discord/db-models` workspace package
- Implemented health check endpoint at `GET /health`
- Configured TypeScript 5.x with ESM support and NestJS decorators
- Service runs on port 3002 (configurable via PORT env var)
- Added README with development instructions

## Architecture
Follows the same patterns as `api-gateway` and `user-service`:
- `src/main.ts` - Bootstrap with Fastify adapter
- `src/app.module.ts` - Root module importing PrismaModule and HealthModule
- `src/prisma/` - Global Prisma module with lifecycle hooks
- `src/health/` - Health check feature module

## Test Results
- Build successful: `pnpm --filter @unite-discord/discussion-service build`
- Service starts successfully and registers all routes
- All modules initialize correctly (PrismaModule, HealthModule)

## Testing Instructions
```bash
# Build the service
pnpm --filter @unite-discord/discussion-service build

# Run in development mode
pnpm --filter @unite-discord/discussion-service dev

# Test health endpoint (once DATABASE_URL is configured)
curl http://localhost:3002/health
```

## Breaking Changes
None - this is a new service.

Fixes #32

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>