### PR TITLE
feat: scaffold ai-service with NestJS base (closes #33)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,43 @@ importers:
         specifier: 5.7.3
         version: 5.7.3
 
+  services/ai-service:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^10.3.0
+        version: 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^10.3.0
+        version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/platform-fastify':
+        specifier: ^10.3.0
+        version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
+      '@unite-discord/ai-client':
+        specifier: workspace:*
+        version: link:../../packages/ai-client
+      '@unite-discord/db-models':
+        specifier: workspace:*
+        version: link:../../packages/db-models
+      fastify:
+        specifier: ^4.25.2
+        version: 4.29.1
+      reflect-metadata:
+        specifier: ^0.2.1
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.12
+        version: 20.17.12
+      tsx:
+        specifier: ^4.7.0
+        version: 4.21.0
+      typescript:
+        specifier: 5.7.3
+        version: 5.7.3
+
   services/api-gateway:
     dependencies:
       '@nestjs/common':

--- a/services/ai-service/README.md
+++ b/services/ai-service/README.md
@@ -1,0 +1,82 @@
+# AI Service
+
+AI service for content analysis and moderation using AWS Bedrock.
+
+## Overview
+
+This service provides AI-powered capabilities for the uniteDiscord platform, including:
+- Content analysis and classification
+- Automated moderation
+- Sentiment analysis
+- Integration with AWS Bedrock
+
+## Technology Stack
+
+- **Framework**: NestJS 10.x
+- **Runtime**: Node.js 20 LTS
+- **HTTP Server**: Fastify
+- **Database ORM**: Prisma (via @unite-discord/db-models)
+- **AI Provider**: AWS Bedrock (via @unite-discord/ai-client)
+
+## Project Structure
+
+```
+src/
+├── ai/               # AI service logic (Bedrock integration)
+│   ├── ai.module.ts
+│   └── bedrock.service.ts
+├── health/           # Health check endpoints
+│   ├── health.controller.ts
+│   └── health.module.ts
+├── prisma/           # Database integration
+│   ├── prisma.module.ts
+│   └── prisma.service.ts
+├── app.module.ts     # Root application module
+└── main.ts           # Application entry point
+```
+
+## Development
+
+```bash
+# Install dependencies
+pnpm install
+
+# Run in development mode
+pnpm dev
+
+# Build for production
+pnpm build
+
+# Start production server
+pnpm start:prod
+
+# Type checking
+pnpm typecheck
+```
+
+## API Endpoints
+
+### Health Check
+- **GET** `/health` - Service health status
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PORT` | Service port | `3002` |
+| `DATABASE_URL` | PostgreSQL connection string | - |
+
+## Current Implementation Status
+
+- ✅ NestJS base setup with Fastify
+- ✅ Health check endpoint
+- ✅ Prisma module integration
+- ⚠️ Bedrock service (stub/placeholder - awaiting full implementation)
+
+## Future Enhancements
+
+- Full AWS Bedrock integration with actual AI models
+- Content analysis endpoints
+- Moderation workflows
+- Rate limiting and caching
+- Comprehensive test coverage

--- a/services/ai-service/package.json
+++ b/services/ai-service/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@unite-discord/ai-service",
+  "version": "0.1.0",
+  "description": "AI service for content analysis and moderation using AWS Bedrock",
+  "type": "module",
+  "main": "./dist/main.js",
+  "types": "./dist/main.d.ts",
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "rm -rf dist .tsbuildinfo",
+    "typecheck": "tsc --noEmit",
+    "dev": "tsx watch src/main.ts",
+    "start": "node dist/main.js",
+    "start:dev": "tsx watch src/main.ts",
+    "start:prod": "node dist/main.js",
+    "test": "echo \"No tests yet\" && exit 0"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.3.0",
+    "@nestjs/core": "^10.3.0",
+    "@nestjs/platform-fastify": "^10.3.0",
+    "@unite-discord/ai-client": "workspace:*",
+    "@unite-discord/db-models": "workspace:*",
+    "fastify": "^4.25.2",
+    "reflect-metadata": "^0.2.1",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.12",
+    "tsx": "^4.7.0",
+    "typescript": "5.7.3"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/services/ai-service/src/ai/ai.module.ts
+++ b/services/ai-service/src/ai/ai.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { BedrockService } from './bedrock.service.js';
+
+@Module({
+  providers: [BedrockService],
+  exports: [BedrockService],
+})
+export class AiModule {}

--- a/services/ai-service/src/ai/bedrock.service.ts
+++ b/services/ai-service/src/ai/bedrock.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Bedrock AI Service
+ *
+ * This is a placeholder/stub for AWS Bedrock integration.
+ * Will be implemented in future tasks with actual AI capabilities.
+ */
+@Injectable()
+export class BedrockService {
+  constructor() {
+    console.log('🤖 Bedrock service initialized (stub)');
+  }
+
+  /**
+   * Placeholder method for content analysis
+   * @param content - The content to analyze
+   * @returns Analysis result (stub implementation)
+   */
+  async analyzeContent(content: string): Promise<{ analyzed: boolean; content: string }> {
+    // Stub implementation - will be replaced with actual Bedrock API calls
+    return {
+      analyzed: true,
+      content,
+    };
+  }
+
+  /**
+   * Placeholder method for content moderation
+   * @param content - The content to moderate
+   * @returns Moderation result (stub implementation)
+   */
+  async moderateContent(content: string): Promise<{ flagged: boolean; reason?: string }> {
+    // Stub implementation - will be replaced with actual Bedrock API calls
+    return {
+      flagged: false,
+    };
+  }
+}

--- a/services/ai-service/src/app.module.ts
+++ b/services/ai-service/src/app.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { HealthModule } from './health/health.module.js';
+import { PrismaModule } from './prisma/prisma.module.js';
+import { AiModule } from './ai/ai.module.js';
+
+@Module({
+  imports: [PrismaModule, HealthModule, AiModule],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/services/ai-service/src/health/health.controller.ts
+++ b/services/ai-service/src/health/health.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('health')
+export class HealthController {
+  @Get()
+  check() {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      service: 'ai-service',
+    };
+  }
+}

--- a/services/ai-service/src/health/health.module.ts
+++ b/services/ai-service/src/health/health.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller.js';
+
+@Module({
+  controllers: [HealthController],
+})
+export class HealthModule {}

--- a/services/ai-service/src/main.ts
+++ b/services/ai-service/src/main.ts
@@ -1,0 +1,20 @@
+import { NestFactory } from '@nestjs/core';
+import {
+  FastifyAdapter,
+  type NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { AppModule } from './app.module.js';
+
+async function bootstrap() {
+  const app = await NestFactory.create<NestFastifyApplication>(
+    AppModule,
+    new FastifyAdapter(),
+  );
+
+  const port = process.env['PORT'] || 3002;
+  await app.listen(port, '0.0.0.0');
+
+  console.log(`🤖 AI Service is running on: http://localhost:${port}`);
+}
+
+bootstrap();

--- a/services/ai-service/src/prisma/prisma.module.ts
+++ b/services/ai-service/src/prisma/prisma.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common';
+import { PrismaService } from './prisma.service.js';
+
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/services/ai-service/src/prisma/prisma.service.ts
+++ b/services/ai-service/src/prisma/prisma.service.ts
@@ -1,0 +1,18 @@
+import { Injectable, type OnModuleInit, type OnModuleDestroy } from '@nestjs/common';
+import { PrismaClient } from '@unite-discord/db-models';
+
+@Injectable()
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  async onModuleInit() {
+    await this.$connect();
+    console.log('📊 Prisma connected to database');
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+    console.log('📊 Prisma disconnected from database');
+  }
+}

--- a/services/ai-service/tsconfig.json
+++ b/services/ai-service/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
Implements issue #33 (T033) - scaffolding the AI service with NestJS foundation.

This establishes the base infrastructure for AI-powered content analysis and moderation using AWS Bedrock. The service is fully functional but the AI integration is a stub awaiting future implementation.

## Changes Made
- Created `services/ai-service/` with NestJS 10.x and Fastify adapter
- Added Prisma module integration for database access
- Implemented health check endpoint at `/health`
- Created Bedrock service stub (placeholder for future AI capabilities)
- Set up TypeScript 5.x with strict configuration
- Added development and production build scripts
- Service runs on port 3002 by default

## Project Structure
```
services/ai-service/
├── src/
│   ├── ai/               # Bedrock service stub
│   ├── health/           # Health check endpoints
│   ├── prisma/           # Database integration
│   ├── app.module.ts     # Root module
│   └── main.ts           # Bootstrap
├── package.json
├── tsconfig.json
└── README.md
```

## Dependencies
- Integrates with `@unite-discord/db-models` for Prisma client
- Integrates with `@unite-discord/ai-client` (declared but stub only)
- Follows same patterns as api-gateway, user-service, discussion-service

## Test Results
- Build: ✅ Successful (TypeScript compilation passes)
- Tests: ✅ Passing (placeholder test suite)

## Testing Instructions
```bash
cd services/ai-service
pnpm install
pnpm build
pnpm dev  # Start development server on port 3002
curl http://localhost:3002/health  # Should return health status
```

## Breaking Changes
None - this is a new service

Fixes #33

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>