### PR TITLE
feat: scaffold fact-check-service with NestJS base (closes #37)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,40 @@ importers:
         specifier: 5.7.3
         version: 5.7.3
 
+  services/fact-check-service:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^10.3.0
+        version: 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^10.3.0
+        version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/platform-fastify':
+        specifier: ^10.3.0
+        version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
+      '@unite-discord/db-models':
+        specifier: workspace:*
+        version: link:../../packages/db-models
+      fastify:
+        specifier: ^4.25.2
+        version: 4.29.1
+      reflect-metadata:
+        specifier: ^0.2.1
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.12
+        version: 20.17.12
+      tsx:
+        specifier: ^4.7.0
+        version: 4.21.0
+      typescript:
+        specifier: 5.7.3
+        version: 5.7.3
+
   services/moderation-service:
     dependencies:
       '@nestjs/common':

--- a/services/fact-check-service/package.json
+++ b/services/fact-check-service/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@unite-discord/fact-check-service",
+  "version": "0.1.0",
+  "description": "Fact-checking service with NestJS and Prisma",
+  "type": "module",
+  "main": "./dist/main.js",
+  "types": "./dist/main.d.ts",
+  "scripts": {
+    "build": "tsc --build",
+    "clean": "rm -rf dist .tsbuildinfo",
+    "typecheck": "tsc --noEmit",
+    "dev": "tsx watch src/main.ts",
+    "start": "node dist/main.js",
+    "start:dev": "tsx watch src/main.ts",
+    "start:prod": "node dist/main.js",
+    "test": "echo \"No tests yet\" && exit 0"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.3.0",
+    "@nestjs/core": "^10.3.0",
+    "@nestjs/platform-fastify": "^10.3.0",
+    "@unite-discord/db-models": "workspace:*",
+    "fastify": "^4.25.2",
+    "reflect-metadata": "^0.2.1",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.12",
+    "tsx": "^4.7.0",
+    "typescript": "5.7.3"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/services/fact-check-service/src/app.module.ts
+++ b/services/fact-check-service/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from './prisma/prisma.module.js';
+import { HealthModule } from './health/health.module.js';
+
+@Module({
+  imports: [PrismaModule, HealthModule],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/services/fact-check-service/src/health/health.controller.ts
+++ b/services/fact-check-service/src/health/health.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('health')
+export class HealthController {
+  @Get()
+  check() {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      service: 'fact-check-service',
+    };
+  }
+}

--- a/services/fact-check-service/src/health/health.module.ts
+++ b/services/fact-check-service/src/health/health.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller.js';
+
+@Module({
+  controllers: [HealthController],
+})
+export class HealthModule {}

--- a/services/fact-check-service/src/main.ts
+++ b/services/fact-check-service/src/main.ts
@@ -1,0 +1,20 @@
+import { NestFactory } from '@nestjs/core';
+import {
+  FastifyAdapter,
+  type NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { AppModule } from './app.module.js';
+
+async function bootstrap() {
+  const app = await NestFactory.create<NestFastifyApplication>(
+    AppModule,
+    new FastifyAdapter(),
+  );
+
+  const port = process.env['PORT'] || 3006;
+  await app.listen(port, '0.0.0.0');
+
+  console.log(`🚀 Fact-Check Service is running on: http://localhost:${port}`);
+}
+
+bootstrap();

--- a/services/fact-check-service/src/prisma/prisma.module.ts
+++ b/services/fact-check-service/src/prisma/prisma.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service.js';
+
+/**
+ * Global Prisma module that makes PrismaService available
+ * throughout the application without needing to import the module
+ * in every feature module.
+ */
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/services/fact-check-service/src/prisma/prisma.service.ts
+++ b/services/fact-check-service/src/prisma/prisma.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, type OnModuleInit, type OnModuleDestroy } from '@nestjs/common';
+import { PrismaClient } from '@unite-discord/db-models';
+
+/**
+ * Prisma service that provides database access throughout the fact-check service.
+ * Implements lifecycle hooks to connect and disconnect gracefully.
+ */
+@Injectable()
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  constructor() {
+    super({
+      log:
+        process.env['NODE_ENV'] === 'development'
+          ? ['query', 'error', 'warn']
+          : ['error'],
+    });
+  }
+
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}

--- a/services/fact-check-service/tsconfig.json
+++ b/services/fact-check-service/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
Scaffolds the fact-check-service with a complete NestJS base setup including Prisma module integration and health check endpoint.

## Changes Made
- Created `services/fact-check-service/` with standard NestJS structure
- Added `package.json` with NestJS 10.x, Fastify adapter, and Prisma dependencies
- Configured TypeScript with decorators support for NestJS
- Implemented Prisma module and service for database access
- Created health check endpoint at `/health` (returns service status)
- Set service to run on port 3006
- Updated `pnpm-lock.yaml` with new dependencies

## Test Results
- TypeScript compilation successful (no errors)
- Type checking passes
- Follows same pattern as existing services

## Testing Instructions
```bash
cd services/fact-check-service
pnpm install
pnpm run typecheck  # Should pass
pnpm run build      # Should compile successfully
```

## Breaking Changes
None - new service addition only

Fixes #37

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>