### PR TITLE
feat: Add SQS queue definitions for LocalStack (closes #38)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
     volumes:
       - localstack_data:/var/lib/localstack
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./infrastructure/localstack/init-queues.sh:/etc/localstack/init/ready.d/init-queues.sh
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
       interval: 10s

--- a/infrastructure/localstack/README.md
+++ b/infrastructure/localstack/README.md
@@ -1,0 +1,189 @@
+# LocalStack Infrastructure
+
+This directory contains initialization scripts and configuration for LocalStack, which provides local AWS service emulation for development and testing.
+
+## Overview
+
+LocalStack is configured via `docker-compose.yml` to emulate the following AWS services:
+- **SQS**: Message queuing for event-driven architecture
+- **SNS**: Pub/sub notifications (topics defined in `init-topics.sh`)
+- **S3**: Object storage for file uploads
+- **DynamoDB**: NoSQL database (if needed)
+
+## SQS Queues
+
+The `init-queues.sh` script creates all required SQS queues for the platform's event-driven architecture.
+
+### Event Processing Queues
+
+| Queue Name | Purpose | Visibility Timeout | Max Receive Count |
+|------------|---------|-------------------|-------------------|
+| `response-analysis-queue` | AI service processes `response.created` events for bias detection and feedback | 300s (5min) | 3 |
+| `discussion-events-queue` | Discussion service processes `response.analyzed` events to update feedback | 60s | 3 |
+| `moderation-queue` | Moderation service processes `moderation.action.requested` events | 120s (2min) | 3 |
+| `notification-queue` | Notification service processes notification events (common-ground, etc.) | 60s | 5 |
+| `user-trust-queue` | User service processes `user.trust.updated` events | 30s | 3 |
+| `recommendation-queue` | Recommendation service processes `topic.participant.joined` events | 90s | 3 |
+| `common-ground-queue` | Discussion/Notification services process `common-ground.generated` events | 60s | 3 |
+
+### Utility Queues
+
+| Queue Name | Purpose | Visibility Timeout | Max Receive Count |
+|------------|---------|-------------------|-------------------|
+| `email-queue` | Async email sending | 60s | 3 |
+| `audit-log-queue` | System audit events | 30s | 5 |
+| `global-dlq` | Global dead letter queue for unroutable messages | 30s | N/A |
+
+### Dead Letter Queues (DLQ)
+
+Each primary queue has an associated DLQ (e.g., `response-analysis-queue-dlq`) that receives messages that fail processing after the max receive count is exceeded. This allows for:
+- Failed message inspection and debugging
+- Manual retry or discard decisions
+- Alerting on systematic failures
+
+## Event Flow
+
+The platform uses an event-driven architecture with the following key events:
+
+```
+response.created
+  → response-analysis-queue → AI Service
+    → response.analyzed
+      → discussion-events-queue → Discussion Service
+
+topic.participant.joined
+  → recommendation-queue → Recommendation Service
+
+moderation.action.requested
+  → moderation-queue → Moderation Service
+    → user.trust.updated
+      → user-trust-queue → User Service
+
+common-ground.generated
+  → common-ground-queue → Discussion Service, Notification Service
+```
+
+## Usage
+
+### Automatic Initialization
+
+The queues are automatically created when you start the docker-compose stack:
+
+```bash
+docker-compose up -d
+```
+
+The `init-queues.sh` script runs as part of LocalStack's startup process.
+
+### Manual Re-initialization
+
+To manually re-run the initialization script:
+
+```bash
+# From the project root
+docker-compose exec localstack /bin/bash -c "bash /etc/localstack/init/ready.d/init-queues.sh"
+```
+
+### Accessing Queues
+
+All queues are accessible via the AWS CLI or SDKs using the LocalStack endpoint:
+
+```bash
+# List all queues
+aws --endpoint-url=http://localhost:4566 sqs list-queues
+
+# Get queue URL
+aws --endpoint-url=http://localhost:4566 sqs get-queue-url --queue-name response-analysis-queue
+
+# Send a test message
+aws --endpoint-url=http://localhost:4566 sqs send-message \
+  --queue-url http://localhost:4566/000000000000/response-analysis-queue \
+  --message-body '{"event": "test"}'
+
+# Receive messages
+aws --endpoint-url=http://localhost:4566 sqs receive-message \
+  --queue-url http://localhost:4566/000000000000/response-analysis-queue
+```
+
+### Checking Queue Attributes
+
+```bash
+# Get all attributes of a queue
+aws --endpoint-url=http://localhost:4566 sqs get-queue-attributes \
+  --queue-url http://localhost:4566/000000000000/response-analysis-queue \
+  --attribute-names All
+```
+
+### Monitoring Dead Letter Queues
+
+```bash
+# Check DLQ depth
+aws --endpoint-url=http://localhost:4566 sqs get-queue-attributes \
+  --queue-url http://localhost:4566/000000000000/response-analysis-queue-dlq \
+  --attribute-names ApproximateNumberOfMessages
+
+# Receive failed messages from DLQ
+aws --endpoint-url=http://localhost:4566 sqs receive-message \
+  --queue-url http://localhost:4566/000000000000/response-analysis-queue-dlq \
+  --max-number-of-messages 10
+```
+
+## Configuration
+
+### Queue Parameters
+
+The queues are configured with the following standard attributes:
+
+- **VisibilityTimeout**: Time a message is hidden after being received (varies by queue based on expected processing time)
+- **MessageRetentionPeriod**: 1209600 seconds (14 days) - how long messages are retained
+- **ReceiveMessageWaitTimeSeconds**: 0 (short polling by default)
+- **DelaySeconds**: 0 (no delivery delay)
+- **MaxReceiveCount**: 3-5 (varies by queue) - number of receive attempts before sending to DLQ
+
+### Customizing Queues
+
+To modify queue attributes, edit the parameters in `init-queues.sh`:
+
+```bash
+# Syntax: create_queue_with_dlq "queue-name" visibility_timeout max_receive_count
+create_queue_with_dlq "my-queue" 120 5
+```
+
+## Integration with Services
+
+Services integrate with these queues using the `packages/common/src/events/` utilities:
+
+- **EventPublisher**: Publishes events to SNS topics (which fan out to SQS queues via subscriptions)
+- **EventSubscriber**: Subscribes to SQS queues and processes messages
+- **DLQHandler**: Monitors and processes dead letter queue messages
+
+See the following packages for event infrastructure:
+- `packages/common/src/events/` - Base event publishing/consuming classes
+- `packages/event-schemas/src/` - Event type definitions
+
+## Troubleshooting
+
+### Queues Not Created
+
+1. Check LocalStack logs: `docker-compose logs localstack`
+2. Verify LocalStack health: `curl http://localhost:4566/_localstack/health`
+3. Manually run init script: `docker-compose exec localstack /bin/bash -c "bash /etc/localstack/init/ready.d/init-queues.sh"`
+
+### Can't Connect to Queues
+
+1. Ensure LocalStack container is running: `docker-compose ps`
+2. Check port mapping: LocalStack should be accessible on `localhost:4566`
+3. Verify AWS CLI configuration uses correct endpoint: `--endpoint-url=http://localhost:4566`
+
+### Messages Not Being Processed
+
+1. Check queue depth: messages accumulating indicates consumer issues
+2. Check DLQ: messages in DLQ indicate repeated processing failures
+3. Review service logs for error messages
+4. Verify event schema matches between publisher and consumer
+
+## References
+
+- [LocalStack Documentation](https://docs.localstack.cloud/)
+- [AWS SQS Developer Guide](https://docs.aws.amazon.com/sqs/)
+- [Event-Driven Architecture Patterns](https://microservices.io/patterns/data/event-driven-architecture.html)

--- a/infrastructure/localstack/init-queues.sh
+++ b/infrastructure/localstack/init-queues.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+
+# LocalStack SQS Queue Initialization Script
+# Creates all SQS queues required for the Unite Discord platform
+# This script runs automatically when LocalStack starts via docker-compose
+
+set -e
+
+echo "Initializing SQS queues in LocalStack..."
+
+LOCALSTACK_ENDPOINT="http://localhost:4566"
+AWS_REGION="us-east-1"
+
+# Wait for LocalStack to be ready
+echo "Waiting for LocalStack to be ready..."
+until curl -s "${LOCALSTACK_ENDPOINT}/_localstack/health" | grep -q '"sqs": "available"'; do
+  echo "Waiting for SQS service..."
+  sleep 2
+done
+echo "LocalStack is ready!"
+
+# Function to create a queue with standard attributes
+create_queue() {
+  local queue_name=$1
+  local visibility_timeout=${2:-30}
+  local message_retention=${3:-1209600}  # 14 days default
+  local receive_wait_time=${4:-0}
+
+  echo "Creating queue: ${queue_name}"
+
+  aws --endpoint-url="${LOCALSTACK_ENDPOINT}" \
+      --region="${AWS_REGION}" \
+      sqs create-queue \
+      --queue-name "${queue_name}" \
+      --attributes "{
+        \"VisibilityTimeout\": \"${visibility_timeout}\",
+        \"MessageRetentionPeriod\": \"${message_retention}\",
+        \"ReceiveMessageWaitTimeSeconds\": \"${receive_wait_time}\",
+        \"DelaySeconds\": \"0\"
+      }" > /dev/null
+
+  echo "✓ Created queue: ${queue_name}"
+}
+
+# Function to create a FIFO queue
+create_fifo_queue() {
+  local queue_name=$1
+  local visibility_timeout=${2:-30}
+  local message_retention=${3:-1209600}
+
+  echo "Creating FIFO queue: ${queue_name}.fifo"
+
+  aws --endpoint-url="${LOCALSTACK_ENDPOINT}" \
+      --region="${AWS_REGION}" \
+      sqs create-queue \
+      --queue-name "${queue_name}.fifo" \
+      --attributes "{
+        \"FifoQueue\": \"true\",
+        \"ContentBasedDeduplication\": \"true\",
+        \"VisibilityTimeout\": \"${visibility_timeout}\",
+        \"MessageRetentionPeriod\": \"${message_retention}\"
+      }" > /dev/null
+
+  echo "✓ Created FIFO queue: ${queue_name}.fifo"
+}
+
+# Function to create a dead-letter queue and its main queue
+create_queue_with_dlq() {
+  local queue_name=$1
+  local visibility_timeout=${2:-30}
+  local max_receive_count=${3:-3}
+
+  echo "Creating DLQ for: ${queue_name}"
+
+  # Create the dead-letter queue first
+  aws --endpoint-url="${LOCALSTACK_ENDPOINT}" \
+      --region="${AWS_REGION}" \
+      sqs create-queue \
+      --queue-name "${queue_name}-dlq" \
+      --attributes "{
+        \"MessageRetentionPeriod\": \"1209600\"
+      }" > /dev/null
+
+  # Get the DLQ ARN
+  dlq_url=$(aws --endpoint-url="${LOCALSTACK_ENDPOINT}" \
+                --region="${AWS_REGION}" \
+                sqs get-queue-url \
+                --queue-name "${queue_name}-dlq" \
+                --query 'QueueUrl' \
+                --output text)
+
+  dlq_arn=$(aws --endpoint-url="${LOCALSTACK_ENDPOINT}" \
+                --region="${AWS_REGION}" \
+                sqs get-queue-attributes \
+                --queue-url "${dlq_url}" \
+                --attribute-names QueueArn \
+                --query 'Attributes.QueueArn' \
+                --output text)
+
+  echo "✓ Created DLQ: ${queue_name}-dlq"
+
+  # Create the main queue with DLQ policy
+  echo "Creating main queue: ${queue_name}"
+
+  aws --endpoint-url="${LOCALSTACK_ENDPOINT}" \
+      --region="${AWS_REGION}" \
+      sqs create-queue \
+      --queue-name "${queue_name}" \
+      --attributes "{
+        \"VisibilityTimeout\": \"${visibility_timeout}\",
+        \"MessageRetentionPeriod\": \"1209600\",
+        \"RedrivePolicy\": \"{\\\"deadLetterTargetArn\\\":\\\"${dlq_arn}\\\",\\\"maxReceiveCount\\\":\\\"${max_receive_count}\\\"}\"
+      }" > /dev/null
+
+  echo "✓ Created main queue: ${queue_name} (with DLQ)"
+}
+
+echo ""
+echo "=========================================="
+echo "Creating Event Processing Queues"
+echo "=========================================="
+echo ""
+
+# Response Analysis Queue (AI Service)
+# Processes response.created events for bias detection, feedback generation
+create_queue_with_dlq "response-analysis-queue" 300 3
+
+# Discussion Events Queue (Discussion Service)
+# Processes response.analyzed events to update feedback
+create_queue_with_dlq "discussion-events-queue" 60 3
+
+# Moderation Queue (Moderation Service)
+# Processes moderation.action.requested events
+create_queue_with_dlq "moderation-queue" 120 3
+
+# Notification Queue (Notification Service)
+# Processes notification events (common-ground.generated, etc.)
+create_queue_with_dlq "notification-queue" 60 5
+
+# User Trust Update Queue (User Service)
+# Processes user.trust.updated events
+create_queue_with_dlq "user-trust-queue" 30 3
+
+# Recommendation Queue (Recommendation Service)
+# Processes topic.participant.joined events for diversity checks
+create_queue_with_dlq "recommendation-queue" 90 3
+
+# Common Ground Queue (Discussion + Notification Services)
+# Processes common-ground.generated events
+create_queue_with_dlq "common-ground-queue" 60 3
+
+echo ""
+echo "=========================================="
+echo "Creating Utility Queues"
+echo "=========================================="
+echo ""
+
+# Global Dead Letter Queue for unroutable messages
+create_queue "global-dlq" 30 1209600
+
+# Email Queue for async email sending
+create_queue_with_dlq "email-queue" 60 3
+
+# Audit Log Queue for system audit events
+create_queue_with_dlq "audit-log-queue" 30 5
+
+echo ""
+echo "=========================================="
+echo "Queue Creation Complete"
+echo "=========================================="
+echo ""
+
+# List all created queues
+echo "Listing all queues:"
+aws --endpoint-url="${LOCALSTACK_ENDPOINT}" \
+    --region="${AWS_REGION}" \
+    sqs list-queues \
+    --query 'QueueUrls[*]' \
+    --output text | tr '\t' '\n'
+
+echo ""
+echo "✓ All SQS queues initialized successfully!"
+echo ""
+echo "Queue endpoints available at: ${LOCALSTACK_ENDPOINT}"
+echo "AWS Region: ${AWS_REGION}"


### PR DESCRIPTION
## Summary
Implements comprehensive SQS queue infrastructure for the platform's event-driven architecture in LocalStack.

## Changes Made
- **Created `infrastructure/localstack/init-queues.sh`**: Automated script to provision all required SQS queues with proper DLQ configuration
- **Added 7 primary event processing queues**:
  - `response-analysis-queue` (AI service, 300s visibility timeout)
  - `discussion-events-queue` (Discussion service, 60s timeout)
  - `moderation-queue` (Moderation service, 120s timeout)
  - `notification-queue` (Notification service, 60s timeout)
  - `user-trust-queue` (User service, 30s timeout)
  - `recommendation-queue` (Recommendation service, 90s timeout)
  - `common-ground-queue` (Discussion/Notification services, 60s timeout)
- **Added 3 utility queues**: `email-queue`, `audit-log-queue`, `global-dlq`
- **Each primary queue has a dedicated DLQ** for failed message handling
- **Updated `docker-compose.yml`**: Mounts init script to auto-run on LocalStack startup
- **Created comprehensive `README.md`**: Documents queue architecture, event flows, configuration, and usage examples

## Test Results
- All queues successfully created and verified with LocalStack 3
- DLQ policies correctly configured with appropriate maxReceiveCount values
- Queue attributes verified (visibility timeout, message retention, etc.)
- LocalStack health checks passing

## Testing Instructions
```bash
# Start LocalStack
docker compose up -d localstack

# Wait for initialization (~30 seconds)
sleep 30

# Verify queues were created
aws --endpoint-url=http://localhost:4566 --region=us-east-1 sqs list-queues

# Check queue attributes
aws --endpoint-url=http://localhost:4566 --region=us-east-1 sqs get-queue-attributes \
  --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/response-analysis-queue \
  --attribute-names All
```

## Breaking Changes
None - this is net-new infrastructure setup.

Fixes #38

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>