### PR TITLE
feat: implement EventPublisher utility in packages/common (closes #40)

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,6 +17,10 @@
     "./utils": {
       "types": "./dist/utils/index.d.ts",
       "import": "./dist/utils/index.js"
+    },
+    "./events": {
+      "types": "./dist/events/index.d.ts",
+      "import": "./dist/events/index.js"
     }
   },
   "files": [
@@ -28,7 +32,10 @@
     "typecheck": "tsc --noEmit",
     "dev": "tsc --watch"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@aws-sdk/client-sns": "^3.504.0",
+    "@unite-discord/event-schemas": "workspace:*"
+  },
   "devDependencies": {
     "typescript": "5.7.3"
   },

--- a/packages/common/src/events/EventPublisher.ts
+++ b/packages/common/src/events/EventPublisher.ts
@@ -1,0 +1,227 @@
+/**
+ * EventPublisher interface and implementations for publishing domain events.
+ *
+ * This module provides an abstraction for publishing events to various
+ * message brokers (SNS, EventBridge, etc.) used in the event-driven architecture.
+ */
+
+import type { BaseEvent, EventEnvelope } from '@unite-discord/event-schemas';
+
+/**
+ * Configuration for publishing events
+ */
+export interface PublishOptions {
+  /**
+   * Message deduplication ID for FIFO topics/queues.
+   * Required for exactly-once delivery semantics.
+   */
+  deduplicationId?: string;
+
+  /**
+   * Message group ID for FIFO topics/queues.
+   * Events with the same group ID are processed in order.
+   */
+  messageGroupId?: string;
+
+  /**
+   * Additional attributes to attach to the message for filtering
+   */
+  attributes?: Record<string, string>;
+}
+
+/**
+ * Result of publishing an event
+ */
+export interface PublishResult {
+  /**
+   * Message ID assigned by the message broker
+   */
+  messageId: string;
+
+  /**
+   * Sequence number (for FIFO topics/queues)
+   */
+  sequenceNumber?: string;
+}
+
+/**
+ * Interface for publishing domain events to a message broker.
+ *
+ * Implementations should handle:
+ * - Event serialization
+ * - Error handling and retries
+ * - Message deduplication (for FIFO queues)
+ * - Message ordering (via message group IDs)
+ */
+export interface EventPublisher {
+  /**
+   * Publishes a domain event to the configured topic/exchange.
+   *
+   * @param event - The domain event to publish
+   * @param options - Optional publishing configuration
+   * @returns Promise resolving to publish result with message ID
+   * @throws {Error} If publishing fails after retries
+   */
+  publish<TEvent extends BaseEvent>(
+    event: TEvent,
+    options?: PublishOptions
+  ): Promise<PublishResult>;
+
+  /**
+   * Publishes multiple events in a batch for efficiency.
+   * Implementations may support partial success.
+   *
+   * @param events - Array of events to publish
+   * @param options - Optional publishing configuration applied to all events
+   * @returns Promise resolving to array of results (same order as input)
+   * @throws {Error} If batch publishing fails
+   */
+  publishBatch<TEvent extends BaseEvent>(
+    events: TEvent[],
+    options?: PublishOptions
+  ): Promise<PublishResult[]>;
+}
+
+/**
+ * Configuration for SNS-based EventPublisher
+ */
+export interface SnsPublisherConfig {
+  /**
+   * ARN of the SNS topic to publish to
+   */
+  topicArn: string;
+
+  /**
+   * AWS region for the SNS client
+   */
+  region: string;
+
+  /**
+   * Service name to include in event metadata
+   */
+  serviceName: string;
+}
+
+/**
+ * SNS-based implementation of EventPublisher.
+ *
+ * Publishes events to an AWS SNS topic. Requires AWS SDK credentials
+ * to be configured in the environment (via environment variables,
+ * EC2 instance profile, or ECS task role).
+ *
+ * Example usage:
+ * ```typescript
+ * const publisher = new SnsEventPublisher({
+ *   topicArn: 'arn:aws:sns:us-east-1:123456789012:events',
+ *   region: 'us-east-1',
+ *   serviceName: 'discussion-service'
+ * });
+ *
+ * await publisher.publish({
+ *   id: '123e4567-e89b-12d3-a456-426614174000',
+ *   type: 'response.created',
+ *   timestamp: new Date().toISOString(),
+ *   version: 1,
+ *   payload: { responseId: 'resp-123', ... },
+ *   metadata: { source: 'discussion-service' }
+ * });
+ * ```
+ */
+export class SnsEventPublisher implements EventPublisher {
+  private readonly config: SnsPublisherConfig;
+  private snsClient: any; // SNSClient from @aws-sdk/client-sns
+
+  constructor(config: SnsPublisherConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Lazy initialization of SNS client.
+   * Only imports AWS SDK when actually needed.
+   */
+  private async getSnsClient(): Promise<any> {
+    if (!this.snsClient) {
+      const { SNSClient } = await import('@aws-sdk/client-sns');
+      this.snsClient = new SNSClient({ region: this.config.region });
+    }
+    return this.snsClient;
+  }
+
+  async publish<TEvent extends BaseEvent>(
+    event: TEvent,
+    options?: PublishOptions
+  ): Promise<PublishResult> {
+    const client = await this.getSnsClient();
+    const { PublishCommand } = await import('@aws-sdk/client-sns');
+
+    // Enrich event metadata with source service
+    const enrichedEvent: TEvent = {
+      ...event,
+      metadata: {
+        ...event.metadata,
+        source: event.metadata?.source ?? this.config.serviceName,
+      },
+    };
+
+    // Wrap event in envelope for transport
+    const envelope: EventEnvelope<TEvent> = {
+      event: enrichedEvent,
+      ...(options?.deduplicationId !== undefined && { deduplicationId: options.deduplicationId }),
+      ...(options?.messageGroupId !== undefined && { messageGroupId: options.messageGroupId }),
+    };
+
+    // Build message attributes for filtering
+    const messageAttributes: Record<string, any> = {
+      eventType: {
+        DataType: 'String',
+        StringValue: event.type,
+      },
+      version: {
+        DataType: 'Number',
+        StringValue: String(event.version),
+      },
+    };
+
+    // Add custom attributes
+    if (options?.attributes) {
+      for (const [key, value] of Object.entries(options.attributes)) {
+        messageAttributes[key] = {
+          DataType: 'String',
+          StringValue: value,
+        };
+      }
+    }
+
+    const command = new PublishCommand({
+      TopicArn: this.config.topicArn,
+      Message: JSON.stringify(envelope),
+      MessageAttributes: messageAttributes,
+      MessageDeduplicationId: options?.deduplicationId,
+      MessageGroupId: options?.messageGroupId,
+    });
+
+    const response = await client.send(command);
+
+    return {
+      messageId: response.MessageId!,
+      sequenceNumber: response.SequenceNumber,
+    };
+  }
+
+  async publishBatch<TEvent extends BaseEvent>(
+    events: TEvent[],
+    options?: PublishOptions
+  ): Promise<PublishResult[]> {
+    // SNS doesn't have native batch publishing, so publish sequentially
+    // For better performance, services should use SQS batch publishing
+    // or implement parallel publishing with Promise.all
+    const results: PublishResult[] = [];
+
+    for (const event of events) {
+      const result = await this.publish(event, options);
+      results.push(result);
+    }
+
+    return results;
+  }
+}

--- a/packages/common/src/events/index.ts
+++ b/packages/common/src/events/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Event publishing utilities for the event-driven architecture.
+ *
+ * This module provides interfaces and implementations for publishing
+ * domain events to message brokers (SNS, EventBridge, etc.).
+ *
+ * @example
+ * ```typescript
+ * import { SnsEventPublisher } from '@unite-discord/common/events';
+ *
+ * const publisher = new SnsEventPublisher({
+ *   topicArn: process.env.SNS_TOPIC_ARN!,
+ *   region: process.env.AWS_REGION!,
+ *   serviceName: 'discussion-service'
+ * });
+ *
+ * await publisher.publish({
+ *   id: crypto.randomUUID(),
+ *   type: 'response.created',
+ *   timestamp: new Date().toISOString(),
+ *   version: 1,
+ *   payload: { responseId: 'resp-123', ... }
+ * });
+ * ```
+ */
+
+export type {
+  EventPublisher,
+  PublishOptions,
+  PublishResult,
+  SnsPublisherConfig,
+} from './EventPublisher.js';
+
+export { SnsEventPublisher } from './EventPublisher.js';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -6,3 +6,4 @@
 
 export * from './types/index.js';
 export * from './utils/index.js';
+export * from './events/index.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,13 @@ importers:
         version: 5.7.3
 
   packages/common:
+    dependencies:
+      '@aws-sdk/client-sns':
+        specifier: ^3.504.0
+        version: 3.971.0
+      '@unite-discord/event-schemas':
+        specifier: workspace:*
+        version: link:../event-schemas
     devDependencies:
       typescript:
         specifier: 5.7.3
@@ -398,6 +405,10 @@ packages:
 
   '@aws-sdk/client-bedrock-runtime@3.971.0':
     resolution: {integrity: sha512-W5c454+PPeN67yKicYkGphzWS/X395Q9DSliQP2ziQekgfd+ESBz54yKzoi/dq8KQoQTGztVzHuP1DR6cIhE9w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sns@3.971.0':
+    resolution: {integrity: sha512-uTtk/8hRCtMr7snbSWT02Wfs63dR1sem0c0mpkdlD7K4UMVx2c9nlm3NYGVJ8Z0p9ACM0IARyXW1SwJUgfHCCw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-sso@3.971.0':
@@ -2560,6 +2571,50 @@ snapshots:
       '@smithy/util-middleware': 4.2.8
       '@smithy/util-retry': 4.2.8
       '@smithy/util-stream': 4.5.10
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sns@3.971.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.970.0
+      '@aws-sdk/credential-provider-node': 3.971.0
+      '@aws-sdk/middleware-host-header': 3.969.0
+      '@aws-sdk/middleware-logger': 3.969.0
+      '@aws-sdk/middleware-recursion-detection': 3.969.0
+      '@aws-sdk/middleware-user-agent': 3.970.0
+      '@aws-sdk/region-config-resolver': 3.969.0
+      '@aws-sdk/types': 3.969.0
+      '@aws-sdk/util-endpoints': 3.970.0
+      '@aws-sdk/util-user-agent-browser': 3.969.0
+      '@aws-sdk/util-user-agent-node': 3.971.0
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.20.7
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.8
+      '@smithy/middleware-retry': 4.4.24
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.10.9
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.23
+      '@smithy/util-defaults-mode-node': 4.2.26
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
Implements EventPublisher interface and SNS-based implementation for publishing domain events to AWS SNS topics in the event-driven architecture.

## Changes Made
- Created `EventPublisher` interface with `publish()` and `publishBatch()` methods
- Implemented `SnsEventPublisher` class for AWS SNS integration (packages/common/src/events/EventPublisher.ts:117)
- Added `@aws-sdk/client-sns` dependency to packages/common
- Added `@unite-discord/event-schemas` as workspace dependency
- Exported events module from main package index (packages/common/src/index.ts:9)
- Updated package.json exports to include `/events` subpath export (packages/common/package.json:21-24)

## Features
The EventPublisher provides:
- Clean abstraction for publishing BaseEvent objects to message brokers
- Event metadata enrichment with source service name
- Message attributes for event filtering on consumers
- FIFO queue support (deduplication ID, message group ID)
- Batch publishing capability
- Lazy AWS SDK loading for optimal cold start performance

## Test Results
- Package builds successfully with TypeScript strict mode
- All type checks pass
- No breaking changes to existing exports

## Testing Instructions
```bash
cd packages/common
pnpm install
pnpm run build
```

## Breaking Changes
None - this is a new utility addition to the common package.

Fixes #40

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>