### PR TITLE
feat: Set up React Router with route definitions (closes #45)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "7.12.0"
   },
   "devDependencies": {
     "@tailwindcss/forms": "0.5.11",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useRoutes } from 'react-router-dom';
+import { routes } from './routes';
 
 function App() {
-  const [count, setCount] = useState(0);
+  const routing = useRoutes(routes);
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -11,29 +12,7 @@ function App() {
           <p className="text-primary-100 text-lg">Rational Discussion Platform</p>
         </div>
       </header>
-      <main className="flex-1 px-4 py-12">
-        <div className="max-w-4xl mx-auto">
-          <div className="bg-white rounded-xl shadow-md p-8 border border-gray-200">
-            <h2 className="text-2xl font-semibold text-gray-900 mb-4">
-              Welcome to Unite Discord
-            </h2>
-            <p className="text-gray-600 mb-6">
-              A platform for fostering rational discussions and meaningful dialogue.
-            </p>
-            <div className="space-y-4">
-              <button
-                onClick={() => setCount((count) => count + 1)}
-                className="bg-primary-500 hover:bg-primary-600 text-white font-medium px-6 py-3 rounded-lg shadow transition-colors duration-200"
-              >
-                Count is {count}
-              </button>
-              <p className="text-sm text-gray-500">
-                Edit <code className="bg-gray-100 px-2 py-1 rounded font-mono text-xs">src/App.tsx</code> and save to test HMR
-              </p>
-            </div>
-          </div>
-        </div>
-      </main>
+      <main className="flex-1 px-4 py-12">{routing}</main>
       <footer className="bg-gray-800 text-gray-300 py-6 px-4">
         <div className="max-w-6xl mx-auto text-center">
           <p>Powered by React 18 + Vite + Tailwind CSS</p>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
 import './index.css';
 
@@ -11,6 +12,8 @@ if (!rootElement) {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>
 );

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom';
+
+function AboutPage() {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="bg-white rounded-xl shadow-md p-8 border border-gray-200">
+        <h2 className="text-2xl font-semibold text-gray-900 mb-4">About</h2>
+        <p className="text-gray-600 mb-6">
+          Learn more about the Unite Discord platform and its mission.
+        </p>
+        <div className="space-y-4">
+          <p className="text-gray-700">
+            Unite Discord is a rational discussion platform designed to foster
+            meaningful dialogue and constructive conversations.
+          </p>
+          <nav className="flex gap-4">
+            <Link
+              to="/"
+              className="bg-primary-500 hover:bg-primary-600 text-white font-medium px-6 py-3 rounded-lg shadow transition-colors duration-200"
+            >
+              Home
+            </Link>
+          </nav>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AboutPage;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,31 @@
+import { Link } from 'react-router-dom';
+
+function HomePage() {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="bg-white rounded-xl shadow-md p-8 border border-gray-200">
+        <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+          Welcome to Unite Discord
+        </h2>
+        <p className="text-gray-600 mb-6">
+          A platform for fostering rational discussions and meaningful dialogue.
+        </p>
+        <div className="space-y-4">
+          <p className="text-gray-700">
+            This is the home page of the Unite Discord application.
+          </p>
+          <nav className="flex gap-4">
+            <Link
+              to="/about"
+              className="bg-primary-500 hover:bg-primary-600 text-white font-medium px-6 py-3 rounded-lg shadow transition-colors duration-200"
+            >
+              About
+            </Link>
+          </nav>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default HomePage;

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,26 @@
+import { Link } from 'react-router-dom';
+
+function NotFoundPage() {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="bg-white rounded-xl shadow-md p-8 border border-gray-200">
+        <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+          404 - Page Not Found
+        </h2>
+        <p className="text-gray-600 mb-6">
+          The page you are looking for does not exist.
+        </p>
+        <nav className="flex gap-4">
+          <Link
+            to="/"
+            className="bg-primary-500 hover:bg-primary-600 text-white font-medium px-6 py-3 rounded-lg shadow transition-colors duration-200"
+          >
+            Go Home
+          </Link>
+        </nav>
+      </div>
+    </div>
+  );
+}
+
+export default NotFoundPage;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,0 +1,25 @@
+import type { RouteObject } from 'react-router-dom';
+import HomePage from '../pages/HomePage';
+import AboutPage from '../pages/AboutPage';
+import NotFoundPage from '../pages/NotFoundPage';
+
+/**
+ * Route definitions for the Unite Discord application.
+ *
+ * This file defines all routes using React Router v7.
+ * Each route maps a URL path to a component.
+ */
+export const routes: RouteObject[] = [
+  {
+    path: '/',
+    element: <HomePage />,
+  },
+  {
+    path: '/about',
+    element: <AboutPage />,
+  },
+  {
+    path: '*',
+    element: <NotFoundPage />,
+  },
+];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: 7.12.0
+        version: 7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@tailwindcss/forms':
         specifier: 0.5.11
@@ -2865,6 +2868,23 @@ packages:
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
+
+  react-router-dom@7.12.0:
+    resolution: {integrity: sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.12.0:
+    resolution: {integrity: sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -6262,6 +6282,20 @@ snapshots:
   react-is@18.3.1: {}
 
   react-refresh@0.17.0: {}
+
+  react-router-dom@7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  react-router@7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      cookie: 1.1.1
+      react: 18.3.1
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:


### PR DESCRIPTION
## Summary
Set up React Router v7 with centralized route definitions for the Unite Discord frontend application. This establishes the routing foundation needed for multi-page navigation.

## Changes Made
- Installed `react-router-dom` v7.12.0 as a dependency
- Created `frontend/src/routes/index.tsx` with centralized route definitions
- Created three placeholder pages in `frontend/src/pages/`:
  - `HomePage.tsx` - Main landing page
  - `AboutPage.tsx` - About page
  - `NotFoundPage.tsx` - 404 error page
- Updated `frontend/src/main.tsx` to wrap App with `BrowserRouter`
- Updated `frontend/src/App.tsx` to use `useRoutes` hook for route rendering

## Test Results
- TypeScript compilation: ✓ passed
- ESLint: ✓ passed
- Production build: ✓ passed (180KB bundle)

## Testing Instructions
```bash
cd frontend
pnpm dev
```
Navigate to `/`, `/about`, and any invalid route to verify routing works.

## Breaking Changes
None - this is a new feature addition.

Fixes #45

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>