### PR TITLE
feat: Set up Playwright for E2E testing (closes #49)

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,9 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,0 +1,72 @@
+# E2E Testing with Playwright
+
+This directory contains end-to-end tests for the Unite Discord frontend application.
+
+## Running Tests
+
+### Prerequisites
+- The Playwright browsers must be installed: `npx playwright install`
+- For the first time, install system dependencies: `npx playwright install-deps`
+
+### Test Commands
+
+```bash
+# Run all E2E tests (headless mode)
+npm run test:e2e
+
+# Run tests with UI mode (interactive)
+npm run test:e2e:ui
+
+# Run tests in headed mode (see browser)
+npm run test:e2e:headed
+
+# Run tests in debug mode
+npm run test:e2e:debug
+
+# Show last test report
+npm run test:e2e:report
+```
+
+## Test Structure
+
+Tests are organized in the `e2e/` directory:
+- `example.spec.ts` - Example test suite demonstrating basic patterns
+
+## Configuration
+
+The Playwright configuration is in `playwright.config.ts` at the frontend root.
+
+Key settings:
+- Base URL: `http://localhost:5173` (configurable via `PLAYWRIGHT_BASE_URL`)
+- Browser: Chromium (can be extended to Firefox, WebKit)
+- Screenshots: Captured on failure
+- Video: Captured on retry
+- Traces: Captured on first retry
+
+## Writing Tests
+
+Example test pattern:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Feature Name', () => {
+  test('should do something', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('h1')).toBeVisible();
+  });
+});
+```
+
+## CI/CD Integration
+
+The tests are configured to run optimally in CI environments:
+- Retries: 2 retries on CI, 0 locally
+- Workers: 1 on CI, unlimited locally
+- Forbid `.only`: Tests with `.only` will fail on CI
+
+## Resources
+
+- [Playwright Documentation](https://playwright.dev/)
+- [Playwright Best Practices](https://playwright.dev/docs/best-practices)
+- [Playwright API Reference](https://playwright.dev/docs/api/class-playwright)

--- a/frontend/e2e/example.spec.ts
+++ b/frontend/e2e/example.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Example E2E test suite for the Unite Discord application
+ *
+ * This file demonstrates basic Playwright test patterns and serves
+ * as a template for future E2E tests.
+ */
+
+test.describe('Application Layout', () => {
+  test('should display the main header with application title', async ({ page }) => {
+    // Navigate to the home page
+    await page.goto('/');
+
+    // Check that the header is visible
+    const header = page.locator('header');
+    await expect(header).toBeVisible();
+
+    // Verify the application title
+    const title = page.locator('h1');
+    await expect(title).toHaveText('Unite Discord');
+
+    // Verify the subtitle
+    const subtitle = page.getByText('Rational Discussion Platform');
+    await expect(subtitle).toBeVisible();
+  });
+
+  test('should display the footer', async ({ page }) => {
+    await page.goto('/');
+
+    // Check that the footer is visible
+    const footer = page.locator('footer');
+    await expect(footer).toBeVisible();
+
+    // Verify footer content
+    await expect(footer).toContainText('Powered by React 18 + Vite + Tailwind CSS');
+  });
+
+  test('should have proper page structure', async ({ page }) => {
+    await page.goto('/');
+
+    // Verify the main sections exist
+    await expect(page.locator('header')).toBeVisible();
+    await expect(page.locator('main')).toBeVisible();
+    await expect(page.locator('footer')).toBeVisible();
+
+    // Verify the page has a title
+    await expect(page).toHaveTitle(/Unite Discord/i);
+  });
+});
+
+test.describe('Navigation', () => {
+  test('should load the home page successfully', async ({ page }) => {
+    const response = await page.goto('/');
+
+    // Verify successful page load
+    expect(response?.status()).toBe(200);
+
+    // Wait for the page to be fully loaded
+    await page.waitForLoadState('networkidle');
+  });
+});
+
+test.describe('Accessibility', () => {
+  test('should have no critical accessibility violations', async ({ page }) => {
+    await page.goto('/');
+
+    // Basic accessibility checks
+    // Verify page has a proper heading structure
+    const h1Count = await page.locator('h1').count();
+    expect(h1Count).toBeGreaterThan(0);
+
+    // Verify main landmark exists
+    const main = page.locator('main');
+    await expect(main).toBeVisible();
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,12 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:debug": "playwright test --debug",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@tanstack/react-query": "5.90.18",
@@ -18,8 +23,10 @@
     "react-router-dom": "7.12.0"
   },
   "devDependencies": {
+    "@playwright/test": "1.57.0",
     "@tailwindcss/forms": "0.5.11",
     "@tailwindcss/typography": "0.5.19",
+    "@types/node": "20.17.12",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@typescript-eslint/eslint-plugin": "^8.21.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,89 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: [
+    ['html', { outputFolder: 'playwright-report' }],
+    ['list'],
+  ],
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5173',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+
+    /* Take screenshot on failure */
+    screenshot: 'only-on-failure',
+
+    /* Capture video on first retry */
+    video: 'retain-on-failure',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // Uncomment to test on additional browsers
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    stdout: 'ignore',
+    stderr: 'pipe',
+  },
+});


### PR DESCRIPTION
## Summary
Implements comprehensive E2E testing infrastructure using Playwright for the Unite Discord frontend application. This provides automated browser testing capabilities to ensure UI functionality and prevent regressions.

## Changes Made
- **Playwright installation** (frontend/package.json):
  - Added @playwright/test@1.57.0 and @types/node@20.17.12
  - Installed Chromium browser for testing
  
- **Configuration** (frontend/playwright.config.ts):
  - Configured test directory as `./e2e`
  - Set base URL to http://localhost:5173 (configurable via PLAYWRIGHT_BASE_URL)
  - Auto-starts dev server before tests
  - Screenshots on failure, video on retry, traces on first retry
  - CI-optimized settings: 2 retries, 1 worker, forbids .only
  
- **Example tests** (frontend/e2e/example.spec.ts):
  - Application Layout tests: header, footer, page structure
  - Navigation tests: page loading
  - Accessibility tests: basic a11y checks
  - Total: 5 test cases demonstrating Playwright patterns
  
- **Test scripts** (frontend/package.json):
  - `test:e2e` - Run all tests headless
  - `test:e2e:ui` - Interactive UI mode
  - `test:e2e:headed` - Visible browser mode
  - `test:e2e:debug` - Debug mode
  - `test:e2e:report` - View last test report
  
- **Gitignore updates** (frontend/.gitignore):
  - Added Playwright artifacts: test-results/, playwright-report/, blob-report/, playwright/.cache/
  
- **Documentation** (frontend/e2e/README.md):
  - Comprehensive guide for running and writing E2E tests
  - Configuration details and best practices

## Test Results
- TypeScript compilation: ✓ Passing
- Playwright installation: ✓ Version 1.57.0
- Test discovery: ✓ 5 tests found in 1 file
- Test listing: ✓ All tests properly configured

## Testing Instructions
```bash
cd frontend

# List tests (no execution)
npx playwright test --list

# Run tests (requires dev server)
npm run dev  # In one terminal
npm run test:e2e  # In another terminal

# Or use interactive UI mode
npm run test:e2e:ui
```

## Breaking Changes
None - this is new testing infrastructure

Fixes #49

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>