### PR TITLE
feat: implement GET /topics endpoint with filtering (closes #65)

### DIFF
--- a/services/discussion-service/src/app.module.ts
+++ b/services/discussion-service/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { PrismaModule } from './prisma/prisma.module.js';
 import { HealthModule } from './health/health.module.js';
+import { TopicsModule } from './topics/topics.module.js';
 
 @Module({
-  imports: [PrismaModule, HealthModule],
+  imports: [PrismaModule, HealthModule, TopicsModule],
   controllers: [],
   providers: [],
 })

--- a/services/discussion-service/src/topics/dto/get-topics-query.dto.ts
+++ b/services/discussion-service/src/topics/dto/get-topics-query.dto.ts
@@ -1,0 +1,9 @@
+export class GetTopicsQueryDto {
+  status?: 'SEEDING' | 'ACTIVE' | 'ARCHIVED';
+  creatorId?: string;
+  tag?: string;
+  page?: number;
+  limit?: number;
+  sortBy?: 'createdAt' | 'participantCount' | 'responseCount';
+  sortOrder?: 'asc' | 'desc';
+}

--- a/services/discussion-service/src/topics/dto/topic-response.dto.ts
+++ b/services/discussion-service/src/topics/dto/topic-response.dto.ts
@@ -1,0 +1,31 @@
+export interface TopicResponseDto {
+  id: string;
+  title: string;
+  description: string;
+  creatorId: string;
+  status: string;
+  evidenceStandards: string;
+  minimumDiversityScore: number;
+  currentDiversityScore: number | null;
+  participantCount: number;
+  responseCount: number;
+  crossCuttingThemes: string[];
+  createdAt: Date;
+  activatedAt: Date | null;
+  archivedAt: Date | null;
+  tags?: {
+    id: string;
+    name: string;
+    slug: string;
+  }[];
+}
+
+export interface PaginatedTopicsResponseDto {
+  data: TopicResponseDto[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+}

--- a/services/discussion-service/src/topics/topics.controller.ts
+++ b/services/discussion-service/src/topics/topics.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { TopicsService } from './topics.service.js';
+import { GetTopicsQueryDto } from './dto/get-topics-query.dto.js';
+import type { PaginatedTopicsResponseDto } from './dto/topic-response.dto.js';
+
+@Controller('topics')
+export class TopicsController {
+  constructor(private readonly topicsService: TopicsService) {}
+
+  @Get()
+  async getTopics(
+    @Query() query: GetTopicsQueryDto,
+  ): Promise<PaginatedTopicsResponseDto> {
+    return this.topicsService.getTopics(query);
+  }
+}

--- a/services/discussion-service/src/topics/topics.module.ts
+++ b/services/discussion-service/src/topics/topics.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TopicsController } from './topics.controller.js';
+import { TopicsService } from './topics.service.js';
+import { PrismaModule } from '../prisma/prisma.module.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [TopicsController],
+  providers: [TopicsService],
+  exports: [TopicsService],
+})
+export class TopicsModule {}

--- a/services/discussion-service/src/topics/topics.service.ts
+++ b/services/discussion-service/src/topics/topics.service.ts
@@ -1,0 +1,106 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { GetTopicsQueryDto } from './dto/get-topics-query.dto.js';
+import type { PaginatedTopicsResponseDto, TopicResponseDto } from './dto/topic-response.dto.js';
+import { Prisma } from '@unite-discord/db-models';
+
+@Injectable()
+export class TopicsService {
+  constructor(private prisma: PrismaService) {}
+
+  async getTopics(query: GetTopicsQueryDto): Promise<PaginatedTopicsResponseDto> {
+    const {
+      status,
+      creatorId,
+      tag,
+      page = 1,
+      limit = 20,
+      sortBy = 'createdAt',
+      sortOrder = 'desc',
+    } = query;
+
+    // Build where clause
+    const where: Prisma.DiscussionTopicWhereInput = {};
+
+    if (status) {
+      where.status = status;
+    }
+
+    if (creatorId) {
+      where.creatorId = creatorId;
+    }
+
+    if (tag) {
+      where.tags = {
+        some: {
+          tag: {
+            OR: [
+              { name: { contains: tag, mode: 'insensitive' } },
+              { slug: { contains: tag, mode: 'insensitive' } },
+            ],
+          },
+        },
+      };
+    }
+
+    // Build orderBy clause
+    const orderBy: Prisma.DiscussionTopicOrderByWithRelationInput = {};
+    orderBy[sortBy] = sortOrder;
+
+    // Calculate pagination
+    const skip = (page - 1) * limit;
+
+    // Execute queries
+    const [topics, total] = await Promise.all([
+      this.prisma.discussionTopic.findMany({
+        where,
+        orderBy,
+        skip,
+        take: limit,
+        include: {
+          tags: {
+            include: {
+              tag: {
+                select: {
+                  id: true,
+                  name: true,
+                  slug: true,
+                },
+              },
+            },
+          },
+        },
+      }),
+      this.prisma.discussionTopic.count({ where }),
+    ]);
+
+    // Map to DTOs
+    const data: TopicResponseDto[] = topics.map((topic) => ({
+      id: topic.id,
+      title: topic.title,
+      description: topic.description,
+      creatorId: topic.creatorId,
+      status: topic.status,
+      evidenceStandards: topic.evidenceStandards,
+      minimumDiversityScore: topic.minimumDiversityScore.toNumber(),
+      currentDiversityScore: topic.currentDiversityScore?.toNumber() ?? null,
+      participantCount: topic.participantCount,
+      responseCount: topic.responseCount,
+      crossCuttingThemes: topic.crossCuttingThemes,
+      createdAt: topic.createdAt,
+      activatedAt: topic.activatedAt,
+      archivedAt: topic.archivedAt,
+      tags: topic.tags.map((tt) => tt.tag),
+    }));
+
+    return {
+      data,
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary
Implemented GET /topics endpoint with comprehensive filtering capabilities to support topic discovery and browsing in the discussion service.

## Changes Made
- Created `TopicsModule`, `TopicsController`, and `TopicsService` in `services/discussion-service/src/topics/`
- Added DTOs for request validation and response formatting:
  - `GetTopicsQueryDto`: Query parameters for filtering and pagination
  - `TopicResponseDto` and `PaginatedTopicsResponseDto`: Response formatting
- Registered `TopicsModule` in `AppModule`

## Features
- **Status filtering**: Filter by `SEEDING`, `ACTIVE`, or `ARCHIVED` status
- **Creator filtering**: Filter by creator user ID
- **Tag filtering**: Search by tag name or slug (case-insensitive)
- **Pagination**: Support for page and limit parameters (default: page=1, limit=20)
- **Sorting**: Sort by `createdAt`, `participantCount`, or `responseCount`
- **Sort order**: Ascending or descending order (default: desc)

## Test Results
- TypeScript compilation successful
- All builds passing

## Testing Instructions
```bash
cd services/discussion-service
npm run build
npm run dev
```

Then test the endpoint:
```bash
curl http://localhost:3000/topics
curl http://localhost:3000/topics?status=ACTIVE&page=1&limit=10
curl http://localhost:3000/topics?tag=politics&sortBy=participantCount&sortOrder=desc
```

## Breaking Changes
None - this is a new endpoint.

Fixes #65

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>