### PR TITLE
feat: implement GET /topics/:id detail (closes #66)

### DIFF
--- a/services/discussion-service/src/topics/topics.controller.ts
+++ b/services/discussion-service/src/topics/topics.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, Param } from '@nestjs/common';
 import { TopicsService } from './topics.service.js';
 import { GetTopicsQueryDto } from './dto/get-topics-query.dto.js';
-import type { PaginatedTopicsResponseDto } from './dto/topic-response.dto.js';
+import type { PaginatedTopicsResponseDto, TopicResponseDto } from './dto/topic-response.dto.js';
 
 @Controller('topics')
 export class TopicsController {
@@ -12,5 +12,10 @@ export class TopicsController {
     @Query() query: GetTopicsQueryDto,
   ): Promise<PaginatedTopicsResponseDto> {
     return this.topicsService.getTopics(query);
+  }
+
+  @Get(':id')
+  async getTopicById(@Param('id') id: string): Promise<TopicResponseDto> {
+    return this.topicsService.getTopicById(id);
   }
 }


### PR DESCRIPTION
## Summary
Implements GET /topics/:id endpoint to retrieve detailed information for a specific discussion topic, including its tags, participation counts, and diversity scores.

## Changes Made
- Added GET /topics/:id route to TopicsController (services/discussion-service/src/topics/topics.controller.ts:17-20)
- Added getTopicById method to TopicsService with proper error handling (services/discussion-service/src/topics/topics.service.ts:107-146)
- Returns 404 NotFoundException if topic not found
- Includes topic tags in response using same data structure as list endpoint

## Test Results
- Build passes: TypeScript compilation successful across all workspace packages
- Code follows existing patterns from GET /topics list endpoint
- Error handling implemented for non-existent topics

## Testing Instructions
```bash
pnpm run build
```

## Breaking Changes
None

Fixes #66

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>