### PR TITLE
feat: implement topic search endpoint (closes #67)

### DIFF
--- a/services/discussion-service/src/topics/dto/search-topics-query.dto.ts
+++ b/services/discussion-service/src/topics/dto/search-topics-query.dto.ts
@@ -1,0 +1,5 @@
+export class SearchTopicsQueryDto {
+  q?: string; // Search query
+  page?: number;
+  limit?: number;
+}

--- a/services/discussion-service/src/topics/topics.controller.ts
+++ b/services/discussion-service/src/topics/topics.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Query, Param } from '@nestjs/common';
 import { TopicsService } from './topics.service.js';
 import { GetTopicsQueryDto } from './dto/get-topics-query.dto.js';
+import { SearchTopicsQueryDto } from './dto/search-topics-query.dto.js';
 import type { PaginatedTopicsResponseDto, TopicResponseDto } from './dto/topic-response.dto.js';
 
 @Controller('topics')
@@ -12,6 +13,13 @@ export class TopicsController {
     @Query() query: GetTopicsQueryDto,
   ): Promise<PaginatedTopicsResponseDto> {
     return this.topicsService.getTopics(query);
+  }
+
+  @Get('search')
+  async searchTopics(
+    @Query() query: SearchTopicsQueryDto,
+  ): Promise<PaginatedTopicsResponseDto> {
+    return this.topicsService.searchTopics(query);
   }
 
   @Get(':id')

--- a/services/discussion-service/src/topics/topics.service.ts
+++ b/services/discussion-service/src/topics/topics.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { GetTopicsQueryDto } from './dto/get-topics-query.dto.js';
+import { SearchTopicsQueryDto } from './dto/search-topics-query.dto.js';
 import type { PaginatedTopicsResponseDto, TopicResponseDto } from './dto/topic-response.dto.js';
 import { Prisma } from '@unite-discord/db-models';
 
@@ -142,6 +143,76 @@ export class TopicsService {
       activatedAt: topic.activatedAt,
       archivedAt: topic.archivedAt,
       tags: topic.tags.map((tt) => tt.tag),
+    };
+  }
+
+  async searchTopics(query: SearchTopicsQueryDto): Promise<PaginatedTopicsResponseDto> {
+    const { q, page = 1, limit = 20 } = query;
+
+    // Build where clause for search
+    const where: Prisma.DiscussionTopicWhereInput = {};
+
+    if (q) {
+      where.OR = [
+        { title: { contains: q, mode: 'insensitive' } },
+        { description: { contains: q, mode: 'insensitive' } },
+      ];
+    }
+
+    // Calculate pagination
+    const skip = (page - 1) * limit;
+
+    // Execute queries
+    const [topics, total] = await Promise.all([
+      this.prisma.discussionTopic.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: limit,
+        include: {
+          tags: {
+            include: {
+              tag: {
+                select: {
+                  id: true,
+                  name: true,
+                  slug: true,
+                },
+              },
+            },
+          },
+        },
+      }),
+      this.prisma.discussionTopic.count({ where }),
+    ]);
+
+    // Map to DTOs
+    const data: TopicResponseDto[] = topics.map((topic) => ({
+      id: topic.id,
+      title: topic.title,
+      description: topic.description,
+      creatorId: topic.creatorId,
+      status: topic.status,
+      evidenceStandards: topic.evidenceStandards,
+      minimumDiversityScore: topic.minimumDiversityScore.toNumber(),
+      currentDiversityScore: topic.currentDiversityScore?.toNumber() ?? null,
+      participantCount: topic.participantCount,
+      responseCount: topic.responseCount,
+      crossCuttingThemes: topic.crossCuttingThemes,
+      createdAt: topic.createdAt,
+      activatedAt: topic.activatedAt,
+      archivedAt: topic.archivedAt,
+      tags: topic.tags.map((tt) => tt.tag),
+    }));
+
+    return {
+      data,
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
     };
   }
 }


### PR DESCRIPTION
## Summary
Implements GET /topics/search endpoint to search discussion topics by keywords, searching across both title and description fields with case-insensitive matching.

## Changes Made
- Added GET /topics/search route to TopicsController (services/discussion-service/src/topics/topics.controller.ts:18-23)
- Added searchTopics method to TopicsService (services/discussion-service/src/topics/topics.service.ts:149-217)
- Created SearchTopicsQueryDto for query validation (services/discussion-service/src/topics/dto/search-topics-query.dto.ts)
- Search uses Prisma OR condition to search across title and description
- Results ordered by creation date (newest first)
- Includes pagination support (page, limit parameters)
- Returns topics with tags in same format as list endpoint

## Test Results
- Build passes: TypeScript compilation successful across all workspace packages
- Code follows existing patterns from GET /topics list endpoint
- Search route placed before :id route to avoid routing conflicts

## Testing Instructions
```bash
pnpm run build
```

## Breaking Changes
None

Fixes #67

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>