### PR TITLE
feat: Document validation rules for Tag entity (closes #19)

### DIFF
--- a/packages/db-models/prisma/schema.prisma
+++ b/packages/db-models/prisma/schema.prisma
@@ -177,6 +177,7 @@ enum EvidenceStandard {
 }
 
 /// Tags for categorizing discussion topics
+/// Validation: Name must be 2-50 characters (max 50 enforced by VarChar, min 2 at application level)
 model Tag {
   id            String   @id @default(uuid()) @db.Uuid
   name          String   @unique @db.VarChar(50)


### PR DESCRIPTION
## Summary
Completes the Tag and TopicTag entity definitions by documenting validation rules. Both entities were already fully defined in the schema with all required fields, relations, enums, and indexes.

## Changes Made
- Added documentation to Tag model noting that name minimum length (2 characters) must be enforced at application level
- Maximum length (50 characters) already enforced by VarChar(50)
- Ran Prisma format to validate the schema structure

## Details

### Tag Entity
- All required fields: id, name, slug, usageCount, aiSynonyms, parentThemeId, createdAt
- Unique constraints on name and slug
- Self-referential hierarchy (TagHierarchy relation for parent/child themes)
- Relation to TopicTag junction table
- Index on usageCount DESC for popular tags

### TopicTag Junction Entity
- Composite primary key (topicId, tagId)
- Source field with TagSource enum (CREATOR, AI_SUGGESTED, COMMUNITY)
- Relations to DiscussionTopic and Tag with cascade delete
- Index on tagId for efficient tag lookups
- createdAt timestamp for audit trail

## Test Results
- Schema validation passed: `npx prisma format` completed successfully

## Testing Instructions
```bash
cd packages/db-models
npx prisma format
```

## Breaking Changes
None

Fixes #19

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>