### PR TITLE
feat: Document TopicLink unique constraint (closes #20)

### DIFF
--- a/packages/db-models/prisma/schema.prisma
+++ b/packages/db-models/prisma/schema.prisma
@@ -221,6 +221,7 @@ enum TagSource {
 }
 
 /// Links between related discussion topics
+/// Unique constraint prevents duplicate links of same type between same topics
 model TopicLink {
   id                 String                @id @default(uuid()) @db.Uuid
   sourceTopicId      String                @map("source_topic_id") @db.Uuid


### PR DESCRIPTION
## Summary
Completes the TopicLink entity definition. The entity was already fully defined with all required fields, enums, relations, and indexes.

## Changes Made
- Added documentation noting the unique constraint behavior (prevents duplicate links of same type between same topics)

## Details
The TopicLink entity includes:
- All fields: id, sourceTopicId, targetTopicId, relationshipType, linkSource, proposerId, confirmationStatus, confirmedByCount, rejectedByCount, createdAt
- All enums: TopicRelationshipType (BUILDS_ON, RESPONDS_TO, CONTRADICTS, RELATED, SHARES_PROPOSITION), LinkSource (AI_SUGGESTED, USER_PROPOSED), ConfirmationStatus (PENDING, CONFIRMED, REJECTED)
- Relations: DiscussionTopic (source/target), User (proposer)
- Indexes: sourceTopicId, targetTopicId, relationshipType, confirmationStatus
- Unique constraint: [sourceTopicId, targetTopicId, relationshipType]

## Test Results
- Schema validation passed

Fixes #20

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>