### PR TITLE
feat: Create profile edit form component (closes #63)

### DIFF
--- a/frontend/e2e/profile-edit-form.spec.ts
+++ b/frontend/e2e/profile-edit-form.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * E2E tests for ProfileEditForm component
+ */
+
+import { test } from '@playwright/test';
+
+test.describe('ProfileEditForm Component', () => {
+  // Note: These tests verify the component renders and validates correctly
+  // Full integration testing with auth backend will require mock server setup
+
+  test('should render profile edit form with all fields', async ({ page }) => {
+    // Navigate to a page that contains the ProfileEditForm
+    // For now, we'll test the form in isolation via component test page
+    await page.goto('/');
+
+    // This is a placeholder - actual navigation will depend on routing setup
+    // The form should have these elements when integrated:
+    // - Display name input field
+    // - Save button
+    // - Cancel button (if onCancel provided)
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  test('should validate display name length (minimum 3 characters)', async ({ page }) => {
+    // This test will be implemented when the form is integrated into a route
+    // Expected behavior:
+    // - Enter 1-2 characters
+    // - Blur the field
+    // - Error message should appear: "Display name must be at least 3 characters"
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  test('should validate display name length (maximum 50 characters)', async ({ page }) => {
+    // This test will be implemented when the form is integrated into a route
+    // Expected behavior:
+    // - Enter 51+ characters
+    // - Blur the field
+    // - Error message should appear: "Display name must not exceed 50 characters"
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  test('should validate required display name field', async ({ page }) => {
+    // This test will be implemented when the form is integrated into a route
+    // Expected behavior:
+    // - Clear the display name field
+    // - Blur the field
+    // - Error message should appear: "Display name is required"
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  test('should show loading state when submitting', async ({ page }) => {
+    // This test will be implemented when the form is integrated into a route
+    // Expected behavior:
+    // - Fill in valid display name
+    // - Click save button
+    // - Button should show "Saving..." text
+    // - Button should be disabled during submission
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  test('should display error message when submission fails', async ({ page }) => {
+    // This test will be implemented when the form is integrated into a route
+    // Expected behavior:
+    // - Fill in valid display name
+    // - Mock API to return error
+    // - Click save button
+    // - Error message should be displayed in red box
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  test('should call onCancel when cancel button is clicked', async ({ page }) => {
+    // This test will be implemented when the form is integrated into a route
+    // Expected behavior:
+    // - Cancel button should be visible (when onCancel prop provided)
+    // - Click cancel button
+    // - Form should trigger onCancel callback
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  test('should accept valid display name (3-50 characters)', async ({ page }) => {
+    // This test will be implemented when the form is integrated into a route
+    // Expected behavior:
+    // - Enter "ValidName123" (valid format)
+    // - No error should be shown
+    // - Save button should be enabled
+  });
+});

--- a/frontend/src/components/profile/ProfileEditForm.tsx
+++ b/frontend/src/components/profile/ProfileEditForm.tsx
@@ -1,0 +1,206 @@
+import React, { useState } from 'react';
+import Input from '../ui/Input';
+import Button from '../ui/Button';
+import Card, { CardHeader, CardBody } from '../ui/Card';
+
+export interface ProfileEditFormData {
+  displayName: string;
+}
+
+export interface ProfileEditFormProps {
+  /**
+   * Initial profile data to populate the form
+   */
+  initialData?: ProfileEditFormData;
+
+  /**
+   * Callback when the form is submitted with valid data
+   */
+  onSubmit: (data: ProfileEditFormData) => void | Promise<void>;
+
+  /**
+   * Callback when the user cancels editing
+   */
+  onCancel?: () => void;
+
+  /**
+   * Whether the form is in a loading/submitting state
+   */
+  isLoading?: boolean;
+
+  /**
+   * Error message to display at the form level
+   */
+  error?: string;
+
+  /**
+   * Custom CSS class name for the form wrapper
+   */
+  className?: string;
+}
+
+interface FormErrors {
+  displayName?: string;
+}
+
+function ProfileEditForm({
+  initialData = { displayName: '' },
+  onSubmit,
+  onCancel,
+  isLoading = false,
+  error,
+  className = '',
+}: ProfileEditFormProps) {
+  const [formData, setFormData] = useState<ProfileEditFormData>(initialData);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+
+  // Display name validation (matches RegistrationForm validation)
+  const validateDisplayName = (displayName: string): string | undefined => {
+    if (!displayName) {
+      return 'Display name is required';
+    }
+    if (displayName.length < 3) {
+      return 'Display name must be at least 3 characters';
+    }
+    if (displayName.length > 50) {
+      return 'Display name must not exceed 50 characters';
+    }
+    return undefined;
+  };
+
+  // Validate all fields
+  const validateForm = (): boolean => {
+    const displayNameError = validateDisplayName(formData.displayName);
+
+    const newErrors: FormErrors = {};
+    if (displayNameError) newErrors.displayName = displayNameError;
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  // Handle input change
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setFormData({ displayName: value });
+
+    // Validate on change if field has been touched
+    if (touched['displayName']) {
+      const fieldError = validateDisplayName(value);
+      setErrors((prev) => {
+        const updated = { ...prev };
+        if (fieldError) {
+          updated.displayName = fieldError;
+        } else {
+          delete updated.displayName;
+        }
+        return updated;
+      });
+    }
+  };
+
+  // Handle input blur
+  const handleBlur = () => {
+    setTouched((prev) => ({ ...prev, displayName: true }));
+
+    // Validate field on blur
+    const fieldError = validateDisplayName(formData.displayName);
+    setErrors((prev) => {
+      const updated = { ...prev };
+      if (fieldError) {
+        updated.displayName = fieldError;
+      } else {
+        delete updated.displayName;
+      }
+      return updated;
+    });
+  };
+
+  // Handle form submission
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // Mark all fields as touched
+    setTouched({ displayName: true });
+
+    // Validate form
+    if (!validateForm()) {
+      return;
+    }
+
+    // Submit form
+    await onSubmit(formData);
+  };
+
+  // Handle cancel
+  const handleCancel = () => {
+    if (onCancel) {
+      onCancel();
+    }
+  };
+
+  return (
+    <Card variant="default" padding="lg" className={className}>
+      <CardHeader>
+        <h2 className="text-2xl font-bold text-gray-900">Edit Profile</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          Update your profile information
+        </p>
+      </CardHeader>
+
+      <CardBody>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <div className="rounded-lg bg-fallacy-light border border-fallacy-DEFAULT p-4">
+              <p className="text-sm text-fallacy-dark">{error}</p>
+            </div>
+          )}
+
+          <Input
+            label="Display Name"
+            type="text"
+            id="displayName"
+            value={formData.displayName}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            {...(touched['displayName'] && errors.displayName ? { error: errors.displayName } : {})}
+            helperText="This is how your name will appear to other users (3-50 characters)"
+            required
+            fullWidth
+            placeholder="Your Name"
+            autoComplete="username"
+          />
+
+          <div className="flex gap-4">
+            <Button
+              type="submit"
+              variant="primary"
+              size="lg"
+              fullWidth
+              isLoading={isLoading}
+              disabled={isLoading}
+            >
+              {isLoading ? 'Saving...' : 'Save Changes'}
+            </Button>
+
+            {onCancel && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="lg"
+                fullWidth
+                onClick={handleCancel}
+                disabled={isLoading}
+              >
+                Cancel
+              </Button>
+            )}
+          </div>
+        </form>
+      </CardBody>
+    </Card>
+  );
+}
+
+export default ProfileEditForm;

--- a/frontend/src/components/profile/index.ts
+++ b/frontend/src/components/profile/index.ts
@@ -1,0 +1,2 @@
+export { default as ProfileEditForm } from './ProfileEditForm';
+export type { ProfileEditFormData, ProfileEditFormProps } from './ProfileEditForm';


### PR DESCRIPTION
## Summary
Created a ProfileEditForm component that allows users to edit their profile information (currently display name). The form includes validation, loading states, and error handling.

## Changes Made
- Created `frontend/src/components/profile/ProfileEditForm.tsx` with:
  - Display name validation (3-50 characters, required)
  - Real-time validation on blur and change
  - Loading states during submission
  - Error message display
  - Cancel button support (optional via onCancel prop)
- Created `frontend/src/components/profile/index.ts` for clean exports
- Added E2E test file `frontend/e2e/profile-edit-form.spec.ts` with test placeholders for future integration

## Test Results
- TypeScript compilation: ✓ Passed
- ESLint: ✓ Passed
- Frontend build: ✓ Passed

## Testing Instructions
```bash
cd frontend
npm run typecheck
npm run lint
npm run build
```

## Breaking Changes
None - this is a new component with no external dependencies.

Fixes #63

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>