### PR TITLE
feat: Create edit response modal component (closes #80)

### DIFF
--- a/frontend/src/components/responses/EditResponseModal.tsx
+++ b/frontend/src/components/responses/EditResponseModal.tsx
@@ -1,0 +1,322 @@
+import React, { useState, useEffect } from 'react';
+import Modal from '../ui/Modal';
+import Button from '../ui/Button';
+import Input from '../ui/Input';
+import type { Response, UpdateResponseRequest } from '../../types/response';
+
+export interface EditResponseModalProps {
+  /**
+   * Whether the modal is open
+   */
+  isOpen: boolean;
+
+  /**
+   * Callback when the modal should be closed
+   */
+  onClose: () => void;
+
+  /**
+   * The response being edited
+   */
+  response: Response;
+
+  /**
+   * Callback when the edit is submitted
+   */
+  onSubmit: (responseId: string, data: UpdateResponseRequest) => void | Promise<void>;
+
+  /**
+   * Whether the form is in a loading state
+   */
+  isLoading?: boolean;
+
+  /**
+   * Maximum character limit for the response
+   */
+  maxLength?: number;
+
+  /**
+   * Minimum character limit for the response
+   */
+  minLength?: number;
+}
+
+const EditResponseModal: React.FC<EditResponseModalProps> = ({
+  isOpen,
+  onClose,
+  response,
+  onSubmit,
+  isLoading = false,
+  maxLength = 10000,
+  minLength = 10,
+}) => {
+  const [content, setContent] = useState('');
+  const [citedSources, setCitedSources] = useState<string[]>([]);
+  const [currentSource, setCurrentSource] = useState('');
+  const [containsOpinion, setContainsOpinion] = useState(false);
+  const [containsFactualClaims, setContainsFactualClaims] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Initialize form with response data when modal opens
+  useEffect(() => {
+    if (isOpen && response) {
+      setContent(response.content);
+      setCitedSources(response.citedSources?.map(s => s.url) || []);
+      setContainsOpinion(response.containsOpinion);
+      setContainsFactualClaims(response.containsFactualClaims);
+      setError(null);
+    }
+  }, [isOpen, response]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    // Validation
+    if (content.length < minLength) {
+      setError(`Response must be at least ${minLength} characters`);
+      return;
+    }
+
+    if (content.length > maxLength) {
+      setError(`Response must not exceed ${maxLength} characters`);
+      return;
+    }
+
+    const updateData: UpdateResponseRequest = {
+      content: content.trim(),
+      containsOpinion,
+      containsFactualClaims,
+    };
+
+    if (citedSources.length > 0) {
+      updateData.citedSources = citedSources;
+    }
+
+    try {
+      await onSubmit(response.id, updateData);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update response');
+    }
+  };
+
+  const handleAddSource = () => {
+    const trimmedSource = currentSource.trim();
+    if (trimmedSource && !citedSources.includes(trimmedSource)) {
+      try {
+        // Basic URL validation
+        new URL(trimmedSource);
+        setCitedSources([...citedSources, trimmedSource]);
+        setCurrentSource('');
+        setError(null);
+      } catch {
+        setError('Please enter a valid URL');
+      }
+    }
+  };
+
+  const handleRemoveSource = (index: number) => {
+    setCitedSources(citedSources.filter((_, i) => i !== index));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAddSource();
+    }
+  };
+
+  const handleCancel = () => {
+    setError(null);
+    onClose();
+  };
+
+  const characterCount = content.length;
+  const isValid = characterCount >= minLength && characterCount <= maxLength;
+  const hasChanges =
+    content.trim() !== response.content ||
+    citedSources.length !== (response.citedSources?.length || 0) ||
+    citedSources.some((source, i) => source !== response.citedSources?.[i]?.url) ||
+    containsOpinion !== response.containsOpinion ||
+    containsFactualClaims !== response.containsFactualClaims;
+
+  const footer = (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={handleCancel}
+        disabled={isLoading}
+      >
+        Cancel
+      </Button>
+      <Button
+        type="submit"
+        variant="primary"
+        onClick={handleSubmit}
+        isLoading={isLoading}
+        disabled={!isValid || !hasChanges || isLoading}
+      >
+        Save Changes
+      </Button>
+    </>
+  );
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleCancel}
+      title="Edit Response"
+      size="lg"
+      footer={footer}
+      closeOnBackdropClick={!isLoading}
+      closeOnEscape={!isLoading}
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {/* Content */}
+        <div>
+          <label htmlFor="edit-response-content" className="block text-sm font-medium text-gray-700 mb-1.5">
+            Your Response
+            <span className="text-fallacy-DEFAULT ml-1">*</span>
+          </label>
+          <textarea
+            id="edit-response-content"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="Share your perspective..."
+            className={`w-full px-4 py-3 rounded-lg border transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 resize-y min-h-[200px] ${
+              error
+                ? 'border-fallacy-DEFAULT focus:border-fallacy-DEFAULT focus:ring-fallacy-DEFAULT/20'
+                : 'border-gray-300 focus:border-primary-500 focus:ring-primary-500/20'
+            }`}
+            maxLength={maxLength}
+            disabled={isLoading}
+            aria-invalid={!!error}
+            aria-describedby={error ? 'edit-response-error' : 'edit-character-count'}
+          />
+          <div className="flex justify-between items-center mt-1.5">
+            <span
+              id="edit-character-count"
+              className={`text-sm ${
+                !isValid && characterCount > 0
+                  ? 'text-fallacy-DEFAULT'
+                  : characterCount >= maxLength * 0.9
+                  ? 'text-secondary-600'
+                  : 'text-gray-500'
+              }`}
+            >
+              {characterCount} / {maxLength} characters
+              {characterCount < minLength && characterCount > 0 && ` (minimum ${minLength})`}
+            </span>
+          </div>
+        </div>
+
+        {error && (
+          <p id="edit-response-error" className="text-sm text-fallacy-DEFAULT" role="alert">
+            {error}
+          </p>
+        )}
+
+        {/* Cited Sources */}
+        <div>
+          <label htmlFor="edit-cited-source" className="block text-sm font-medium text-gray-700 mb-1.5">
+            Cited Sources (Optional)
+          </label>
+          <div className="flex gap-2">
+            <Input
+              id="edit-cited-source"
+              type="url"
+              value={currentSource}
+              onChange={(e) => setCurrentSource(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="https://example.com/source"
+              disabled={isLoading}
+              fullWidth
+            />
+            <Button
+              type="button"
+              onClick={handleAddSource}
+              variant="outline"
+              disabled={!currentSource.trim() || isLoading}
+            >
+              Add
+            </Button>
+          </div>
+          {citedSources.length > 0 && (
+            <ul className="mt-2 space-y-1">
+              {citedSources.map((source, index) => (
+                <li
+                  key={index}
+                  className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-md"
+                >
+                  <a
+                    href={source}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-primary-600 hover:text-primary-700 truncate flex-1"
+                  >
+                    {source}
+                  </a>
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveSource(index)}
+                    className="ml-2 text-gray-400 hover:text-fallacy-DEFAULT"
+                    disabled={isLoading}
+                    aria-label={`Remove source ${source}`}
+                  >
+                    <svg
+                      className="h-4 w-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Response Metadata Checkboxes */}
+        <div className="space-y-2">
+          <div className="flex items-center">
+            <input
+              id="edit-contains-opinion"
+              type="checkbox"
+              checked={containsOpinion}
+              onChange={(e) => setContainsOpinion(e.target.checked)}
+              disabled={isLoading}
+              className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
+            />
+            <label htmlFor="edit-contains-opinion" className="ml-2 text-sm text-gray-700">
+              This response contains my opinion
+            </label>
+          </div>
+          <div className="flex items-center">
+            <input
+              id="edit-contains-factual-claims"
+              type="checkbox"
+              checked={containsFactualClaims}
+              onChange={(e) => setContainsFactualClaims(e.target.checked)}
+              disabled={isLoading}
+              className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
+            />
+            <label htmlFor="edit-contains-factual-claims" className="ml-2 text-sm text-gray-700">
+              This response contains factual claims
+            </label>
+          </div>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default EditResponseModal;

--- a/frontend/src/components/responses/index.ts
+++ b/frontend/src/components/responses/index.ts
@@ -4,3 +4,5 @@ export { default as ResponseCard } from './ResponseCard';
 export type { ResponseCardProps } from './ResponseCard';
 export { default as ThreadedResponseDisplay } from './ThreadedResponseDisplay';
 export type { ThreadedResponseDisplayProps } from './ThreadedResponseDisplay';
+export { default as EditResponseModal } from './EditResponseModal';
+export type { EditResponseModalProps } from './EditResponseModal';

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useRef } from 'react';
+
+export interface ModalProps {
+  /**
+   * Whether the modal is open
+   */
+  isOpen: boolean;
+
+  /**
+   * Callback when the modal should be closed
+   */
+  onClose: () => void;
+
+  /**
+   * Modal title
+   */
+  title: string;
+
+  /**
+   * Modal content
+   */
+  children: React.ReactNode;
+
+  /**
+   * Optional footer content (typically action buttons)
+   */
+  footer?: React.ReactNode;
+
+  /**
+   * Size of the modal
+   */
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+
+  /**
+   * Whether to close when clicking the backdrop
+   */
+  closeOnBackdropClick?: boolean;
+
+  /**
+   * Whether to close when pressing Escape
+   */
+  closeOnEscape?: boolean;
+
+  /**
+   * Whether to show the close button
+   */
+  showCloseButton?: boolean;
+}
+
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+  footer,
+  size = 'md',
+  closeOnBackdropClick = true,
+  closeOnEscape = true,
+  showCloseButton = true,
+}) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // Handle escape key
+  useEffect(() => {
+    if (!isOpen || !closeOnEscape) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, closeOnEscape, onClose]);
+
+  // Prevent body scroll when modal is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
+  // Focus trap
+  useEffect(() => {
+    if (!isOpen || !modalRef.current) return;
+
+    const focusableElements = modalRef.current.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const firstElement = focusableElements[0] as HTMLElement;
+    const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+
+      if (e.shiftKey) {
+        if (document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement?.focus();
+        }
+      } else {
+        if (document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement?.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleTab);
+    firstElement?.focus();
+
+    return () => document.removeEventListener('keydown', handleTab);
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const sizeClasses = {
+    sm: 'max-w-md',
+    md: 'max-w-lg',
+    lg: 'max-w-2xl',
+    xl: 'max-w-4xl',
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (closeOnBackdropClick && e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 overflow-y-auto"
+      aria-labelledby="modal-title"
+      role="dialog"
+      aria-modal="true"
+    >
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-gray-900 bg-opacity-50 transition-opacity"
+        onClick={handleBackdropClick}
+      />
+
+      {/* Modal */}
+      <div className="flex min-h-full items-center justify-center p-4">
+        <div
+          ref={modalRef}
+          className={`relative bg-white rounded-lg shadow-xl transition-all w-full ${sizeClasses[size]}`}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+            <h2 id="modal-title" className="text-lg font-semibold text-gray-900">
+              {title}
+            </h2>
+            {showCloseButton && (
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-primary-500 rounded-md p-1"
+                aria-label="Close modal"
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            )}
+          </div>
+
+          {/* Body */}
+          <div className="px-6 py-4 max-h-[calc(100vh-200px)] overflow-y-auto">
+            {children}
+          </div>
+
+          {/* Footer */}
+          {footer && (
+            <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 bg-gray-50">
+              {footer}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -7,3 +7,6 @@ export type { InputProps } from './Input';
 
 export { default as Card, CardHeader, CardBody, CardFooter } from './Card';
 export type { CardProps, CardHeaderProps, CardBodyProps, CardFooterProps } from './Card';
+
+export { default as Modal } from './Modal';
+export type { ModalProps } from './Modal';

--- a/frontend/src/types/response.ts
+++ b/frontend/src/types/response.ts
@@ -43,3 +43,10 @@ export interface CreateResponseRequest {
   propositionIds?: string[];
   acknowledgedFeedback?: boolean;
 }
+
+export interface UpdateResponseRequest {
+  content: string;
+  citedSources?: string[];
+  containsOpinion?: boolean;
+  containsFactualClaims?: boolean;
+}

--- a/frontend/tests/edit-response-modal.spec.ts
+++ b/frontend/tests/edit-response-modal.spec.ts
@@ -1,0 +1,45 @@
+import { test } from '@playwright/test';
+
+test.describe('EditResponseModal', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to a test page with EditResponseModal
+    // This will need to be adjusted based on where the modal is used in the app
+    await page.goto('/');
+  });
+
+  test.skip('should display modal with response content when opened', async () => {
+    // This test would open the edit modal and verify it displays the correct content
+    // Implementation depends on the actual app structure
+    // Placeholder for when the modal is integrated into pages
+  });
+
+  test.skip('should validate minimum character length', async () => {
+    // Test validation for minimum character count
+    // Placeholder for when the modal is integrated into pages
+  });
+
+  test.skip('should validate maximum character length', async () => {
+    // Test validation for maximum character count
+    // Placeholder for when the modal is integrated into pages
+  });
+
+  test.skip('should allow adding and removing cited sources', async () => {
+    // Test the cited sources functionality
+    // Placeholder for when the modal is integrated into pages
+  });
+
+  test.skip('should only enable save button when changes are made', async () => {
+    // Test that save button is disabled when no changes
+    // Placeholder for when the modal is integrated into pages
+  });
+
+  test.skip('should close modal on cancel', async () => {
+    // Test cancel functionality
+    // Placeholder for when the modal is integrated into pages
+  });
+
+  test.skip('should handle checkbox state for opinion and factual claims', async () => {
+    // Test checkbox functionality
+    // Placeholder for when the modal is integrated into pages
+  });
+});


### PR DESCRIPTION
## Summary
Implements the edit response modal component for T084, allowing users to edit their responses through a modal interface. This includes a new reusable Modal base component and the EditResponseModal component with full editing capabilities.

## Changes Made
- Created `Modal.tsx` base component in UI library (`frontend/src/components/ui/Modal.tsx`)
  - Reusable modal with customizable size, backdrop click handling, escape key support
  - Focus trap and accessibility features (ARIA labels, keyboard navigation)
  - Prevents body scroll when open
- Implemented `EditResponseModal.tsx` (`frontend/src/components/responses/EditResponseModal.tsx`)
  - Pre-populates form with existing response data
  - Character count validation (min/max)
  - Cited sources management (add/remove URLs with validation)
  - Opinion and factual claims checkboxes
  - Save button only enabled when changes are detected
  - Error handling and display
  - Loading state support
- Added `UpdateResponseRequest` type to `frontend/src/types/response.ts`
- Exported new components from index files
- Created placeholder Playwright test file (`frontend/tests/edit-response-modal.spec.ts`)

## Test Results
- TypeScript type checking: ✓ Passing
- ESLint: ✓ Passing (0 errors, 0 warnings)
- Build: ✓ Successful
- Vite production build: ✓ 110 modules transformed

## Testing Instructions
```bash
cd frontend
npm run typecheck
npm run lint
npm run build
```

## Breaking Changes
None

Fixes #80

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>