### PR TITLE
feat: Implement POST /alignments endpoint (closes #83)

### DIFF
--- a/services/discussion-service/src/alignments/alignments.controller.ts
+++ b/services/discussion-service/src/alignments/alignments.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Controller,
+  Put,
+  Delete,
+  Param,
+  Body,
+  Headers,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { AlignmentsService } from './alignments.service.js';
+import { SetAlignmentDto } from './dto/set-alignment.dto.js';
+import type { AlignmentDto } from './dto/alignment.dto.js';
+
+@Controller('propositions')
+export class AlignmentsController {
+  constructor(private readonly alignmentsService: AlignmentsService) {}
+
+  /**
+   * Set or update alignment on a proposition
+   * PUT /propositions/:propositionId/alignment
+   *
+   * Creates new alignment or updates existing one
+   */
+  @Put(':propositionId/alignment')
+  @HttpCode(HttpStatus.OK)
+  async setAlignment(
+    @Param('propositionId') propositionId: string,
+    @Headers('x-user-id') userId: string,
+    @Body() setAlignmentDto: SetAlignmentDto,
+  ): Promise<AlignmentDto> {
+    return this.alignmentsService.setAlignment(
+      propositionId,
+      userId,
+      setAlignmentDto,
+    );
+  }
+
+  /**
+   * Remove alignment from a proposition
+   * DELETE /propositions/:propositionId/alignment
+   */
+  @Delete(':propositionId/alignment')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async removeAlignment(
+    @Param('propositionId') propositionId: string,
+    @Headers('x-user-id') userId: string,
+  ): Promise<void> {
+    await this.alignmentsService.removeAlignment(propositionId, userId);
+  }
+}

--- a/services/discussion-service/src/alignments/alignments.module.ts
+++ b/services/discussion-service/src/alignments/alignments.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AlignmentsController } from './alignments.controller.js';
+import { AlignmentsService } from './alignments.service.js';
+import { PrismaModule } from '../prisma/prisma.module.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [AlignmentsController],
+  providers: [AlignmentsService],
+  exports: [AlignmentsService],
+})
+export class AlignmentsModule {}

--- a/services/discussion-service/src/alignments/alignments.service.ts
+++ b/services/discussion-service/src/alignments/alignments.service.ts
@@ -1,0 +1,128 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import type { AlignmentDto } from './dto/alignment.dto.js';
+import type { SetAlignmentDto } from './dto/set-alignment.dto.js';
+
+@Injectable()
+export class AlignmentsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Set or update user alignment on a proposition
+   * Creates new alignment or updates existing one
+   */
+  async setAlignment(
+    propositionId: string,
+    userId: string,
+    setAlignmentDto: SetAlignmentDto,
+  ): Promise<AlignmentDto> {
+    // Verify proposition exists
+    const proposition = await this.prisma.proposition.findUnique({
+      where: { id: propositionId },
+    });
+
+    if (!proposition) {
+      throw new NotFoundException(`Proposition with ID ${propositionId} not found`);
+    }
+
+    // Validate nuanceExplanation is provided when stance is NUANCED
+    if (setAlignmentDto.stance === 'NUANCED' && !setAlignmentDto.nuanceExplanation) {
+      throw new BadRequestException('nuanceExplanation is required when stance is NUANCED');
+    }
+
+    // Check for existing alignment
+    const existingAlignment = await this.prisma.alignment.findUnique({
+      where: {
+        userId_propositionId: {
+          userId,
+          propositionId,
+        },
+      },
+    });
+
+    // Update existing alignment
+    if (existingAlignment) {
+      const updatedAlignment = await this.prisma.alignment.update({
+        where: { id: existingAlignment.id },
+        data: {
+          stance: setAlignmentDto.stance,
+          nuanceExplanation: setAlignmentDto.nuanceExplanation || null,
+        },
+      });
+      return this.mapToAlignmentDto(updatedAlignment);
+    }
+
+    // Create new alignment
+    const newAlignment = await this.prisma.alignment.create({
+      data: {
+        userId,
+        propositionId,
+        stance: setAlignmentDto.stance,
+        nuanceExplanation: setAlignmentDto.nuanceExplanation || null,
+      },
+    });
+
+    return this.mapToAlignmentDto(newAlignment);
+  }
+
+  /**
+   * Remove user alignment from a proposition
+   */
+  async removeAlignment(propositionId: string, userId: string): Promise<void> {
+    const alignment = await this.prisma.alignment.findUnique({
+      where: {
+        userId_propositionId: {
+          userId,
+          propositionId,
+        },
+      },
+    });
+
+    if (!alignment) {
+      throw new NotFoundException('Alignment not found');
+    }
+
+    await this.prisma.alignment.delete({
+      where: { id: alignment.id },
+    });
+  }
+
+  /**
+   * Get user's alignment on a proposition (if exists)
+   */
+  async getUserAlignment(propositionId: string, userId: string): Promise<AlignmentDto | null> {
+    const alignment = await this.prisma.alignment.findUnique({
+      where: {
+        userId_propositionId: {
+          userId,
+          propositionId,
+        },
+      },
+    });
+
+    if (!alignment) {
+      return null;
+    }
+
+    return this.mapToAlignmentDto(alignment);
+  }
+
+  private mapToAlignmentDto(alignment: {
+    id: string;
+    stance: string;
+    nuanceExplanation: string | null;
+    createdAt: Date;
+  }): AlignmentDto {
+    const dto: AlignmentDto = {
+      id: alignment.id,
+      stance: alignment.stance as 'SUPPORT' | 'OPPOSE' | 'NUANCED',
+      createdAt: alignment.createdAt,
+    };
+
+    if (alignment.nuanceExplanation) {
+      dto.nuanceExplanation = alignment.nuanceExplanation;
+    }
+
+    return dto;
+  }
+}

--- a/services/discussion-service/src/alignments/dto/alignment.dto.ts
+++ b/services/discussion-service/src/alignments/dto/alignment.dto.ts
@@ -1,0 +1,10 @@
+/**
+ * DTO for alignment response
+ * Matches the Alignment schema from the OpenAPI spec
+ */
+export interface AlignmentDto {
+  id: string;
+  stance: 'SUPPORT' | 'OPPOSE' | 'NUANCED';
+  nuanceExplanation?: string;
+  createdAt: Date;
+}

--- a/services/discussion-service/src/alignments/dto/set-alignment.dto.ts
+++ b/services/discussion-service/src/alignments/dto/set-alignment.dto.ts
@@ -1,0 +1,23 @@
+import { IsEnum, IsOptional, IsString, MaxLength, ValidateIf } from 'class-validator';
+
+/**
+ * DTO for setting user alignment on a proposition
+ * Matches the SetAlignmentRequest schema from the OpenAPI spec
+ */
+export class SetAlignmentDto {
+  /**
+   * User's stance on the proposition
+   */
+  @IsEnum(['SUPPORT', 'OPPOSE', 'NUANCED'])
+  stance!: 'SUPPORT' | 'OPPOSE' | 'NUANCED';
+
+  /**
+   * Explanation required when stance is NUANCED
+   * Optional for SUPPORT/OPPOSE
+   */
+  @IsOptional()
+  @ValidateIf((o) => o.stance === 'NUANCED')
+  @IsString()
+  @MaxLength(500)
+  nuanceExplanation?: string;
+}

--- a/services/discussion-service/src/app.module.ts
+++ b/services/discussion-service/src/app.module.ts
@@ -4,9 +4,10 @@ import { HealthModule } from './health/health.module.js';
 import { TopicsModule } from './topics/topics.module.js';
 import { ResponsesModule } from './responses/responses.module.js';
 import { VotesModule } from './votes/votes.module.js';
+import { AlignmentsModule } from './alignments/alignments.module.js';
 
 @Module({
-  imports: [PrismaModule, HealthModule, TopicsModule, ResponsesModule, VotesModule],
+  imports: [PrismaModule, HealthModule, TopicsModule, ResponsesModule, VotesModule, AlignmentsModule],
   controllers: [],
   providers: [],
 })


### PR DESCRIPTION
## Summary
Implemented the alignments API endpoints to allow users to set their stance (SUPPORT/OPPOSE/NUANCED) on propositions. This is a key feature for tracking user opinions and building consensus analysis.

## Changes Made
- Created `AlignmentsModule` in `services/discussion-service/src/alignments/`
  - `alignments.controller.ts` - REST endpoints for alignment operations
  - `alignments.service.ts` - Business logic for create/update/delete alignments
  - `dto/set-alignment.dto.ts` - Request validation with class-validator
  - `dto/alignment.dto.ts` - Response serialization interface
  - `alignments.module.ts` - NestJS module configuration
- Integrated AlignmentsModule into `app.module.ts`

## API Endpoints
- `PUT /propositions/:propositionId/alignment` - Set or update user alignment
- `DELETE /propositions/:propositionId/alignment` - Remove user alignment

## Features
- Upsert behavior (creates new or updates existing alignment)
- Validates proposition exists before creating alignment
- Validates `nuanceExplanation` is provided when stance is NUANCED
- Uses Prisma unique constraint (userId + propositionId) to prevent duplicates
- Proper error handling with NotFoundException and BadRequestException

## Request Schema
```typescript
{
  stance: 'SUPPORT' | 'OPPOSE' | 'NUANCED',
  nuanceExplanation?: string  // required when stance is NUANCED
}
```

## Response Schema
```typescript
{
  id: string,
  stance: 'SUPPORT' | 'OPPOSE' | 'NUANCED',
  nuanceExplanation?: string,
  createdAt: Date
}
```

## Test Results
- Build passes: `npm run build` ✓
- TypeScript compilation successful ✓
- All modules properly integrated ✓

## Testing Instructions
```bash
cd services/discussion-service
npm run build
```

## Breaking Changes
None - this is a new feature.

Fixes #83

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>