### PR TITLE
feat: Add GET endpoint for user alignment tracking (#88)

### DIFF
--- a/services/discussion-service/src/alignments/alignments.controller.ts
+++ b/services/discussion-service/src/alignments/alignments.controller.ts
@@ -1,5 +1,6 @@
 import {
   Controller,
+  Get,
   Put,
   Delete,
   Param,
@@ -15,6 +16,20 @@ import type { AlignmentDto } from './dto/alignment.dto.js';
 @Controller('propositions')
 export class AlignmentsController {
   constructor(private readonly alignmentsService: AlignmentsService) {}
+
+  /**
+   * Get user's alignment on a proposition
+   * GET /propositions/:propositionId/alignment
+   *
+   * Returns user's alignment if exists, null otherwise
+   */
+  @Get(':propositionId/alignment')
+  async getUserAlignment(
+    @Param('propositionId') propositionId: string,
+    @Headers('x-user-id') userId: string,
+  ): Promise<AlignmentDto | null> {
+    return this.alignmentsService.getUserAlignment(propositionId, userId);
+  }
 
   /**
    * Set or update alignment on a proposition


### PR DESCRIPTION
## Summary
- Added GET /propositions/:propositionId/alignment endpoint
- Exposes existing getUserAlignment service method via controller
- Returns user's alignment on a proposition if it exists, null otherwise

## Changes
- Modified `services/discussion-service/src/alignments/alignments.controller.ts`:
  - Added Get decorator import
  - Added getUserAlignment endpoint method
  - Endpoint follows existing pattern with x-user-id header authentication

## API
**New Endpoint:**
```
GET /propositions/:propositionId/alignment
Headers: x-user-id: <userId>
Response: AlignmentDto | null
```

## Test plan
- [x] Build passes (pnpm build)
- [ ] Manual testing: Verify GET endpoint returns user's alignment
- [ ] Manual testing: Verify returns null when no alignment exists
- [ ] Integration with frontend alignment components

Implements issue #88 (T092)

🤖 Generated with [Claude Code](https://claude.com/claude-code)