### PR TITLE
feat: Implement POST /feedback/request endpoint (closes #97)

### DIFF
--- a/services/ai-service/src/app.module.ts
+++ b/services/ai-service/src/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { HealthModule } from './health/health.module.js';
 import { PrismaModule } from './prisma/prisma.module.js';
 import { AiModule } from './ai/ai.module.js';
+import { FeedbackModule } from './feedback/feedback.module.js';
 
 @Module({
-  imports: [PrismaModule, HealthModule, AiModule],
+  imports: [PrismaModule, HealthModule, AiModule, FeedbackModule],
   controllers: [],
   providers: [],
 })

--- a/services/ai-service/src/feedback/dto/feedback-response.dto.ts
+++ b/services/ai-service/src/feedback/dto/feedback-response.dto.ts
@@ -1,0 +1,54 @@
+/**
+ * DTO for feedback response
+ */
+export class FeedbackResponseDto {
+  /**
+   * UUID of the created feedback
+   */
+  id!: string;
+
+  /**
+   * UUID of the response being analyzed
+   */
+  responseId!: string;
+
+  /**
+   * Type of feedback (FALLACY, INFLAMMATORY, UNSOURCED, BIAS, AFFIRMATION)
+   */
+  type!: string;
+
+  /**
+   * Optional subtype for more specific categorization
+   */
+  subtype?: string;
+
+  /**
+   * AI-generated suggestion text
+   */
+  suggestionText!: string;
+
+  /**
+   * Reasoning behind the feedback
+   */
+  reasoning!: string;
+
+  /**
+   * Confidence score (0.00 to 1.00)
+   */
+  confidenceScore!: number;
+
+  /**
+   * Optional educational resources (URLs, articles, etc.)
+   */
+  educationalResources?: any;
+
+  /**
+   * Whether this feedback is displayed to the user
+   */
+  displayedToUser!: boolean;
+
+  /**
+   * Timestamp when feedback was created
+   */
+  createdAt!: Date;
+}

--- a/services/ai-service/src/feedback/dto/index.ts
+++ b/services/ai-service/src/feedback/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './request-feedback.dto.js';
+export * from './feedback-response.dto.js';

--- a/services/ai-service/src/feedback/dto/request-feedback.dto.ts
+++ b/services/ai-service/src/feedback/dto/request-feedback.dto.ts
@@ -1,0 +1,20 @@
+import { IsUUID, IsString, IsNotEmpty } from 'class-validator';
+
+/**
+ * DTO for requesting AI-generated feedback on a response
+ */
+export class RequestFeedbackDto {
+  /**
+   * UUID of the response to analyze
+   */
+  @IsUUID()
+  @IsNotEmpty()
+  responseId!: string;
+
+  /**
+   * The content of the response to analyze
+   */
+  @IsString()
+  @IsNotEmpty()
+  content!: string;
+}

--- a/services/ai-service/src/feedback/feedback.controller.ts
+++ b/services/ai-service/src/feedback/feedback.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import { FeedbackService } from './feedback.service.js';
+import { RequestFeedbackDto, FeedbackResponseDto } from './dto/index.js';
+
+/**
+ * Controller for feedback-related endpoints
+ */
+@Controller('feedback')
+export class FeedbackController {
+  constructor(private readonly feedbackService: FeedbackService) {}
+
+  /**
+   * Request AI-generated feedback for a response
+   * POST /feedback/request
+   *
+   * @param dto Request containing responseId and content
+   * @returns Created feedback record
+   */
+  @Post('request')
+  @HttpCode(HttpStatus.CREATED)
+  async requestFeedback(@Body() dto: RequestFeedbackDto): Promise<FeedbackResponseDto> {
+    return this.feedbackService.requestFeedback(dto);
+  }
+}

--- a/services/ai-service/src/feedback/feedback.module.ts
+++ b/services/ai-service/src/feedback/feedback.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { FeedbackController } from './feedback.controller.js';
+import { FeedbackService } from './feedback.service.js';
+import { PrismaModule } from '../prisma/prisma.module.js';
+import { AiModule } from '../ai/ai.module.js';
+
+/**
+ * Module for feedback functionality
+ */
+@Module({
+  imports: [PrismaModule, AiModule],
+  controllers: [FeedbackController],
+  providers: [FeedbackService],
+  exports: [FeedbackService],
+})
+export class FeedbackModule {}

--- a/services/ai-service/src/feedback/feedback.service.ts
+++ b/services/ai-service/src/feedback/feedback.service.ts
@@ -1,0 +1,99 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { BedrockService } from '../ai/bedrock.service.js';
+import { RequestFeedbackDto, FeedbackResponseDto } from './dto/index.js';
+import { FeedbackType, Prisma } from '@unite-discord/db-models';
+
+/**
+ * Service for handling AI-generated feedback on responses
+ */
+@Injectable()
+export class FeedbackService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly bedrock: BedrockService,
+  ) {}
+
+  /**
+   * Request AI-generated feedback for a response
+   * @param dto Request containing responseId and content
+   * @returns Created feedback record
+   */
+  async requestFeedback(dto: RequestFeedbackDto): Promise<FeedbackResponseDto> {
+    // Verify the response exists
+    const response = await this.prisma.response.findUnique({
+      where: { id: dto.responseId },
+    });
+
+    if (!response) {
+      throw new NotFoundException(`Response with ID ${dto.responseId} not found`);
+    }
+
+    // Generate AI feedback using Bedrock
+    const aiAnalysis = await this.generateFeedback(dto.content);
+
+    // Store feedback in database
+    const feedback = await this.prisma.feedback.create({
+      data: {
+        responseId: dto.responseId,
+        type: aiAnalysis.type,
+        subtype: aiAnalysis.subtype ?? null,
+        suggestionText: aiAnalysis.suggestionText,
+        reasoning: aiAnalysis.reasoning,
+        confidenceScore: new Prisma.Decimal(aiAnalysis.confidenceScore),
+        educationalResources: aiAnalysis.educationalResources ?? null,
+        displayedToUser: true,
+        userAcknowledged: false,
+        userRevised: false,
+      },
+    });
+
+    return this.mapToResponseDto(feedback);
+  }
+
+  /**
+   * Generate feedback using AI (stub implementation for now)
+   * @param content The response content to analyze
+   * @returns AI-generated feedback analysis
+   */
+  private async generateFeedback(content: string): Promise<{
+    type: FeedbackType;
+    subtype?: string;
+    suggestionText: string;
+    reasoning: string;
+    confidenceScore: number;
+    educationalResources?: any;
+  }> {
+    // For now, use the stub Bedrock service
+    // In the future, this will make actual AI calls to analyze the content
+    await this.bedrock.analyzeContent(content);
+
+    // Stub implementation - returns a generic affirmation
+    // This will be replaced with actual AI analysis in future tasks
+    return {
+      type: FeedbackType.AFFIRMATION,
+      suggestionText: 'Your response contributes to constructive dialogue.',
+      reasoning:
+        'This is a stub implementation. Actual AI analysis will be implemented in future tasks.',
+      confidenceScore: 0.5,
+    };
+  }
+
+  /**
+   * Map Prisma Feedback to FeedbackResponseDto
+   */
+  private mapToResponseDto(feedback: any): FeedbackResponseDto {
+    return {
+      id: feedback.id,
+      responseId: feedback.responseId,
+      type: feedback.type,
+      subtype: feedback.subtype,
+      suggestionText: feedback.suggestionText,
+      reasoning: feedback.reasoning,
+      confidenceScore: Number(feedback.confidenceScore),
+      educationalResources: feedback.educationalResources,
+      displayedToUser: feedback.displayedToUser,
+      createdAt: feedback.createdAt,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
Implements POST /feedback/request endpoint for requesting AI-generated feedback on user responses. This is part of the AI Feedback feature (US2) and provides the foundation for content analysis and feedback generation.

## Changes Made
- Created `FeedbackController` with POST /feedback/request endpoint (services/ai-service/src/feedback/feedback.controller.ts)
- Created `FeedbackService` to orchestrate feedback generation (services/ai-service/src/feedback/feedback.service.ts)
- Created DTOs: `RequestFeedbackDto` and `FeedbackResponseDto` (services/ai-service/src/feedback/dto/)
- Created `FeedbackModule` and registered in AppModule (services/ai-service/src/feedback/feedback.module.ts)
- Integrated with Prisma for database operations
- Uses BedrockService stub for AI analysis (actual AI integration will come in future tasks)

## Implementation Details
- Endpoint: `POST /feedback/request`
- Request body: `{ responseId: string, content: string }`
- Response: Feedback record with id, type, suggestionText, reasoning, confidenceScore, etc.
- Validates that the response exists before creating feedback
- Currently returns stub feedback (AFFIRMATION type) - will be enhanced with actual AI analysis

## Test Results
- TypeScript compilation: ✅ Passing
- Build: ✅ Successful

## Testing Instructions
```bash
cd services/ai-service
pnpm build
```

## Breaking Changes
None

Fixes #97

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>