### PR TITLE
feat: Implement GET /feedback/:id endpoint (closes #100)

### DIFF
--- a/services/ai-service/src/feedback/feedback.controller.ts
+++ b/services/ai-service/src/feedback/feedback.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Post, Get, Body, Param, HttpCode, HttpStatus } from '@nestjs/common';
 import { FeedbackService } from './feedback.service.js';
 import { RequestFeedbackDto, FeedbackResponseDto } from './dto/index.js';
 
@@ -20,5 +20,18 @@ export class FeedbackController {
   @HttpCode(HttpStatus.CREATED)
   async requestFeedback(@Body() dto: RequestFeedbackDto): Promise<FeedbackResponseDto> {
     return this.feedbackService.requestFeedback(dto);
+  }
+
+  /**
+   * Get feedback by ID
+   * GET /feedback/:id
+   *
+   * @param id Feedback UUID
+   * @returns Feedback record
+   */
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  async getFeedback(@Param('id') id: string): Promise<FeedbackResponseDto> {
+    return this.feedbackService.getFeedbackById(id);
   }
 }

--- a/services/ai-service/src/feedback/feedback.service.ts
+++ b/services/ai-service/src/feedback/feedback.service.ts
@@ -52,6 +52,24 @@ export class FeedbackService {
   }
 
   /**
+   * Get feedback by ID
+   * @param id Feedback UUID
+   * @returns Feedback record
+   * @throws NotFoundException if feedback not found
+   */
+  async getFeedbackById(id: string): Promise<FeedbackResponseDto> {
+    const feedback = await this.prisma.feedback.findUnique({
+      where: { id },
+    });
+
+    if (!feedback) {
+      throw new NotFoundException(`Feedback with ID ${id} not found`);
+    }
+
+    return this.mapToResponseDto(feedback);
+  }
+
+  /**
    * Generate feedback using comprehensive analysis
    * Analyzes emotional tone, logical fallacies, and clarity
    * @param content The response content to analyze


### PR DESCRIPTION
## Summary
Implements T104 - GET endpoint to retrieve feedback records by UUID. This allows clients to fetch individual feedback items that were previously generated.

## Changes Made
- **FeedbackService** (`services/ai-service/src/feedback/feedback.service.ts`):
  - Added `getFeedbackById(id: string)` method
  - Queries Prisma for feedback by UUID
  - Throws `NotFoundException` if feedback not found
  - Reuses existing `mapToResponseDto` helper for consistent data transformation
  
- **FeedbackController** (`services/ai-service/src/feedback/feedback.controller.ts`):
  - Added `GET /feedback/:id` endpoint
  - Accepts UUID parameter
  - Returns HTTP 200 OK with `FeedbackResponseDto`
  - Added `Get` and `Param` imports from `@nestjs/common`

## Implementation Details
- Follows existing patterns from POST /feedback/request endpoint
- Reuses `FeedbackResponseDto` for consistent API responses
- Proper error handling with NestJS `NotFoundException`
- Consistent HTTP status codes (200 OK for successful GET)

## Test Results
- Type checking: ✓ Passing (`npm run typecheck`)
- Build: ✓ Passing (`npm run build`)
- All workspace packages type-check successfully

## Testing Instructions
```bash
# Type check
npm run typecheck

# Build
cd services/ai-service
npm run build
```

## Breaking Changes
None - this is a new endpoint with no changes to existing functionality

Fixes #100

🤖 Generated with Claude Code
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>