### PR TITLE
[T127] Implement GET /topics/:id/common-ground endpoint

### DIFF
--- a/services/discussion-service/src/topics/dto/common-ground-query.dto.ts
+++ b/services/discussion-service/src/topics/dto/common-ground-query.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional, IsInt, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GetCommonGroundQueryDto {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  version?: number;
+}

--- a/services/discussion-service/src/topics/dto/common-ground-response.dto.ts
+++ b/services/discussion-service/src/topics/dto/common-ground-response.dto.ts
@@ -1,0 +1,39 @@
+export interface AgreementZoneDto {
+  description: string;
+  confidence: number;
+  propositionIds: string[];
+  participantPercentage: number;
+}
+
+export interface MisunderstandingDefinitionDto {
+  definition: string;
+  userCount: number;
+}
+
+export interface MisunderstandingDto {
+  description: string;
+  term: string;
+  definitions: MisunderstandingDefinitionDto[];
+  affectedPropositions: string[];
+}
+
+export type MoralFoundation = 'care' | 'fairness' | 'loyalty' | 'authority' | 'sanctity' | 'liberty';
+
+export interface GenuineDisagreementDto {
+  description: string;
+  underlyingValues: string[];
+  moralFoundations: MoralFoundation[];
+  propositionIds: string[];
+}
+
+export interface CommonGroundResponseDto {
+  id: string;
+  version: number;
+  agreementZones: AgreementZoneDto[];
+  misunderstandings: MisunderstandingDto[];
+  genuineDisagreements: GenuineDisagreementDto[];
+  overallConsensusScore: number;
+  participantCountAtGeneration: number;
+  responseCountAtGeneration: number;
+  generatedAt: Date;
+}

--- a/services/discussion-service/src/topics/topics.controller.ts
+++ b/services/discussion-service/src/topics/topics.controller.ts
@@ -2,7 +2,9 @@ import { Controller, Get, Query, Param } from '@nestjs/common';
 import { TopicsService } from './topics.service.js';
 import { GetTopicsQueryDto } from './dto/get-topics-query.dto.js';
 import { SearchTopicsQueryDto } from './dto/search-topics-query.dto.js';
+import { GetCommonGroundQueryDto } from './dto/common-ground-query.dto.js';
 import type { PaginatedTopicsResponseDto, TopicResponseDto } from './dto/topic-response.dto.js';
+import type { CommonGroundResponseDto } from './dto/common-ground-response.dto.js';
 
 @Controller('topics')
 export class TopicsController {
@@ -25,5 +27,13 @@ export class TopicsController {
   @Get(':id')
   async getTopicById(@Param('id') id: string): Promise<TopicResponseDto> {
     return this.topicsService.getTopicById(id);
+  }
+
+  @Get(':id/common-ground')
+  async getCommonGroundAnalysis(
+    @Param('id') id: string,
+    @Query() query: GetCommonGroundQueryDto,
+  ): Promise<CommonGroundResponseDto> {
+    return this.topicsService.getCommonGroundAnalysis(id, query.version);
   }
 }


### PR DESCRIPTION
## Summary
Implements the GET /topics/:id/common-ground endpoint to retrieve common ground analysis for a discussion topic.

## Changes
- Created `CommonGroundResponseDto` with nested DTOs (`AgreementZoneDto`, `MisunderstandingDto`, `GenuineDisagreementDto`) matching the OpenAPI specification
- Created `GetCommonGroundQueryDto` for the optional `version` query parameter
- Implemented `TopicsService.getCommonGroundAnalysis()` to fetch analysis from database
  - Supports fetching latest version or specific version
  - Verifies topic exists before fetching analysis
  - Returns 404 with appropriate message if not found
- Added `TopicsController.getCommonGroundAnalysis()` endpoint at `/topics/:id/common-ground`

## Implementation Details
- Endpoint path: `GET /topics/:id/common-ground`
- Optional query parameter: `version` (integer)
- Returns latest analysis by default, ordered by version DESC
- Properly handles Prisma Decimal to number conversion for consensus score
- Validates topic existence before attempting to fetch analysis

## Testing
- Built successfully with TypeScript strict mode
- Follows existing controller/service patterns in the codebase

## Related
Closes #123 (T127)
Part of User Story US3: Common Ground Analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)