### PR TITLE
[T128] Implement common ground refresh trigger

### DIFF
--- a/services/discussion-service/src/responses/responses.module.ts
+++ b/services/discussion-service/src/responses/responses.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module.js';
 import { ResponsesController } from './responses.controller.js';
 import { ResponsesService } from './responses.service.js';
+import { CommonGroundTriggerService } from '../services/common-ground-trigger.service.js';
 
 @Module({
   imports: [PrismaModule],
   controllers: [ResponsesController],
-  providers: [ResponsesService],
+  providers: [ResponsesService, CommonGroundTriggerService],
   exports: [ResponsesService],
 })
 export class ResponsesModule {}

--- a/services/discussion-service/src/responses/responses.service.ts
+++ b/services/discussion-service/src/responses/responses.service.ts
@@ -5,13 +5,17 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
+import { CommonGroundTriggerService } from '../services/common-ground-trigger.service.js';
 import { CreateResponseDto } from './dto/create-response.dto.js';
 import { UpdateResponseDto } from './dto/update-response.dto.js';
 import type { ResponseDto, CitedSourceDto, UserSummaryDto } from './dto/response.dto.js';
 
 @Injectable()
 export class ResponsesService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly commonGroundTrigger: CommonGroundTriggerService,
+  ) {}
 
   /**
    * Get all responses for a discussion topic
@@ -157,6 +161,23 @@ export class ResponsesService {
         skipDuplicates: true,
       });
     }
+
+    // Increment topic response count
+    await this.prisma.discussionTopic.update({
+      where: { id: topicId },
+      data: {
+        responseCount: {
+          increment: 1,
+        },
+      },
+    });
+
+    // Check and trigger common ground analysis if needed
+    // This is fire-and-forget - we don't wait for it to complete
+    this.commonGroundTrigger.checkAndTrigger(topicId).catch((error) => {
+      // Error is already logged in the service, but log here too for visibility
+      console.error(`Failed to check/trigger common ground analysis: ${error.message}`);
+    });
 
     // Fetch the complete response with all relations
     const completeResponse = await this.prisma.response.findUnique({

--- a/services/discussion-service/src/services/common-ground-trigger.service.ts
+++ b/services/discussion-service/src/services/common-ground-trigger.service.ts
@@ -1,0 +1,143 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+/**
+ * Service responsible for triggering common ground analysis
+ * when certain thresholds are met.
+ *
+ * Trigger conditions (from data-model.md):
+ * - Response count increases by 10+ OR
+ * - 6+ hours have elapsed since last analysis
+ */
+@Injectable()
+export class CommonGroundTriggerService {
+  private readonly logger = new Logger(CommonGroundTriggerService.name);
+
+  // Trigger thresholds
+  private readonly RESPONSE_DELTA_THRESHOLD = 10;
+  private readonly TIME_THRESHOLD_HOURS = 6;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Check if common ground analysis should be triggered for a topic
+   * and trigger it if conditions are met.
+   *
+   * @param topicId - The ID of the topic to check
+   * @returns true if analysis was triggered, false otherwise
+   */
+  async checkAndTrigger(topicId: string): Promise<boolean> {
+    try {
+      // Get topic with current counts
+      const topic = await this.prisma.discussionTopic.findUnique({
+        where: { id: topicId },
+        select: {
+          id: true,
+          responseCount: true,
+          participantCount: true,
+        },
+      });
+
+      if (!topic) {
+        this.logger.warn(`Topic ${topicId} not found`);
+        return false;
+      }
+
+      // Get latest common ground analysis (if any)
+      const lastAnalysis = await this.prisma.commonGroundAnalysis.findFirst({
+        where: { topicId },
+        orderBy: { version: 'desc' },
+        select: {
+          responseCountAtGeneration: true,
+          createdAt: true,
+        },
+      });
+
+      // Check trigger conditions
+      const shouldTrigger = this.shouldTriggerAnalysis(topic, lastAnalysis);
+
+      if (shouldTrigger) {
+        this.logger.log(`Triggering common ground analysis for topic ${topicId}`);
+        await this.triggerAnalysis(topicId);
+        return true;
+      }
+
+      return false;
+    } catch (error) {
+      this.logger.error(
+        `Error checking/triggering common ground analysis for topic ${topicId}:`,
+        error,
+      );
+      // Don't throw - we don't want to block response creation if trigger fails
+      return false;
+    }
+  }
+
+  /**
+   * Determine if analysis should be triggered based on thresholds
+   */
+  private shouldTriggerAnalysis(
+    topic: { responseCount: number; participantCount: number },
+    lastAnalysis: { responseCountAtGeneration: number; createdAt: Date } | null,
+  ): boolean {
+    // If no analysis exists yet, don't trigger until we have enough participation
+    if (!lastAnalysis) {
+      // Require at least 10 participants and 10 responses before first analysis
+      return topic.participantCount >= 10 && topic.responseCount >= 10;
+    }
+
+    // Condition 1: Response count increased by 10+
+    const responsesDelta = topic.responseCount - lastAnalysis.responseCountAtGeneration;
+    if (responsesDelta >= this.RESPONSE_DELTA_THRESHOLD) {
+      this.logger.debug(
+        `Response delta threshold met: ${responsesDelta} >= ${this.RESPONSE_DELTA_THRESHOLD}`,
+      );
+      return true;
+    }
+
+    // Condition 2: 6+ hours elapsed
+    const hoursSinceLastAnalysis =
+      (Date.now() - lastAnalysis.createdAt.getTime()) / (1000 * 60 * 60);
+    if (hoursSinceLastAnalysis >= this.TIME_THRESHOLD_HOURS) {
+      this.logger.debug(
+        `Time threshold met: ${hoursSinceLastAnalysis.toFixed(2)} hours >= ${this.TIME_THRESHOLD_HOURS} hours`,
+      );
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Trigger common ground analysis by calling AI service
+   *
+   * Note: This is a placeholder implementation. In the full implementation,
+   * this would either:
+   * 1. Make an HTTP call to the AI service's /generate/common-ground endpoint
+   * 2. Publish an event to trigger the AI service
+   *
+   * For now, we'll just log that the trigger would happen.
+   */
+  private async triggerAnalysis(topicId: string): Promise<void> {
+    // TODO: Implement actual trigger mechanism
+    // Options:
+    // 1. HTTP POST to ai-service: POST /generate/common-ground
+    // 2. Publish event: 'common-ground.trigger-requested'
+
+    this.logger.log(
+      `[PLACEHOLDER] Would trigger common ground analysis for topic ${topicId}`,
+    );
+    this.logger.log(
+      `Next step: Implement HTTP client to call AI service /generate/common-ground endpoint`,
+    );
+
+    // Future implementation would look like:
+    // const propositions = await this.fetchPropositions(topicId);
+    // const responses = await this.fetchResponses(topicId);
+    // await this.aiServiceClient.post('/generate/common-ground', {
+    //   topicId,
+    //   propositions,
+    //   responses,
+    // });
+  }
+}


### PR DESCRIPTION
## Summary
Implements automatic triggering of common ground analysis when discussion activity thresholds are met.

## Changes
- **Created `CommonGroundTriggerService`** (`services/discussion-service/src/services/common-ground-trigger.service.ts`)
  - Checks trigger conditions: response delta ≥ 10 OR time elapsed ≥ 6 hours
  - Requires minimum 10 participants before first analysis
  - Placeholder for actual AI service integration (documented in code)
  
- **Updated `ResponsesService`** to increment topic response count and call trigger
  - Increments `responseCount` on `DiscussionTopic` after creating response
  - Calls trigger check in fire-and-forget manner (doesn't block response creation)
  
- **Updated `ResponsesModule`** to provide `CommonGroundTriggerService`

## Trigger Logic

From the data model specification:

| Condition | Threshold |
|-----------|-----------|
| Response delta | 10+ new responses since last analysis |
| Time elapsed | 6+ hours since last analysis |
| First analysis | Requires ≥10 participants |

The service logs when analysis would be triggered but includes a placeholder for the actual integration with the AI service's `/generate/common-ground` endpoint.

## Future Work
- Implement HTTP client to call AI service endpoint
- Subscribe to `common-ground.generated` event to store results
- Or use event-driven architecture (publish trigger event instead of HTTP call)

## Related
Closes #124 (T128)
Part of User Story US3: Common Ground Analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)