### PR TITLE
feat: Implement common ground update events [T132] (#128)

### DIFF
--- a/packages/event-schemas/src/ai.ts
+++ b/packages/event-schemas/src/ai.ts
@@ -10,6 +10,7 @@ import type { BaseEvent } from './base.js';
 export const AI_EVENT_TYPES = {
   RESPONSE_ANALYZED: 'response.analyzed',
   COMMON_GROUND_GENERATED: 'common-ground.generated',
+  COMMON_GROUND_UPDATED: 'common-ground.updated',
 } as const;
 
 /**
@@ -148,6 +149,68 @@ export interface CommonGroundGeneratedEvent
 }
 
 /**
+ * Payload for common-ground.updated event
+ * Published when a new version of common ground analysis is generated for a topic
+ */
+export interface CommonGroundUpdatedPayload {
+  /** Topic that was analyzed */
+  topicId: string;
+  /** Previous version number */
+  previousVersion: number;
+  /** New version number */
+  newVersion: number;
+  /** Previous analysis data */
+  previousAnalysis: {
+    agreementZones: AgreementZone[];
+    misunderstandings: Misunderstanding[];
+    genuineDisagreements: GenuineDisagreement[];
+    overallConsensusScore?: number;
+  };
+  /** New analysis data */
+  newAnalysis: {
+    agreementZones: AgreementZone[];
+    misunderstandings: Misunderstanding[];
+    genuineDisagreements: GenuineDisagreement[];
+    overallConsensusScore?: number;
+  };
+  /** Summary of what changed */
+  changes: {
+    /** Number of new agreement zones found */
+    newAgreementZones: number;
+    /** Number of agreement zones removed */
+    removedAgreementZones: number;
+    /** Number of new misunderstandings identified */
+    newMisunderstandings: number;
+    /** Number of misunderstandings resolved */
+    resolvedMisunderstandings: number;
+    /** Number of new disagreements identified */
+    newDisagreements: number;
+    /** Change in overall consensus score */
+    consensusScoreChange?: number;
+  };
+  /** Reason for the update */
+  reason: 'response_threshold' | 'time_threshold' | 'manual_trigger';
+  /** Participant count at time of update */
+  participantCountAtUpdate: number;
+  /** Response count at time of update */
+  responseCountAtUpdate: number;
+  /** Response count since last version */
+  newResponsesSinceLastVersion: number;
+  /** Model version used */
+  modelVersion: string;
+  /** When update was generated */
+  updatedAt: string;
+}
+
+/**
+ * Event published when a new version of common ground analysis is generated
+ */
+export interface CommonGroundUpdatedEvent
+  extends BaseEvent<typeof AI_EVENT_TYPES.COMMON_GROUND_UPDATED, CommonGroundUpdatedPayload> {
+  type: typeof AI_EVENT_TYPES.COMMON_GROUND_UPDATED;
+}
+
+/**
  * Union type of all AI service events
  */
-export type AIEvent = ResponseAnalyzedEvent | CommonGroundGeneratedEvent;
+export type AIEvent = ResponseAnalyzedEvent | CommonGroundGeneratedEvent | CommonGroundUpdatedEvent;


### PR DESCRIPTION
## Summary
- Adds `common-ground.updated` event type to AI service event schemas
- Provides versioned update tracking for common ground analyses
- Includes change summaries and reason for updates

## Implementation Details
The new event schema includes:
- **Version tracking**: `previousVersion` → `newVersion`
- **Analysis comparison**: Both `previousAnalysis` and `newAnalysis` data
- **Change summary**: Counts of new/removed agreement zones, misunderstandings, disagreements, and consensus score changes
- **Update metadata**: Reason for update (response_threshold, time_threshold, manual_trigger), participant/response counts
- **Timestamps**: `updatedAt` field for when the update occurred

This follows the established pattern from `user.trust.updated` event in moderation.ts, providing consumers with both the before and after states to enable diff-based processing.

## Test plan
- [x] TypeScript compilation passes (`pnpm build` in packages/event-schemas)
- [x] Type definitions are exported correctly
- [x] Event types follow existing patterns in the codebase

## Related Issues
Closes #128 (T132 - Implement common ground update events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)