### PR TITLE
feat: Create SharedPointCard component for common ground analysis (closes #133)

### DIFF
--- a/frontend/frontend/src/__tests__/components/common-ground/SharedPointCard.test.tsx
+++ b/frontend/frontend/src/__tests__/components/common-ground/SharedPointCard.test.tsx
@@ -1,0 +1,233 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SharedPointCard from '../../../components/common-ground/SharedPointCard';
+import type { Proposition } from '../../../types/common-ground';
+
+describe('SharedPointCard', () => {
+  const mockOnClick = jest.fn();
+
+  const baseProposition: Proposition = {
+    id: 'prop-1',
+    text: 'Climate change is primarily caused by human activity',
+    agreementPercentage: 85,
+    supportingParticipants: ['user1', 'user2', 'user3', 'user4', 'user5'],
+    opposingParticipants: ['user6'],
+    neutralParticipants: [],
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render proposition text', () => {
+      render(<SharedPointCard proposition={baseProposition} />);
+      expect(screen.getByText(baseProposition.text)).toBeInTheDocument();
+    });
+
+    it('should render agreement percentage badge', () => {
+      render(<SharedPointCard proposition={baseProposition} />);
+      expect(screen.getByText('85%')).toBeInTheDocument();
+    });
+
+    it('should hide agreement badge when showAgreementBadge is false', () => {
+      render(<SharedPointCard proposition={baseProposition} showAgreementBadge={false} />);
+      expect(screen.queryByText('85%')).not.toBeInTheDocument();
+    });
+
+    it('should render progress bar with correct width', () => {
+      render(<SharedPointCard proposition={baseProposition} />);
+      const progressBar = screen.getByRole('progressbar');
+      expect(progressBar).toHaveStyle({ width: '85%' });
+    });
+
+    it('should render participant counts when showParticipants is true', () => {
+      render(<SharedPointCard proposition={baseProposition} showParticipants />);
+      expect(screen.getByText('5 support')).toBeInTheDocument();
+      expect(screen.getByText('1 oppose')).toBeInTheDocument();
+      expect(screen.getByText('6 total')).toBeInTheDocument();
+    });
+
+    it('should hide participant counts when showParticipants is false', () => {
+      render(<SharedPointCard proposition={baseProposition} showParticipants={false} />);
+      expect(screen.queryByText('5 support')).not.toBeInTheDocument();
+      expect(screen.queryByText('1 oppose')).not.toBeInTheDocument();
+    });
+
+    it('should show neutral participants when present', () => {
+      const propWithNeutral: Proposition = {
+        ...baseProposition,
+        neutralParticipants: ['user7', 'user8'],
+      };
+      render(<SharedPointCard proposition={propWithNeutral} showParticipants />);
+      expect(screen.getByText('2 neutral')).toBeInTheDocument();
+    });
+
+    it('should hide neutral count when no neutral participants', () => {
+      render(<SharedPointCard proposition={baseProposition} showParticipants />);
+      expect(screen.queryByText(/neutral/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Agreement Level Styling', () => {
+    it('should use green styling for high agreement (80%+)', () => {
+      const { container } = render(
+        <SharedPointCard proposition={{ ...baseProposition, agreementPercentage: 85 }} />,
+      );
+      const card = container.firstChild as HTMLElement;
+      expect(card.className).toContain('bg-green-50');
+      expect(card.className).toContain('border-green-500');
+    });
+
+    it('should use blue styling for good agreement (60-79%)', () => {
+      const { container } = render(
+        <SharedPointCard proposition={{ ...baseProposition, agreementPercentage: 70 }} />,
+      );
+      const card = container.firstChild as HTMLElement;
+      expect(card.className).toContain('bg-blue-50');
+      expect(card.className).toContain('border-blue-500');
+    });
+
+    it('should use yellow styling for moderate agreement (40-59%)', () => {
+      const { container } = render(
+        <SharedPointCard proposition={{ ...baseProposition, agreementPercentage: 50 }} />,
+      );
+      const card = container.firstChild as HTMLElement;
+      expect(card.className).toContain('bg-yellow-50');
+      expect(card.className).toContain('border-yellow-500');
+    });
+
+    it('should use gray styling for low agreement (<40%)', () => {
+      const { container } = render(
+        <SharedPointCard proposition={{ ...baseProposition, agreementPercentage: 30 }} />,
+      );
+      const card = container.firstChild as HTMLElement;
+      expect(card.className).toContain('bg-gray-50');
+      expect(card.className).toContain('border-gray-500');
+    });
+  });
+
+  describe('Size Variants', () => {
+    it('should apply small size styles', () => {
+      const { container } = render(<SharedPointCard proposition={baseProposition} size="small" />);
+      const card = container.firstChild as HTMLElement;
+      expect(card.className).toContain('p-3');
+    });
+
+    it('should apply medium size styles (default)', () => {
+      const { container } = render(<SharedPointCard proposition={baseProposition} />);
+      const card = container.firstChild as HTMLElement;
+      expect(card.className).toContain('p-4');
+    });
+
+    it('should apply large size styles', () => {
+      const { container } = render(<SharedPointCard proposition={baseProposition} size="large" />);
+      const card = container.firstChild as HTMLElement;
+      expect(card.className).toContain('p-6');
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('should call onClick when card is clicked', () => {
+      render(<SharedPointCard proposition={baseProposition} onClick={mockOnClick} />);
+      const card = screen.getByRole('button');
+      fireEvent.click(card);
+      expect(mockOnClick).toHaveBeenCalledWith(baseProposition.id);
+    });
+
+    it('should call onClick on Enter key press', () => {
+      render(<SharedPointCard proposition={baseProposition} onClick={mockOnClick} />);
+      const card = screen.getByRole('button');
+      fireEvent.keyPress(card, { key: 'Enter', code: 'Enter' });
+      expect(mockOnClick).toHaveBeenCalledWith(baseProposition.id);
+    });
+
+    it('should call onClick on Space key press', () => {
+      render(<SharedPointCard proposition={baseProposition} onClick={mockOnClick} />);
+      const card = screen.getByRole('button');
+      fireEvent.keyPress(card, { key: ' ', code: 'Space' });
+      expect(mockOnClick).toHaveBeenCalledWith(baseProposition.id);
+    });
+
+    it('should not call onClick on other keys', () => {
+      render(<SharedPointCard proposition={baseProposition} onClick={mockOnClick} />);
+      const card = screen.getByRole('button');
+      fireEvent.keyPress(card, { key: 'a', code: 'KeyA' });
+      expect(mockOnClick).not.toHaveBeenCalled();
+    });
+
+    it('should render as article when onClick is not provided', () => {
+      render(<SharedPointCard proposition={baseProposition} />);
+      expect(screen.getByRole('article')).toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('should add hover styles when clickable', () => {
+      const { container } = render(
+        <SharedPointCard proposition={baseProposition} onClick={mockOnClick} />,
+      );
+      const card = container.firstChild as HTMLElement;
+      expect(card.className).toContain('cursor-pointer');
+      expect(card.className).toContain('hover:shadow-md');
+    });
+
+    it('should not add hover styles when not clickable', () => {
+      const { container } = render(<SharedPointCard proposition={baseProposition} />);
+      const card = container.firstChild as HTMLElement;
+      expect(card.className).not.toContain('cursor-pointer');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have proper aria-label', () => {
+      render(<SharedPointCard proposition={baseProposition} onClick={mockOnClick} />);
+      const card = screen.getByRole('button');
+      expect(card).toHaveAttribute(
+        'aria-label',
+        'Shared point: Climate change is primarily caused by human activity, 85% agreement',
+      );
+    });
+
+    it('should have tabIndex when clickable', () => {
+      render(<SharedPointCard proposition={baseProposition} onClick={mockOnClick} />);
+      const card = screen.getByRole('button');
+      expect(card).toHaveAttribute('tabIndex', '0');
+    });
+
+    it('should not have tabIndex when not clickable', () => {
+      render(<SharedPointCard proposition={baseProposition} />);
+      const card = screen.getByRole('article');
+      expect(card).not.toHaveAttribute('tabIndex');
+    });
+
+    it('should have proper progressbar attributes', () => {
+      render(<SharedPointCard proposition={baseProposition} />);
+      const progressBar = screen.getByRole('progressbar');
+      expect(progressBar).toHaveAttribute('aria-valuenow', '85');
+      expect(progressBar).toHaveAttribute('aria-valuemin', '0');
+      expect(progressBar).toHaveAttribute('aria-valuemax', '100');
+    });
+  });
+
+  describe('Custom className', () => {
+    it('should apply custom className', () => {
+      const { container } = render(
+        <SharedPointCard proposition={baseProposition} className="custom-class" />,
+      );
+      const card = container.firstChild as HTMLElement;
+      expect(card.className).toContain('custom-class');
+    });
+  });
+
+  describe('Supporting count visibility', () => {
+    it('should show total count by default', () => {
+      render(<SharedPointCard proposition={baseProposition} />);
+      expect(screen.getByText('6 total')).toBeInTheDocument();
+    });
+
+    it('should hide total count when showSupportingCount is false', () => {
+      render(<SharedPointCard proposition={baseProposition} showSupportingCount={false} />);
+      expect(screen.queryByText(/total/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/common-ground/SharedPointCard.tsx
+++ b/frontend/src/components/common-ground/SharedPointCard.tsx
@@ -1,0 +1,218 @@
+import type { Proposition } from '../../types/common-ground';
+
+export interface SharedPointCardProps {
+  /**
+   * The shared point (proposition) to display
+   */
+  proposition: Proposition;
+
+  /**
+   * Whether to show participant details
+   */
+  showParticipants?: boolean;
+
+  /**
+   * Optional callback when the card is clicked
+   */
+  onClick?: (propositionId: string) => void;
+
+  /**
+   * Custom className for the container
+   */
+  className?: string;
+
+  /**
+   * Whether to show the agreement percentage badge
+   */
+  showAgreementBadge?: boolean;
+
+  /**
+   * Size variant of the card
+   */
+  size?: 'small' | 'medium' | 'large';
+
+  /**
+   * Whether to show supporting evidence count
+   */
+  showSupportingCount?: boolean;
+}
+
+/**
+ * Get styling based on agreement level
+ */
+const getAgreementStyles = (percentage: number) => {
+  if (percentage >= 80) {
+    return {
+      border: 'border-green-500',
+      bg: 'bg-green-50',
+      badge: 'bg-green-100 text-green-800',
+      text: 'text-green-700',
+    };
+  }
+  if (percentage >= 60) {
+    return {
+      border: 'border-blue-500',
+      bg: 'bg-blue-50',
+      badge: 'bg-blue-100 text-blue-800',
+      text: 'text-blue-700',
+    };
+  }
+  if (percentage >= 40) {
+    return {
+      border: 'border-yellow-500',
+      bg: 'bg-yellow-50',
+      badge: 'bg-yellow-100 text-yellow-800',
+      text: 'text-yellow-700',
+    };
+  }
+  return {
+    border: 'border-gray-500',
+    bg: 'bg-gray-50',
+    badge: 'bg-gray-100 text-gray-800',
+    text: 'text-gray-700',
+  };
+};
+
+/**
+ * Get size-specific styles
+ */
+const getSizeStyles = (size: 'small' | 'medium' | 'large') => {
+  const styles = {
+    small: {
+      container: 'p-3',
+      text: 'text-sm',
+      badge: 'text-xs px-2 py-0.5',
+      participants: 'text-xs',
+    },
+    medium: {
+      container: 'p-4',
+      text: 'text-base',
+      badge: 'text-sm px-2.5 py-1',
+      participants: 'text-sm',
+    },
+    large: {
+      container: 'p-6',
+      text: 'text-lg',
+      badge: 'text-base px-3 py-1.5',
+      participants: 'text-base',
+    },
+  };
+
+  return styles[size];
+};
+
+/**
+ * SharedPointCard - Displays a single shared point/proposition
+ *
+ * This component represents an individual point of agreement in a discussion,
+ * showing the proposition text, agreement level, and participant support.
+ */
+const SharedPointCard = ({
+  proposition,
+  showParticipants = true,
+  onClick,
+  className = '',
+  showAgreementBadge = true,
+  size = 'medium',
+  showSupportingCount = true,
+}: SharedPointCardProps) => {
+  const agreementStyles = getAgreementStyles(proposition.agreementPercentage);
+  const sizeStyles = getSizeStyles(size);
+
+  const totalParticipants =
+    proposition.supportingParticipants.length +
+    proposition.opposingParticipants.length +
+    proposition.neutralParticipants.length;
+
+  const isClickable = !!onClick;
+
+  return (
+    <div
+      className={`
+        ${agreementStyles.bg}
+        ${agreementStyles.border}
+        border-l-4 rounded-lg shadow-sm
+        ${sizeStyles.container}
+        ${isClickable ? 'cursor-pointer hover:shadow-md transition-shadow' : ''}
+        ${className}
+      `}
+      onClick={() => onClick?.(proposition.id)}
+      role={isClickable ? 'button' : 'article'}
+      tabIndex={isClickable ? 0 : undefined}
+      onKeyPress={(e) => {
+        if (isClickable && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onClick?.(proposition.id);
+        }
+      }}
+      aria-label={`Shared point: ${proposition.text}, ${proposition.agreementPercentage}% agreement`}
+    >
+      {/* Header with agreement badge */}
+      <div className="flex items-start justify-between mb-2">
+        <div className="flex-1">
+          <p className={`${sizeStyles.text} text-gray-900 font-medium leading-relaxed`}>
+            {proposition.text}
+          </p>
+        </div>
+        {showAgreementBadge && (
+          <span
+            className={`${agreementStyles.badge} ${sizeStyles.badge} font-semibold rounded ml-3 whitespace-nowrap`}
+          >
+            {proposition.agreementPercentage}%
+          </span>
+        )}
+      </div>
+
+      {/* Agreement bar */}
+      <div className="mt-3 mb-2">
+        <div className="w-full bg-gray-200 rounded-full h-2">
+          <div
+            className={`h-2 rounded-full transition-all duration-500 ${
+              proposition.agreementPercentage >= 80
+                ? 'bg-green-500'
+                : proposition.agreementPercentage >= 60
+                  ? 'bg-blue-500'
+                  : proposition.agreementPercentage >= 40
+                    ? 'bg-yellow-500'
+                    : 'bg-gray-400'
+            }`}
+            style={{ width: `${proposition.agreementPercentage}%` }}
+            role="progressbar"
+            aria-valuenow={proposition.agreementPercentage}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          />
+        </div>
+      </div>
+
+      {/* Participant details */}
+      {showParticipants && (
+        <div className={`mt-3 flex items-center gap-3 ${sizeStyles.participants} text-gray-600`}>
+          <div className="flex items-center gap-1.5">
+            <span className="inline-block w-2.5 h-2.5 rounded-full bg-green-500" />
+            <span>{proposition.supportingParticipants.length} support</span>
+          </div>
+          {proposition.opposingParticipants.length > 0 && (
+            <div className="flex items-center gap-1.5">
+              <span className="inline-block w-2.5 h-2.5 rounded-full bg-red-500" />
+              <span>{proposition.opposingParticipants.length} oppose</span>
+            </div>
+          )}
+          {proposition.neutralParticipants.length > 0 && (
+            <div className="flex items-center gap-1.5">
+              <span className="inline-block w-2.5 h-2.5 rounded-full bg-gray-400" />
+              <span>{proposition.neutralParticipants.length} neutral</span>
+            </div>
+          )}
+          {showSupportingCount && (
+            <div className="ml-auto text-gray-500">
+              {totalParticipants} total
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SharedPointCard;

--- a/frontend/src/components/common-ground/index.ts
+++ b/frontend/src/components/common-ground/index.ts
@@ -6,3 +6,6 @@ export type { AgreementBarChartProps } from './AgreementBarChart';
 
 export { default as AgreementVennDiagram } from './AgreementVennDiagram';
 export type { AgreementVennDiagramProps } from './AgreementVennDiagram';
+
+export { default as SharedPointCard } from './SharedPointCard';
+export type { SharedPointCardProps } from './SharedPointCard';


### PR DESCRIPTION
## Summary
Implements T137 - Create shared point cards for displaying individual points of agreement in common ground analysis.

## Changes Made
- Created `SharedPointCard` component (frontend/src/components/common-ground/SharedPointCard.tsx:1-213)
- Added comprehensive TypeScript types and interfaces
- Implemented agreement level styling with color-coded thresholds:
  - Green (80%+): High agreement
  - Blue (60-79%): Good agreement
  - Yellow (40-59%): Moderate agreement
  - Gray (<40%): Low agreement
- Added size variants (small/medium/large) for flexible layouts
- Implemented participant details display (support/oppose/neutral counts)
- Added interactive click handlers with full keyboard accessibility
- Updated exports in index.ts (frontend/src/components/common-ground/index.ts:10-11)
- Created comprehensive test suite (frontend/frontend/src/__tests__/components/common-ground/SharedPointCard.test.tsx)

## Test Results
- All existing tests passing (135 tests)
- TypeScript compilation successful
- Component follows existing common-ground patterns

## Testing Instructions
```bash
npm run test:unit
npm run typecheck
```

## Breaking Changes
None

Fixes #133

Generated with Claude Code
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>