### PR TITLE
feat: Create bridging suggestions section component (closes #135)

### DIFF
--- a/frontend/src/components/common-ground/BridgingSuggestionsSection.tsx
+++ b/frontend/src/components/common-ground/BridgingSuggestionsSection.tsx
@@ -1,0 +1,315 @@
+import type { BridgingSuggestionsResponse } from '../../types/common-ground';
+
+export interface BridgingSuggestionsSectionProps {
+  /**
+   * The bridging suggestions data to display
+   */
+  suggestions: BridgingSuggestionsResponse;
+
+  /**
+   * Optional callback when user wants to view details of a suggestion
+   */
+  onViewSuggestion?: (propositionId: string) => void;
+
+  /**
+   * Custom className for the container
+   */
+  className?: string;
+
+  /**
+   * Whether to show the AI attribution
+   */
+  showAttribution?: boolean;
+
+  /**
+   * Whether to show empty state when no suggestions
+   */
+  showEmptyState?: boolean;
+
+  /**
+   * Maximum number of suggestions to display (0 = show all)
+   */
+  maxSuggestions?: number;
+}
+
+/**
+ * Get confidence level styling
+ */
+const getConfidenceStyles = (confidence: number) => {
+  if (confidence >= 0.8) {
+    return {
+      badge: 'bg-green-100 text-green-800',
+      text: 'High Confidence',
+    };
+  }
+  if (confidence >= 0.6) {
+    return {
+      badge: 'bg-blue-100 text-blue-800',
+      text: 'Medium Confidence',
+    };
+  }
+  return {
+    badge: 'bg-yellow-100 text-yellow-800',
+    text: 'Lower Confidence',
+  };
+};
+
+/**
+ * BridgingSuggestionsSection - Displays AI-generated bridging suggestions
+ *
+ * This component shows:
+ * - Overall consensus score and analysis
+ * - Common ground areas
+ * - Conflict areas
+ * - Individual bridging suggestions with reasoning
+ * - AI attribution
+ */
+const BridgingSuggestionsSection = ({
+  suggestions,
+  onViewSuggestion,
+  className = '',
+  showAttribution = true,
+  showEmptyState = true,
+  maxSuggestions = 0,
+}: BridgingSuggestionsSectionProps) => {
+  const hasSuggestions = suggestions.suggestions.length > 0;
+  const displayedSuggestions =
+    maxSuggestions > 0
+      ? suggestions.suggestions.slice(0, maxSuggestions)
+      : suggestions.suggestions;
+
+  if (!hasSuggestions && !showEmptyState) {
+    return null;
+  }
+
+  const consensusPercentage = Math.round(suggestions.overallConsensusScore * 100);
+
+  return (
+    <div className={`space-y-6 ${className}`}>
+      {/* Header with Overall Analysis */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+        <h2 className="text-xl font-semibold text-gray-900 mb-4">
+          Bridging Suggestions
+        </h2>
+
+        {/* Overall Consensus Score */}
+        <div className="mb-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-medium text-gray-700">
+              Overall Consensus
+            </span>
+            <span className="text-sm font-semibold text-gray-900">
+              {consensusPercentage}%
+            </span>
+          </div>
+          <div className="w-full bg-gray-200 rounded-full h-3">
+            <div
+              className="bg-blue-600 h-3 rounded-full transition-all duration-300"
+              style={{ width: `${consensusPercentage}%` }}
+              role="progressbar"
+              aria-valuenow={consensusPercentage}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            />
+          </div>
+        </div>
+
+        {/* Analysis Reasoning */}
+        {suggestions.reasoning && (
+          <div className="mt-4 p-3 bg-gray-50 rounded-md">
+            <p className="text-sm text-gray-700 leading-relaxed">
+              {suggestions.reasoning}
+            </p>
+          </div>
+        )}
+
+        {/* Common Ground Areas */}
+        {suggestions.commonGroundAreas.length > 0 && (
+          <div className="mt-4">
+            <h4 className="text-sm font-medium text-gray-700 mb-2">
+              Areas of Agreement
+            </h4>
+            <div className="flex flex-wrap gap-2">
+              {suggestions.commonGroundAreas.map((area, idx) => (
+                <span
+                  key={idx}
+                  className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800"
+                >
+                  {area}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Conflict Areas */}
+        {suggestions.conflictAreas.length > 0 && (
+          <div className="mt-4">
+            <h4 className="text-sm font-medium text-gray-700 mb-2">
+              Areas of Disagreement
+            </h4>
+            <div className="flex flex-wrap gap-2">
+              {suggestions.conflictAreas.map((area, idx) => (
+                <span
+                  key={idx}
+                  className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-orange-100 text-orange-800"
+                >
+                  {area}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Individual Suggestions */}
+      {hasSuggestions && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">
+            Suggested Bridges ({displayedSuggestions.length}
+            {maxSuggestions > 0 && suggestions.suggestions.length > maxSuggestions
+              ? ` of ${suggestions.suggestions.length}`
+              : ''})
+          </h3>
+          <div className="space-y-4">
+            {displayedSuggestions.map((suggestion, idx) => {
+              const confidenceStyles = getConfidenceStyles(suggestion.confidenceScore);
+              return (
+                <div
+                  key={idx}
+                  className="p-4 rounded-lg border-l-4 bg-indigo-50 border-indigo-500"
+                  role="article"
+                  aria-label={`Bridging suggestion from ${suggestion.sourcePosition} to ${suggestion.targetPosition}`}
+                >
+                  {/* Positions */}
+                  <div className="flex items-center gap-2 mb-3">
+                    <span className="inline-block text-xs font-semibold px-2 py-1 rounded bg-indigo-100 text-indigo-800">
+                      {suggestion.sourcePosition}
+                    </span>
+                    <svg
+                      className="w-4 h-4 text-gray-400"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M17 8l4 4m0 0l-4 4m4-4H3"
+                      />
+                    </svg>
+                    <span className="inline-block text-xs font-semibold px-2 py-1 rounded bg-indigo-100 text-indigo-800">
+                      {suggestion.targetPosition}
+                    </span>
+                    <span
+                      className={`ml-auto text-xs font-semibold px-2 py-1 rounded ${confidenceStyles.badge}`}
+                    >
+                      {confidenceStyles.text}
+                    </span>
+                  </div>
+
+                  {/* Bridging Language */}
+                  <div className="mb-3">
+                    <h4 className="text-sm font-medium text-gray-700 mb-1">
+                      Suggested Bridging Language:
+                    </h4>
+                    <p className="text-base text-gray-900 font-medium leading-relaxed">
+                      "{suggestion.bridgingLanguage}"
+                    </p>
+                  </div>
+
+                  {/* Common Ground */}
+                  <div className="mb-3">
+                    <h4 className="text-sm font-medium text-gray-700 mb-1">
+                      Common Ground:
+                    </h4>
+                    <p className="text-sm text-gray-800 leading-relaxed">
+                      {suggestion.commonGround}
+                    </p>
+                  </div>
+
+                  {/* Reasoning */}
+                  <div className="mb-3">
+                    <h4 className="text-sm font-medium text-gray-700 mb-1">
+                      Why This Helps:
+                    </h4>
+                    <p className="text-sm text-gray-800 leading-relaxed">
+                      {suggestion.reasoning}
+                    </p>
+                  </div>
+
+                  {/* Confidence indicator */}
+                  <div className="mt-3 pt-3 border-t border-indigo-200">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-gray-600">
+                        Confidence Score: {Math.round(suggestion.confidenceScore * 100)}%
+                      </span>
+                      {onViewSuggestion && (
+                        <button
+                          type="button"
+                          onClick={() => onViewSuggestion(suggestion.propositionId)}
+                          className="text-sm text-blue-600 hover:text-blue-800 font-medium"
+                        >
+                          View Proposition →
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Show more indicator */}
+          {maxSuggestions > 0 && suggestions.suggestions.length > maxSuggestions && (
+            <div className="mt-4 text-center">
+              <p className="text-sm text-gray-600">
+                Showing {maxSuggestions} of {suggestions.suggestions.length} suggestions
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Empty State */}
+      {!hasSuggestions && showEmptyState && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 text-center">
+          <div className="text-gray-400 mb-3">
+            <svg
+              className="mx-auto h-12 w-12"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M13 10V3L4 14h7v7l9-11h-7z"
+              />
+            </svg>
+          </div>
+          <h3 className="text-lg font-medium text-gray-900 mb-1">
+            No Bridging Suggestions Available
+          </h3>
+          <p className="text-sm text-gray-500">
+            Bridging suggestions will appear here once the discussion has enough
+            diverse viewpoints to analyze.
+          </p>
+        </div>
+      )}
+
+      {/* AI Attribution */}
+      {showAttribution && hasSuggestions && (
+        <div className="text-center">
+          <p className="text-xs text-gray-500">
+            {suggestions.attribution}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BridgingSuggestionsSection;

--- a/frontend/src/components/common-ground/DivergencePointCard.tsx
+++ b/frontend/src/components/common-ground/DivergencePointCard.tsx
@@ -109,7 +109,7 @@ const getViewpointColor = (index: number) => {
     { bg: 'bg-teal-100', border: 'border-teal-400', text: 'text-teal-800' },
     { bg: 'bg-orange-100', border: 'border-orange-400', text: 'text-orange-800' },
   ];
-  return colors[index % colors.length];
+  return colors[index % colors.length]!;
 };
 
 /**

--- a/frontend/src/components/common-ground/index.ts
+++ b/frontend/src/components/common-ground/index.ts
@@ -12,3 +12,6 @@ export type { SharedPointCardProps } from './SharedPointCard';
 
 export { default as DivergencePointCard } from './DivergencePointCard';
 export type { DivergencePointCardProps } from './DivergencePointCard';
+
+export { default as BridgingSuggestionsSection } from './BridgingSuggestionsSection';
+export type { BridgingSuggestionsSectionProps } from './BridgingSuggestionsSection';

--- a/frontend/src/types/common-ground.ts
+++ b/frontend/src/types/common-ground.ts
@@ -174,3 +174,88 @@ export interface DivergencePoint {
    */
   underlyingValues?: string[];
 }
+
+/**
+ * Individual bridging suggestion connecting different perspectives
+ */
+export interface BridgingSuggestion {
+  /**
+   * ID of the proposition being bridged
+   */
+  propositionId: string;
+
+  /**
+   * Source position/stance (e.g., "SUPPORT", "OPPOSE", "NUANCED")
+   */
+  sourcePosition: string;
+
+  /**
+   * Target position/stance to bridge toward
+   */
+  targetPosition: string;
+
+  /**
+   * Suggested language that bridges the perspectives
+   */
+  bridgingLanguage: string;
+
+  /**
+   * Identified area of common ground between positions
+   */
+  commonGround: string;
+
+  /**
+   * Explanation of why this bridging is valuable
+   */
+  reasoning: string;
+
+  /**
+   * Confidence score for this suggestion (0-1)
+   */
+  confidenceScore: number;
+}
+
+/**
+ * Response from bridging suggestions API endpoint
+ */
+export interface BridgingSuggestionsResponse {
+  /**
+   * The topic ID these suggestions are for
+   */
+  topicId: string;
+
+  /**
+   * Array of bridging suggestions
+   */
+  suggestions: BridgingSuggestion[];
+
+  /**
+   * Overall consensus score derived from propositions (0-1)
+   */
+  overallConsensusScore: number;
+
+  /**
+   * Areas where genuine disagreement exists
+   */
+  conflictAreas: string[];
+
+  /**
+   * Areas where agreement/common ground exists
+   */
+  commonGroundAreas: string[];
+
+  /**
+   * Overall confidence score for the analysis (0-1)
+   */
+  confidenceScore: number;
+
+  /**
+   * Reasoning for the overall analysis
+   */
+  reasoning: string;
+
+  /**
+   * AI attribution label
+   */
+  attribution: string;
+}


### PR DESCRIPTION
## Summary
Implements a new BridgingSuggestionsSection component that displays AI-generated bridging suggestions to help participants find common ground between different viewpoints.

## Changes Made
- **Added BridgingSuggestion and BridgingSuggestionsResponse types** to `frontend/src/types/common-ground.ts:178-261`
  - Mirrors backend DTO structure for type safety
  - Includes confidence scores, bridging language, and reasoning fields

- **Created BridgingSuggestionsSection component** in `frontend/src/components/common-ground/BridgingSuggestionsSection.tsx`
  - Overall consensus score with progress bar visualization
  - Analysis reasoning section
  - Common ground areas (green tags)
  - Conflict areas (orange tags)
  - Individual bridging suggestions displaying:
    - Source and target positions with arrow visual
    - Suggested bridging language (quoted)
    - Common ground explanation
    - Reasoning for why the bridge helps
    - Confidence score percentage
  - Empty state with helpful message
  - AI attribution footer
  - Configurable props for callbacks, display options, and max suggestions

- **Exported component** from `frontend/src/components/common-ground/index.ts:16-17`

- **Fixed TypeScript error** in DivergencePointCard (added non-null assertion to getViewpointColor return)

## Test Results
- TypeScript typecheck: ✓ Passed
- Frontend build: ✓ Passed (vite build successful)

## Testing Instructions
```bash
cd frontend
npm run typecheck
npm run build
```

## Breaking Changes
None

Fixes #135

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>