### PR TITLE
feat: integrate common ground panel in topic detail (closes #137)

### DIFF
--- a/frontend/src/lib/useCommonGroundAnalysis.ts
+++ b/frontend/src/lib/useCommonGroundAnalysis.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from './api';
+import type { CommonGroundAnalysis } from '../types/common-ground';
+
+/**
+ * React Query hook for fetching common ground analysis for a topic
+ */
+export function useCommonGroundAnalysis(topicId: string | undefined) {
+  return useQuery({
+    queryKey: ['commonGroundAnalysis', topicId],
+    queryFn: async () => {
+      if (!topicId) {
+        throw new Error('Topic ID is required');
+      }
+      const response = await apiClient.get<CommonGroundAnalysis>(`/topics/${topicId}/common-ground-analysis`);
+      return response;
+    },
+    enabled: !!topicId,
+  });
+}

--- a/frontend/src/pages/Topics/TopicDetailPage.tsx
+++ b/frontend/src/pages/Topics/TopicDetailPage.tsx
@@ -1,11 +1,14 @@
 import { useParams, Link } from 'react-router-dom';
 import { useTopic } from '../../lib/useTopic';
+import { useCommonGroundAnalysis } from '../../lib/useCommonGroundAnalysis';
 import Card, { CardHeader, CardBody } from '../../components/ui/Card';
 import Button from '../../components/ui/Button';
+import { CommonGroundSummaryPanel } from '../../components/common-ground';
 
 function TopicDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { data: topic, isLoading, error } = useTopic(id);
+  const { data: commonGroundAnalysis, isLoading: isLoadingAnalysis } = useCommonGroundAnalysis(id);
 
   if (isLoading) {
     return (
@@ -247,6 +250,29 @@ function TopicDetailPage() {
           </div>
         </CardBody>
       </Card>
+
+      {/* Common Ground Analysis Section */}
+      {!isLoadingAnalysis && commonGroundAnalysis && (
+        <div className="mb-6">
+          <CommonGroundSummaryPanel
+            analysis={commonGroundAnalysis}
+            showLastUpdated={true}
+            showEmptyState={true}
+            onViewAgreementZone={(zoneId) => {
+              console.log('View agreement zone:', zoneId);
+              // Future: Navigate to detailed view or open modal
+            }}
+            onViewMisunderstanding={(misunderstandingId) => {
+              console.log('View misunderstanding:', misunderstandingId);
+              // Future: Navigate to detailed view or open modal
+            }}
+            onViewDisagreement={(disagreementId) => {
+              console.log('View disagreement:', disagreementId);
+              // Future: Navigate to detailed view or open modal
+            }}
+          />
+        </div>
+      )}
 
       {/* Placeholder for future content sections */}
       <div className="grid grid-cols-1 gap-6">


### PR DESCRIPTION
## Summary
Integrated the CommonGroundSummaryPanel component into the TopicDetailPage to display common ground analysis for topics, including agreement zones, misunderstandings, and genuine disagreements.

## Changes Made
- Created `useCommonGroundAnalysis` hook (frontend/src/lib/useCommonGroundAnalysis.ts) for fetching common ground analysis data via React Query
- Updated `TopicDetailPage` component (frontend/src/pages/Topics/TopicDetailPage.tsx) to:
  - Import and use the new hook
  - Integrate CommonGroundSummaryPanel with conditional rendering
  - Add placeholder callback handlers for viewing agreement zones, misunderstandings, and disagreements
- Panel appears between the main topic card and the discussion responses section
- Panel only renders when analysis data is available (graceful handling of loading states)

## Test Results
- TypeScript type checking: ✓ Passed
- Frontend build: ✓ Passed (1.36s)
- All tests passing

## Testing Instructions
```bash
cd frontend
npm run typecheck
npm run build
```

## Breaking Changes
None

Fixes #137

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>