### PR TITLE
feat: Add comprehensive unit tests for common ground services (closes #145)

### DIFF
--- a/services/discussion-service/src/__tests__/common-ground-export.service.test.ts
+++ b/services/discussion-service/src/__tests__/common-ground-export.service.test.ts
@@ -1,0 +1,473 @@
+import { CommonGroundExportService } from '../services/common-ground-export.service.js';
+import type { CommonGroundResponseDto } from '../topics/dto/common-ground-response.dto.js';
+import PDFDocument from 'pdfkit';
+
+describe('CommonGroundExportService', () => {
+  let service: CommonGroundExportService;
+
+  beforeEach(() => {
+    service = new CommonGroundExportService();
+  });
+
+  // Sample test data
+  const createMockAnalysis = (): CommonGroundResponseDto => ({
+    id: 'test-analysis-123',
+    version: 1,
+    overallConsensusScore: 72,
+    participantCountAtGeneration: 50,
+    responseCountAtGeneration: 150,
+    generatedAt: new Date('2026-01-18T10:00:00Z'),
+    agreementZones: [
+      {
+        description: 'Most participants agree that climate change requires urgent action',
+        confidence: 0.85,
+        propositionIds: ['prop-1', 'prop-2', 'prop-3'],
+        participantPercentage: 78,
+      },
+      {
+        description: 'Strong consensus on the need for renewable energy investment',
+        confidence: 0.92,
+        propositionIds: ['prop-4', 'prop-5'],
+        participantPercentage: 85,
+      },
+    ],
+    misunderstandings: [
+      {
+        term: 'socialism',
+        description: 'Different interpretations of economic systems',
+        definitions: [
+          { definition: 'Government ownership of means of production', userCount: 15 },
+          { definition: 'Strong social safety nets', userCount: 10 },
+          { definition: 'Mixed economy with public services', userCount: 8 },
+        ],
+        affectedPropositions: ['prop-10', 'prop-11'],
+      },
+    ],
+    genuineDisagreements: [
+      {
+        description: 'Fundamental split on taxation policy',
+        underlyingValues: ['economic freedom', 'social equality'],
+        moralFoundations: ['fairness', 'liberty'],
+        propositionIds: ['prop-20', 'prop-21'],
+      },
+    ],
+  });
+
+  describe('exportAnalysis', () => {
+    it('should throw error for unsupported format', async () => {
+      const analysis = createMockAnalysis();
+      await expect(
+        service.exportAnalysis(analysis, 'xml' as any),
+      ).rejects.toThrow('Unsupported export format: xml');
+    });
+
+    it('should route to JSON export for json format', async () => {
+      const analysis = createMockAnalysis();
+      const result = await service.exportAnalysis(analysis, 'json');
+
+      expect(result.mimeType).toBe('application/json');
+      expect(result.filename).toBe('common-ground-test-analysis-123.json');
+      expect(typeof result.data).toBe('string');
+    });
+
+    it('should route to Markdown export for markdown format', async () => {
+      const analysis = createMockAnalysis();
+      const result = await service.exportAnalysis(analysis, 'markdown');
+
+      expect(result.mimeType).toBe('text/markdown');
+      expect(result.filename).toBe('common-ground-test-analysis-123.md');
+      expect(typeof result.data).toBe('string');
+    });
+
+    it('should route to PDF export for pdf format', async () => {
+      const analysis = createMockAnalysis();
+      const result = await service.exportAnalysis(analysis, 'pdf');
+
+      expect(result.mimeType).toBe('application/pdf');
+      expect(result.filename).toBe('common-ground-test-analysis-123.pdf');
+      expect(Buffer.isBuffer(result.data)).toBe(true);
+    });
+  });
+
+  describe('exportToJson', () => {
+    it('should export complete analysis to JSON', async () => {
+      const analysis = createMockAnalysis();
+      const result = await service.exportAnalysis(analysis, 'json');
+
+      expect(result.mimeType).toBe('application/json');
+      expect(result.filename).toBe('common-ground-test-analysis-123.json');
+      expect(typeof result.data).toBe('string');
+
+      const parsed = JSON.parse(result.data as string);
+      expect(parsed.id).toBe('test-analysis-123');
+      expect(parsed.version).toBe(1);
+      expect(parsed.overallConsensusScore).toBe(72);
+      expect(parsed.agreementZones).toHaveLength(2);
+      expect(parsed.misunderstandings).toHaveLength(1);
+      expect(parsed.genuineDisagreements).toHaveLength(1);
+    });
+
+    it('should include all agreement zone details', async () => {
+      const analysis = createMockAnalysis();
+      const result = await service.exportAnalysis(analysis, 'json');
+      const parsed = JSON.parse(result.data as string);
+
+      expect(parsed.agreementZones[0]).toEqual({
+        description: 'Most participants agree that climate change requires urgent action',
+        confidence: 0.85,
+        propositionIds: ['prop-1', 'prop-2', 'prop-3'],
+        participantPercentage: 78,
+      });
+    });
+
+    it('should handle analysis with empty sections', async () => {
+      const minimalAnalysis: CommonGroundResponseDto = {
+        id: 'minimal-123',
+        version: 1,
+        overallConsensusScore: 50,
+        participantCountAtGeneration: 10,
+        responseCountAtGeneration: 25,
+        generatedAt: new Date('2026-01-18T10:00:00Z'),
+        agreementZones: [],
+        misunderstandings: [],
+        genuineDisagreements: [],
+      };
+
+      const result = await service.exportAnalysis(minimalAnalysis, 'json');
+      const parsed = JSON.parse(result.data as string);
+
+      expect(parsed.agreementZones).toEqual([]);
+      expect(parsed.misunderstandings).toEqual([]);
+      expect(parsed.genuineDisagreements).toEqual([]);
+    });
+
+    it('should produce valid JSON that can be round-tripped', async () => {
+      const analysis = createMockAnalysis();
+      const result = await service.exportAnalysis(analysis, 'json');
+
+      // Parse and stringify again to verify it's valid JSON
+      const parsed = JSON.parse(result.data as string);
+      const reparsed = JSON.stringify(parsed, null, 2);
+
+      expect(() => JSON.parse(reparsed)).not.toThrow();
+    });
+  });
+
+  describe('exportToMarkdown', () => {
+    it('should export complete analysis to Markdown', async () => {
+      const analysis = createMockAnalysis();
+      const result = await service.exportAnalysis(analysis, 'markdown');
+
+      expect(result.mimeType).toBe('text/markdown');
+      expect(result.filename).toBe('common-ground-test-analysis-123.md');
+      expect(typeof result.data).toBe('string');
+
+      const markdown = result.data as string;
+      expect(markdown).toContain('# Common Ground Analysis');
+      expect(markdown).toContain('**Analysis ID:** test-analysis-123');
+      expect(markdown).toContain('**Version:** 1');
+      expect(markdown).toContain('**Overall Consensus Score:** 72%');
+    });
+
+    it('should include agreement zones section', async () => {
+      const analysis = createMockAnalysis();
+      const result = await service.exportAnalysis(analysis, 'markdown');
+      const markdown = result.data as string;
+
+      expect(markdown).toContain('## Agreement Zones (2)');
+      expect(markdown).toContain('### 1. Agreement Zone');
+      expect(markdown).toContain('Most participants agree that climate change requires urgent action');
+      expect(markdown).toContain('**Participant Coverage:** 78%');
+      expect(markdown).toContain('**Confidence:** 85%');
+      expect(markdown).toContain('**Propositions:** 3 included');
+    });
+
+    it('should include misunderstandings section', async () => {
+      const analysis = createMockAnalysis();
+      const result = await service.exportAnalysis(analysis, 'markdown');
+      const markdown = result.data as string;
+
+      expect(markdown).toContain('## Identified Misunderstandings (1)');
+      expect(markdown).toContain('### 1. Term: "socialism"');
+      expect(markdown).toContain('Different interpretations of economic systems');
+      expect(markdown).toContain('**Different Definitions:**');
+      expect(markdown).toContain('Government ownership of means of production');
+      expect(markdown).toContain('15 users');
+    });
+
+    it('should include genuine disagreements section', async () => {
+      const analysis = createMockAnalysis();
+      const result = await service.exportAnalysis(analysis, 'markdown');
+      const markdown = result.data as string;
+
+      expect(markdown).toContain('## Genuine Disagreements (1)');
+      expect(markdown).toContain('### 1. Disagreement');
+      expect(markdown).toContain('Fundamental split on taxation policy');
+      expect(markdown).toContain('**Underlying Values:**');
+      expect(markdown).toContain('economic freedom');
+      expect(markdown).toContain('social equality');
+      expect(markdown).toContain('**Moral Foundations:** fairness, liberty');
+    });
+
+    it('should handle empty sections gracefully', async () => {
+      const minimalAnalysis: CommonGroundResponseDto = {
+        id: 'minimal-123',
+        version: 1,
+        overallConsensusScore: 50,
+        participantCountAtGeneration: 10,
+        responseCountAtGeneration: 25,
+        generatedAt: new Date('2026-01-18T10:00:00Z'),
+        agreementZones: [],
+        misunderstandings: [],
+        genuineDisagreements: [],
+      };
+
+      const result = await service.exportAnalysis(minimalAnalysis, 'markdown');
+      const markdown = result.data as string;
+
+      expect(markdown).toContain('# Common Ground Analysis');
+      expect(markdown).toContain('**Overall Consensus Score:** 50%');
+      // Should not contain section headers for empty sections
+      expect(markdown).not.toContain('## Agreement Zones');
+      expect(markdown).not.toContain('## Identified Misunderstandings');
+      expect(markdown).not.toContain('## Genuine Disagreements');
+    });
+
+    it('should include footer with attribution', async () => {
+      const analysis = createMockAnalysis();
+      const result = await service.exportAnalysis(analysis, 'markdown');
+      const markdown = result.data as string;
+
+      expect(markdown).toContain('*Generated by Unite Discord Common Ground Analysis*');
+    });
+  });
+
+  describe('exportToPdf', () => {
+    it('should export complete analysis to PDF', async () => {
+      const analysis = createMockAnalysis();
+      const result = await service.exportAnalysis(analysis, 'pdf');
+
+      expect(result.mimeType).toBe('application/pdf');
+      expect(result.filename).toBe('common-ground-test-analysis-123.pdf');
+      expect(Buffer.isBuffer(result.data)).toBe(true);
+      expect((result.data as Buffer).length).toBeGreaterThan(0);
+    });
+
+    it('should generate PDF buffer with correct magic bytes', async () => {
+      const analysis = createMockAnalysis();
+      const result = await service.exportAnalysis(analysis, 'pdf');
+      const buffer = result.data as Buffer;
+
+      // PDF files start with %PDF-
+      const magicBytes = buffer.toString('ascii', 0, 4);
+      expect(magicBytes).toBe('%PDF');
+    });
+
+    it('should handle analysis with empty sections in PDF', async () => {
+      const minimalAnalysis: CommonGroundResponseDto = {
+        id: 'minimal-123',
+        version: 1,
+        overallConsensusScore: 50,
+        participantCountAtGeneration: 10,
+        responseCountAtGeneration: 25,
+        generatedAt: new Date('2026-01-18T10:00:00Z'),
+        agreementZones: [],
+        misunderstandings: [],
+        genuineDisagreements: [],
+      };
+
+      const result = await service.exportAnalysis(minimalAnalysis, 'pdf');
+
+      expect(Buffer.isBuffer(result.data)).toBe(true);
+      expect((result.data as Buffer).length).toBeGreaterThan(0);
+    });
+
+    it('should include metadata in PDF', async () => {
+      const analysis = createMockAnalysis();
+      const result = await service.exportAnalysis(analysis, 'pdf');
+
+      expect(result.filename).toContain('test-analysis-123');
+      expect(Buffer.isBuffer(result.data)).toBe(true);
+    });
+
+    it('should handle multiple agreement zones in PDF', async () => {
+      const analysis = createMockAnalysis();
+      // Already has 2 agreement zones
+      const result = await service.exportAnalysis(analysis, 'pdf');
+
+      expect(Buffer.isBuffer(result.data)).toBe(true);
+      expect((result.data as Buffer).length).toBeGreaterThan(1000); // Should have substantial content
+    });
+
+    it('should handle multiple misunderstandings with multiple definitions', async () => {
+      const analysis: CommonGroundResponseDto = {
+        ...createMockAnalysis(),
+        misunderstandings: [
+          {
+            term: 'freedom',
+            description: 'Multiple interpretations of personal liberty',
+            definitions: [
+              { definition: 'Absence of government interference', userCount: 20 },
+              { definition: 'Equal opportunity for all', userCount: 18 },
+              { definition: 'Right to self-determination', userCount: 12 },
+            ],
+            affectedPropositions: ['prop-30', 'prop-31', 'prop-32'],
+          },
+          {
+            term: 'justice',
+            description: 'Different views on fairness',
+            definitions: [
+              { definition: 'Equal treatment under law', userCount: 25 },
+              { definition: 'Equitable distribution of resources', userCount: 15 },
+            ],
+            affectedPropositions: ['prop-40'],
+          },
+        ],
+      };
+
+      const result = await service.exportAnalysis(analysis, 'pdf');
+
+      expect(Buffer.isBuffer(result.data)).toBe(true);
+      expect((result.data as Buffer).length).toBeGreaterThan(1000);
+    });
+  });
+
+  describe('generateShareLink', () => {
+    it('should generate correct share link with clean base URL', () => {
+      const link = service.generateShareLink('analysis-123', 'https://app.example.com');
+      expect(link).toBe('https://app.example.com/common-ground/analysis-123');
+    });
+
+    it('should remove trailing slash from base URL', () => {
+      const link = service.generateShareLink('analysis-456', 'https://app.example.com/');
+      expect(link).toBe('https://app.example.com/common-ground/analysis-456');
+    });
+
+    it('should handle localhost URLs', () => {
+      const link = service.generateShareLink('local-test', 'http://localhost:3000');
+      expect(link).toBe('http://localhost:3000/common-ground/local-test');
+    });
+
+    it('should handle URLs with port numbers', () => {
+      const link = service.generateShareLink('test-id', 'https://example.com:8080');
+      expect(link).toBe('https://example.com:8080/common-ground/test-id');
+    });
+
+    it('should handle base URL with multiple trailing slashes', () => {
+      const link = service.generateShareLink('test-123', 'https://example.com///');
+      // Implementation removes only one trailing slash, which is acceptable
+      expect(link).toBe('https://example.com///common-ground/test-123');
+    });
+
+    it('should work with analysis IDs containing special characters', () => {
+      const link = service.generateShareLink('test-123-abc_def', 'https://example.com');
+      expect(link).toBe('https://example.com/common-ground/test-123-abc_def');
+    });
+
+    it('should generate different links for different analysis IDs', () => {
+      const link1 = service.generateShareLink('analysis-1', 'https://app.example.com');
+      const link2 = service.generateShareLink('analysis-2', 'https://app.example.com');
+
+      expect(link1).not.toBe(link2);
+      expect(link1).toContain('analysis-1');
+      expect(link2).toContain('analysis-2');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle very long analysis descriptions', async () => {
+      const longDescription = 'A'.repeat(1000);
+      const analysis: CommonGroundResponseDto = {
+        ...createMockAnalysis(),
+        agreementZones: [
+          {
+            description: longDescription,
+            confidence: 0.9,
+            propositionIds: ['prop-1'],
+            participantPercentage: 80,
+          },
+        ],
+      };
+
+      const jsonResult = await service.exportAnalysis(analysis, 'json');
+      expect(jsonResult.data).toContain(longDescription);
+
+      const markdownResult = await service.exportAnalysis(analysis, 'markdown');
+      expect(markdownResult.data).toContain(longDescription);
+
+      const pdfResult = await service.exportAnalysis(analysis, 'pdf');
+      expect(Buffer.isBuffer(pdfResult.data)).toBe(true);
+    });
+
+    it('should handle zero participants', async () => {
+      const analysis: CommonGroundResponseDto = {
+        ...createMockAnalysis(),
+        participantCountAtGeneration: 0,
+        responseCountAtGeneration: 0,
+      };
+
+      const result = await service.exportAnalysis(analysis, 'json');
+      const parsed = JSON.parse(result.data as string);
+      expect(parsed.participantCountAtGeneration).toBe(0);
+    });
+
+    it('should handle single-user definitions in misunderstandings', async () => {
+      const analysis: CommonGroundResponseDto = {
+        ...createMockAnalysis(),
+        misunderstandings: [
+          {
+            term: 'unique',
+            description: 'Only one person has this interpretation',
+            definitions: [{ definition: 'Singular view', userCount: 1 }],
+            affectedPropositions: [],
+          },
+        ],
+      };
+
+      const markdownResult = await service.exportAnalysis(analysis, 'markdown');
+      const markdown = markdownResult.data as string;
+      // Should use singular "user" not "users"
+      expect(markdown).toContain('1 user');
+      expect(markdown).not.toContain('1 users');
+    });
+
+    it('should handle empty proposition IDs arrays', async () => {
+      const analysis: CommonGroundResponseDto = {
+        ...createMockAnalysis(),
+        agreementZones: [
+          {
+            description: 'Zone with no propositions',
+            confidence: 0.5,
+            propositionIds: [],
+            participantPercentage: 50,
+          },
+        ],
+        misunderstandings: [
+          {
+            term: 'test',
+            description: 'No affected propositions',
+            definitions: [],
+            affectedPropositions: [],
+          },
+        ],
+        genuineDisagreements: [
+          {
+            description: 'Disagreement with no propositions',
+            underlyingValues: [],
+            moralFoundations: [],
+            propositionIds: [],
+          },
+        ],
+      };
+
+      const jsonResult = await service.exportAnalysis(analysis, 'json');
+      expect(jsonResult).toBeDefined();
+
+      const markdownResult = await service.exportAnalysis(analysis, 'markdown');
+      expect(markdownResult).toBeDefined();
+
+      const pdfResult = await service.exportAnalysis(analysis, 'pdf');
+      expect(pdfResult).toBeDefined();
+    });
+  });
+});

--- a/services/discussion-service/src/__tests__/common-ground-trigger.service.test.ts
+++ b/services/discussion-service/src/__tests__/common-ground-trigger.service.test.ts
@@ -1,0 +1,373 @@
+import { CommonGroundTriggerService } from '../services/common-ground-trigger.service.js';
+
+describe('CommonGroundTriggerService', () => {
+  let service: CommonGroundTriggerService;
+  let mockPrisma: any;
+  let mockCache: any;
+
+  beforeEach(() => {
+    // Create simple mock objects
+    mockPrisma = {
+      discussionTopic: {
+        findUnique: async (args: any) => null,
+      },
+      commonGroundAnalysis: {
+        findFirst: async (args: any) => null,
+      },
+    };
+
+    mockCache = {
+      del: async (key: string) => undefined,
+      get: async (key: string) => null,
+      set: async (key: string, value: any) => undefined,
+    };
+
+    service = new CommonGroundTriggerService(mockPrisma, mockCache);
+  });
+
+  describe('checkAndTrigger', () => {
+    it('should return false if topic does not exist', async () => {
+      mockPrisma.discussionTopic.findUnique = async () => null;
+
+      const result = await service.checkAndTrigger('non-existent-topic');
+
+      expect(result).toBe(false);
+    });
+
+    it('should not trigger for first analysis with insufficient participation', async () => {
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 5,
+        participantCount: 3,
+      });
+      mockPrisma.commonGroundAnalysis.findFirst = async () => null;
+
+      const result = await service.checkAndTrigger('topic-1');
+
+      expect(result).toBe(false);
+    });
+
+    it('should trigger for first analysis when reaching minimum threshold', async () => {
+      let cacheDeleted = false;
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 10,
+        participantCount: 10,
+      });
+      mockPrisma.commonGroundAnalysis.findFirst = async () => null;
+      mockCache.del = async (key: string) => {
+        cacheDeleted = true;
+        return undefined;
+      };
+
+      const result = await service.checkAndTrigger('topic-1');
+
+      expect(result).toBe(true);
+      expect(cacheDeleted).toBe(true);
+    });
+
+    it('should trigger when response delta threshold is met', async () => {
+      let cacheDeleted = false;
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 50,
+        participantCount: 20,
+      });
+      mockPrisma.commonGroundAnalysis.findFirst = async () => ({
+        responseCountAtGeneration: 40,
+        createdAt: new Date(Date.now() - 1000 * 60 * 60), // 1 hour ago
+      });
+      mockCache.del = async (key: string) => {
+        cacheDeleted = true;
+        return undefined;
+      };
+
+      const result = await service.checkAndTrigger('topic-1');
+
+      expect(result).toBe(true);
+      expect(cacheDeleted).toBe(true);
+    });
+
+    it('should not trigger when response delta is below threshold', async () => {
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 45,
+        participantCount: 20,
+      });
+      mockPrisma.commonGroundAnalysis.findFirst = async () => ({
+        responseCountAtGeneration: 40,
+        createdAt: new Date(Date.now() - 1000 * 60 * 60), // 1 hour ago
+      });
+
+      const result = await service.checkAndTrigger('topic-1');
+
+      expect(result).toBe(false);
+    });
+
+    it('should trigger when time threshold is met (6+ hours)', async () => {
+      const sixHoursAgo = new Date(Date.now() - 6 * 60 * 60 * 1000);
+      let cacheDeleted = false;
+
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 45,
+        participantCount: 20,
+      });
+      mockPrisma.commonGroundAnalysis.findFirst = async () => ({
+        responseCountAtGeneration: 40,
+        createdAt: sixHoursAgo,
+      });
+      mockCache.del = async (key: string) => {
+        cacheDeleted = true;
+        return undefined;
+      };
+
+      const result = await service.checkAndTrigger('topic-1');
+
+      expect(result).toBe(true);
+      expect(cacheDeleted).toBe(true);
+    });
+
+    it('should not trigger when time threshold is not met (less than 6 hours)', async () => {
+      const fiveHoursAgo = new Date(Date.now() - 5 * 60 * 60 * 1000);
+
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 45,
+        participantCount: 20,
+      });
+      mockPrisma.commonGroundAnalysis.findFirst = async () => ({
+        responseCountAtGeneration: 40,
+        createdAt: fiveHoursAgo,
+      });
+
+      const result = await service.checkAndTrigger('topic-1');
+
+      expect(result).toBe(false);
+    });
+
+    it('should trigger when exactly 10 responses have been added', async () => {
+      let cacheDeleted = false;
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 50,
+        participantCount: 20,
+      });
+      mockPrisma.commonGroundAnalysis.findFirst = async () => ({
+        responseCountAtGeneration: 40,
+        createdAt: new Date(Date.now() - 1000 * 60), // 1 minute ago
+      });
+      mockCache.del = async (key: string) => {
+        cacheDeleted = true;
+        return undefined;
+      };
+
+      const result = await service.checkAndTrigger('topic-1');
+
+      expect(result).toBe(true);
+      expect(cacheDeleted).toBe(true);
+    });
+
+    it('should not trigger with 9 new responses (just under threshold)', async () => {
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 49,
+        participantCount: 20,
+      });
+      mockPrisma.commonGroundAnalysis.findFirst = async () => ({
+        responseCountAtGeneration: 40,
+        createdAt: new Date(Date.now() - 1000 * 60), // 1 minute ago
+      });
+
+      const result = await service.checkAndTrigger('topic-1');
+
+      expect(result).toBe(false);
+    });
+
+    it('should handle errors gracefully and return false', async () => {
+      mockPrisma.discussionTopic.findUnique = async () => {
+        throw new Error('Database connection error');
+      };
+
+      const result = await service.checkAndTrigger('topic-1');
+
+      expect(result).toBe(false);
+    });
+
+    it('should require minimum 10 participants and 10 responses for first analysis', async () => {
+      // 9 participants, 10 responses - should not trigger
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 10,
+        participantCount: 9,
+      });
+      mockPrisma.commonGroundAnalysis.findFirst = async () => null;
+
+      let result = await service.checkAndTrigger('topic-1');
+      expect(result).toBe(false);
+
+      // 10 participants, 9 responses - should not trigger
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 9,
+        participantCount: 10,
+      });
+
+      result = await service.checkAndTrigger('topic-1');
+      expect(result).toBe(false);
+
+      // 10 participants, 10 responses - should trigger
+      let cacheDeleted = false;
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 10,
+        participantCount: 10,
+      });
+      mockCache.del = async (key: string) => {
+        cacheDeleted = true;
+        return undefined;
+      };
+
+      result = await service.checkAndTrigger('topic-1');
+      expect(result).toBe(true);
+      expect(cacheDeleted).toBe(true);
+    });
+
+    it('should trigger with large response delta (60 new responses)', async () => {
+      let cacheDeleted = false;
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 100,
+        participantCount: 50,
+      });
+      mockPrisma.commonGroundAnalysis.findFirst = async () => ({
+        responseCountAtGeneration: 40,
+        createdAt: new Date(Date.now() - 1000 * 60),
+      });
+      mockCache.del = async (key: string) => {
+        cacheDeleted = true;
+        return undefined;
+      };
+
+      const result = await service.checkAndTrigger('topic-1');
+
+      expect(result).toBe(true);
+      expect(cacheDeleted).toBe(true);
+    });
+
+    it('should trigger after exactly 6 hours have elapsed', async () => {
+      const exactlySixHoursAgo = new Date(Date.now() - 6 * 60 * 60 * 1000);
+      let cacheDeleted = false;
+
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 40,
+        participantCount: 20,
+      });
+      mockPrisma.commonGroundAnalysis.findFirst = async () => ({
+        responseCountAtGeneration: 40,
+        createdAt: exactlySixHoursAgo,
+      });
+      mockCache.del = async (key: string) => {
+        cacheDeleted = true;
+        return undefined;
+      };
+
+      const result = await service.checkAndTrigger('topic-1');
+
+      expect(result).toBe(true);
+      expect(cacheDeleted).toBe(true);
+    });
+  });
+
+  describe('invalidateCommonGroundCache', () => {
+    it('should delete the correct cache key', async () => {
+      let deletedKey = '';
+      mockCache.del = async (key: string) => {
+        deletedKey = key;
+        return undefined;
+      };
+
+      await service.invalidateCommonGroundCache('topic-123');
+
+      expect(deletedKey).toBe('common-ground:topic:topic-123:latest');
+    });
+
+    it('should invalidate cache for different topic IDs', async () => {
+      const deletedKeys: string[] = [];
+      mockCache.del = async (key: string) => {
+        deletedKeys.push(key);
+        return undefined;
+      };
+
+      await service.invalidateCommonGroundCache('topic-1');
+      await service.invalidateCommonGroundCache('topic-2');
+
+      expect(deletedKeys).toEqual([
+        'common-ground:topic:topic-1:latest',
+        'common-ground:topic:topic-2:latest',
+      ]);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle topic with zero response count', async () => {
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 0,
+        participantCount: 0,
+      });
+      mockPrisma.commonGroundAnalysis.findFirst = async () => null;
+
+      const result = await service.checkAndTrigger('topic-1');
+
+      expect(result).toBe(false);
+    });
+
+    it('should handle topic with very high response count', async () => {
+      let cacheDeleted = false;
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: 'topic-1',
+        responseCount: 1000000,
+        participantCount: 50000,
+      });
+      mockPrisma.commonGroundAnalysis.findFirst = async () => ({
+        responseCountAtGeneration: 999990,
+        createdAt: new Date(Date.now() - 1000 * 60),
+      });
+      mockCache.del = async (key: string) => {
+        cacheDeleted = true;
+        return undefined;
+      };
+
+      const result = await service.checkAndTrigger('topic-1');
+
+      expect(result).toBe(true);
+      expect(cacheDeleted).toBe(true);
+    });
+
+    it('should handle topic ID with special characters', async () => {
+      const specialTopicId = 'topic-123_abc-def';
+      let deletedKey = '';
+
+      mockPrisma.discussionTopic.findUnique = async () => ({
+        id: specialTopicId,
+        responseCount: 50,
+        participantCount: 20,
+      });
+      mockPrisma.commonGroundAnalysis.findFirst = async () => ({
+        responseCountAtGeneration: 40,
+        createdAt: new Date(Date.now() - 1000 * 60),
+      });
+      mockCache.del = async (key: string) => {
+        deletedKey = key;
+        return undefined;
+      };
+
+      const result = await service.checkAndTrigger(specialTopicId);
+
+      expect(result).toBe(true);
+      expect(deletedKey).toBe(`common-ground:topic:${specialTopicId}:latest`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added comprehensive unit tests for CommonGroundExportService (services/discussion-service/src/__tests__/common-ground-export.service.test.ts)
- Added comprehensive unit tests for CommonGroundTriggerService (services/discussion-service/src/__tests__/common-ground-trigger.service.test.ts)

## Test Coverage

### CommonGroundExportService (31 tests)
- Export to all supported formats (PDF, JSON, Markdown)
- Share link generation with various URL formats
- Edge cases: empty sections, long descriptions, zero participants, special characters

### CommonGroundTriggerService (18 tests)
- Trigger threshold conditions (10+ response delta, 6+ hours elapsed)
- First analysis minimum requirements (10 participants, 10 responses)
- Cache invalidation
- Error handling and edge cases

## Test Results
All 49 tests passing
```
Test Suites: 2 passed, 2 total
Tests:       49 passed, 49 total
```

## Notes
- Tests use simple mock objects following existing patterns in the codebase
- No external dependencies or test database required
- Tests verify business logic and edge cases comprehensively

🤖 Generated with [Claude Code](https://claude.com/claude-code)