### PR TITLE
feat: Implement moderation queue management (closes #178)

### DIFF
--- a/services/moderation-service/src/health/health.controller.ts
+++ b/services/moderation-service/src/health/health.controller.ts
@@ -1,13 +1,40 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Inject } from '@nestjs/common';
+import { QueueService } from '../queue/queue.service.js';
 
 @Controller('health')
 export class HealthController {
+  constructor(
+    @Inject(QueueService) private readonly queueService?: QueueService,
+  ) {}
+
   @Get()
   check() {
     return {
       status: 'ok',
       timestamp: new Date().toISOString(),
       service: 'moderation-service',
+      queue: this.queueService?.getHealthStatus() || { enabled: false },
+    };
+  }
+
+  @Get('queue')
+  checkQueue() {
+    if (!this.queueService) {
+      return { status: 'disabled', message: 'Queue service not available' };
+    }
+
+    const config = this.queueService.getConfig();
+    const health = this.queueService.getHealthStatus();
+
+    return {
+      status: config.enabled ? 'ready' : 'disabled',
+      timestamp: new Date().toISOString(),
+      health,
+      config: {
+        awsRegion: config.awsRegion,
+        serviceName: config.serviceName,
+        enabled: config.enabled,
+      },
     };
   }
 }

--- a/services/moderation-service/src/health/health.module.ts
+++ b/services/moderation-service/src/health/health.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { HealthController } from './health.controller.js';
+import { QueueModule } from '../queue/queue.module.js';
 
 @Module({
+  imports: [QueueModule],
   controllers: [HealthController],
 })
 export class HealthModule {}

--- a/services/moderation-service/src/queue/queue.config.ts
+++ b/services/moderation-service/src/queue/queue.config.ts
@@ -1,0 +1,81 @@
+/**
+ * Queue configuration for moderation service
+ * Provides environment-based configuration for AWS SNS/SQS integration
+ */
+
+export interface QueueConfig {
+  /** AWS region for SNS/SQS */
+  awsRegion: string;
+
+  /** SNS topic ARN for publishing moderation events */
+  snsTopicArn: string;
+
+  /** SQS queue URL for consuming moderation events */
+  sqsQueueUrl: string;
+
+  /** SQS DLQ URL for handling failed messages */
+  dlqUrl: string;
+
+  /** Maximum messages to receive per poll */
+  maxMessages: number;
+
+  /** SQS long polling wait time in seconds */
+  waitTimeSeconds: number;
+
+  /** Message visibility timeout in seconds */
+  visibilityTimeout: number;
+
+  /** Whether to enable queue processing */
+  enabled: boolean;
+
+  /** Service name for event metadata */
+  serviceName: string;
+}
+
+/**
+ * Load queue configuration from environment variables
+ */
+export function loadQueueConfig(): QueueConfig {
+  return {
+    awsRegion: process.env['AWS_REGION'] || 'us-east-1',
+    snsTopicArn: process.env['MODERATION_SNS_TOPIC_ARN'] || '',
+    sqsQueueUrl: process.env['MODERATION_QUEUE_URL'] || '',
+    dlqUrl: process.env['MODERATION_DLQ_URL'] || '',
+    maxMessages: parseInt(process.env['QUEUE_MAX_MESSAGES'] || '10', 10),
+    waitTimeSeconds: parseInt(process.env['QUEUE_WAIT_TIME_SECONDS'] || '20', 10),
+    visibilityTimeout: parseInt(process.env['QUEUE_VISIBILITY_TIMEOUT'] || '120', 10),
+    enabled: process.env['QUEUE_ENABLED'] === 'true',
+    serviceName: 'moderation-service',
+  };
+}
+
+/**
+ * Validate queue configuration
+ */
+export function validateQueueConfig(config: QueueConfig): void {
+  if (!config.enabled) {
+    return;
+  }
+
+  const errors: string[] = [];
+
+  if (!config.awsRegion) {
+    errors.push('AWS_REGION is required');
+  }
+
+  if (!config.snsTopicArn) {
+    errors.push('MODERATION_SNS_TOPIC_ARN is required');
+  }
+
+  if (!config.sqsQueueUrl) {
+    errors.push('MODERATION_QUEUE_URL is required');
+  }
+
+  if (!config.dlqUrl) {
+    errors.push('MODERATION_DLQ_URL is required');
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Queue configuration errors:\n${errors.join('\n')}`);
+  }
+}

--- a/services/moderation-service/src/queue/queue.module.ts
+++ b/services/moderation-service/src/queue/queue.module.ts
@@ -1,0 +1,58 @@
+/**
+ * NestJS module for queue management in moderation service
+ */
+
+import { Module } from '@nestjs/common';
+import { type OnModuleInit, type OnModuleDestroy } from '@nestjs/common';
+import { QueueService } from './queue.service.js';
+import { loadQueueConfig, validateQueueConfig } from './queue.config.js';
+import type { QueueConfig } from './queue.config.js';
+
+@Module({
+  providers: [
+    {
+      provide: 'QueueConfig',
+      useFactory: () => {
+        const config = loadQueueConfig();
+        validateQueueConfig(config);
+        return config;
+      },
+    },
+    {
+      provide: QueueService,
+      useFactory: (config: QueueConfig) => new QueueService(config),
+      inject: ['QueueConfig'],
+    },
+  ],
+  exports: [QueueService, 'QueueConfig'],
+})
+export class QueueModule implements OnModuleInit, OnModuleDestroy {
+  constructor(private readonly queueService: QueueService) {}
+
+  /**
+   * Initialize queue service and start consuming events on module init
+   */
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.queueService.initialize();
+      await this.queueService.startConsuming();
+    } catch (error) {
+      console.error('Failed to initialize QueueModule', error);
+      // Don't throw here - allow the service to start without queue if disabled
+      if (this.queueService.getConfig().enabled) {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Stop consuming events on module destroy
+   */
+  async onModuleDestroy(): Promise<void> {
+    try {
+      await this.queueService.stopConsuming();
+    } catch (error) {
+      console.error('Error stopping QueueModule', error);
+    }
+  }
+}

--- a/services/moderation-service/src/queue/queue.service.ts
+++ b/services/moderation-service/src/queue/queue.service.ts
@@ -1,0 +1,155 @@
+/**
+ * Queue service for managing event publishing and subscription
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { SnsEventPublisher } from '@unite-discord/common';
+import { SqsEventSubscriber } from '@unite-discord/common';
+import { DeadLetterQueueHandler } from '@unite-discord/common';
+import type { BaseEvent } from '@unite-discord/event-schemas';
+import type { EventHandler } from '@unite-discord/common';
+import type { QueueConfig } from './queue.config.js';
+
+@Injectable()
+export class QueueService {
+  private readonly logger = new Logger(QueueService.name);
+  private publisher: SnsEventPublisher | null = null;
+  private subscriber: SqsEventSubscriber | null = null;
+  private dlqHandler: DeadLetterQueueHandler | null = null;
+
+  constructor(private readonly config: QueueConfig) {}
+
+  /**
+   * Initialize the queue service
+   */
+  async initialize(): Promise<void> {
+    if (!this.config.enabled) {
+      this.logger.warn('Queue service is disabled');
+      return;
+    }
+
+    try {
+      // Initialize event publisher
+      this.publisher = new SnsEventPublisher({
+        topicArn: this.config.snsTopicArn,
+        region: this.config.awsRegion,
+        serviceName: this.config.serviceName,
+      });
+
+      this.logger.log(`Event publisher initialized for topic: ${this.config.snsTopicArn}`);
+
+      // Initialize event subscriber
+      this.subscriber = new SqsEventSubscriber({
+        queueUrl: this.config.sqsQueueUrl,
+        region: this.config.awsRegion,
+        serviceName: this.config.serviceName,
+        maxMessages: this.config.maxMessages,
+        waitTimeSeconds: this.config.waitTimeSeconds,
+        visibilityTimeout: this.config.visibilityTimeout,
+      });
+
+      this.logger.log(`Event subscriber initialized for queue: ${this.config.sqsQueueUrl}`);
+
+      // Initialize DLQ handler
+      this.dlqHandler = new DeadLetterQueueHandler({
+        dlqUrl: this.config.dlqUrl,
+        region: this.config.awsRegion,
+        serviceName: this.config.serviceName,
+      });
+
+      this.logger.log(`DLQ handler initialized for queue: ${this.config.dlqUrl}`);
+    } catch (error) {
+      this.logger.error('Failed to initialize queue service', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Publish an event to SNS topic
+   */
+  async publishEvent<TEvent extends BaseEvent>(event: TEvent): Promise<string> {
+    if (!this.publisher) {
+      this.logger.warn('Publisher not initialized, skipping event publication');
+      return '';
+    }
+
+    try {
+      const result = await this.publisher.publish(event);
+      this.logger.debug(`Event published: ${event.type} (messageId: ${result.messageId})`);
+      return result.messageId;
+    } catch (error) {
+      this.logger.error(`Failed to publish event: ${event.type}`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Register an event handler for a specific event type
+   */
+  registerEventHandler<TEvent extends BaseEvent>(
+    eventType: string,
+    handler: EventHandler<TEvent>,
+  ): void {
+    if (!this.subscriber) {
+      this.logger.warn('Subscriber not initialized, cannot register handler');
+      return;
+    }
+
+    this.subscriber.on(eventType, handler);
+    this.logger.debug(`Event handler registered for: ${eventType}`);
+  }
+
+  /**
+   * Start consuming events from the queue
+   */
+  async startConsuming(): Promise<void> {
+    if (!this.subscriber) {
+      this.logger.warn('Subscriber not initialized, cannot start consuming');
+      return;
+    }
+
+    try {
+      await this.subscriber.start();
+      this.logger.log('Started consuming events from moderation queue');
+    } catch (error) {
+      this.logger.error('Failed to start event subscriber', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Stop consuming events from the queue
+   */
+  async stopConsuming(): Promise<void> {
+    if (!this.subscriber) {
+      return;
+    }
+
+    try {
+      await this.subscriber.stop();
+      this.logger.log('Stopped consuming events from moderation queue');
+    } catch (error) {
+      this.logger.error('Failed to stop event subscriber', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get queue health status
+   */
+  getHealthStatus(): Record<string, boolean> {
+    return {
+      publisherReady: this.publisher !== null,
+      subscriberReady: this.subscriber !== null,
+      dlqHandlerReady: this.dlqHandler !== null,
+      enabled: this.config.enabled,
+    };
+  }
+
+  /**
+   * Get queue configuration
+   */
+  getConfig(): QueueConfig {
+    return this.config;
+  }
+}

--- a/services/moderation-service/src/services/__tests__/ai-review.service.spec.ts
+++ b/services/moderation-service/src/services/__tests__/ai-review.service.spec.ts
@@ -10,12 +10,12 @@ import { AIReviewService } from '../ai-review.service.js';
 describe('AIReviewService', () => {
   describe('Service Instantiation', () => {
     it('should be instantiable', () => {
-      const service = new AIReviewService(null as any, null as any);
+      const service = new AIReviewService(null as any, null as any, null as any);
       expect(service).toBeInstanceOf(AIReviewService);
     });
 
     it('should have all required methods', () => {
-      const service = new AIReviewService(null as any, null as any);
+      const service = new AIReviewService(null as any, null as any, null as any);
 
       const methods = [
         'submitAiRecommendation',

--- a/services/moderation-service/src/services/moderation.module.ts
+++ b/services/moderation-service/src/services/moderation.module.ts
@@ -3,9 +3,10 @@ import { ContentScreeningService } from './content-screening.service.js';
 import { AIReviewService } from './ai-review.service.js';
 import { ModerationActionsService } from './moderation-actions.service.js';
 import { PrismaModule } from '../prisma/prisma.module.js';
+import { QueueModule } from '../queue/queue.module.js';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, QueueModule],
   providers: [ContentScreeningService, AIReviewService, ModerationActionsService],
   exports: [ContentScreeningService, AIReviewService, ModerationActionsService],
 })


### PR DESCRIPTION
## Summary
Implemented queue-based asynchronous processing for moderation service with event publishing and subscription capabilities. This enables other services to consume moderation events and react to moderation actions in real-time.

## Changes Made
- **Queue Configuration** (services/moderation-service/src/queue/queue.config.ts:1-73): Environment-based AWS SNS/SQS configuration loader with validation
- **Queue Service** (services/moderation-service/src/queue/queue.service.ts:1-141): Wrapper service managing event publisher, subscriber, and DLQ handler lifecycle
- **Queue Module** (services/moderation-service/src/queue/queue.module.ts:1-45): NestJS module with automatic initialization and graceful shutdown
- **Event Publishing** (services/moderation-service/src/services/ai-review.service.ts:73-100, moderation-actions.service.ts:160-186): Updated AIReviewService and ModerationActionsService to publish ModerationActionRequestedEvent to SNS
- **Health Monitoring** (services/moderation-service/src/health/health.controller.ts:1-40): Extended health check with /health/queue endpoint showing queue status and configuration
- **Module Integration** (services/moderation-service/src/services/moderation.module.ts:1-13, health/health.module.ts:1-10): Integrated QueueModule into moderation and health modules

## Features Implemented
- SNS-based event publishing for moderation actions
- SQS-based event consumption from moderation queue
- Dead Letter Queue handling for failed messages
- Event enrichment with source service and user metadata
- Graceful initialization and shutdown handling
- Health check endpoints for queue status monitoring
- Environment-based configuration with validation

## Test Results
- Moderation service builds without errors
- All unit test fixtures pass
- AI service test failure is pre-existing (unrelated to changes)
- No regression detected in other services

## Environment Variables Required
```
QUEUE_ENABLED=true
AWS_REGION=us-east-1
MODERATION_SNS_TOPIC_ARN=arn:aws:sns:us-east-1:123456789012:moderation-events
MODERATION_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/moderation-queue
MODERATION_DLQ_URL=https://sqs.us-east-1.amazonaws.com/123456789012/moderation-queue-dlq
QUEUE_MAX_MESSAGES=10
QUEUE_WAIT_TIME_SECONDS=20
QUEUE_VISIBILITY_TIMEOUT=120
```

## Testing Instructions
```bash
# Build moderation service
cd services/moderation-service && pnpm build

# Run moderation service tests
pnpm test

# Check health endpoints
curl http://localhost:3004/health
curl http://localhost:3004/health/queue
```

## Breaking Changes
None - queue functionality is optional and disabled by default (requires QUEUE_ENABLED=true)

Fixes #178

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>