### PR TITLE
fix(ci): Add build dependencies stage to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,18 @@ pipeline {
             }
         }
 
+        stage('Build Dependencies') {
+            steps {
+                sh '''
+                    # Build shared packages (required before tests can import them)
+                    pnpm -r --filter="@unite-discord/*" build
+
+                    # Generate Prisma client (required for database-dependent tests)
+                    pnpm --filter="@unite-discord/db-models" exec prisma generate
+                '''
+            }
+        }
+
         stage('Lint & Type Check') {
             parallel {
                 stage('Lint') {


### PR DESCRIPTION
## Summary
- Added new 'Build Dependencies' stage to Jenkinsfile that runs after Setup
- This stage builds shared packages and generates Prisma client before tests run

## Problem
The CI pipeline was failing with these errors:
- `Failed to load url @prisma/client/runtime/library.js` - Prisma client not generated
- `Failed to load url @unite-discord/common` - Shared packages not built

## Solution
Added a new stage between Setup and Lint & Type Check that:
1. Builds all shared packages: `pnpm -r --filter="@unite-discord/*" build`
2. Generates Prisma client: `pnpm --filter="@unite-discord/db-models" exec prisma generate`

## Test plan
- [x] Verified locally that shared packages build correctly
- [ ] CI pipeline should now pass with proper build order

🤖 Generated with [Claude Code](https://claude.com/claude-code)