### PR TITLE
fix(ci): Add redirect support to Jenkins trigger workflow

### DIFF
--- a/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/jenkins-trigger.yml
@@ -40,8 +40,11 @@ jobs:
 
           echo "Triggering Jenkins build for: $BUILD_CAUSE"
 
-          # Trigger Jenkins build with parameters
-          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+          # Normalize Jenkins URL (remove trailing slash if present)
+          JENKINS_URL="${JENKINS_URL%/}"
+
+          # Trigger Jenkins build with parameters (using -L to follow redirects)
+          RESPONSE=$(curl -sL -w "\n%{http_code}" -X POST \
             "${JENKINS_URL}/job/uniteDiscord-ci/buildWithParameters" \
             --user "${JENKINS_USER}:${JENKINS_TOKEN}" \
             --data-urlencode "BRANCH=${BRANCH}" \


### PR DESCRIPTION
## Summary
Fixed the Jenkins trigger workflow which was failing with HTTP 301 redirects.

## Changes
- Added `-L` flag to curl to follow redirects
- Added URL normalization to remove trailing slashes

## Problem
The workflow log showed:
```
##[warning]Failed to trigger Jenkins build (HTTP 301)
Response: <html>
<head><title>301 Moved Permanently</title></head>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)