### PR TITLE
fix(ci): Install detect-secrets dependency for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Install detect-secrets
+        run: |
+          pip install detect-secrets
+          pipx install detect-secrets || pip install --upgrade detect-secrets
+
       - name: Secrets Scan
         run: bash .husky/pre-commit-secrets-scan
         continue-on-error: false


### PR DESCRIPTION
Fixes missing detect-secrets tool in CI workflow that was causing secrets scan stage to fail.