### PR TITLE
fix: Update pnpm-lock.yaml to match package.json dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,18 @@ importers:
         specifier: 5.7.3
         version: 5.7.3
 
+  packages/shared:
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.12
+        version: 20.17.12
+      typescript:
+        specifier: 5.7.3
+        version: 5.7.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@20.17.12)(@vitest/ui@2.1.9)
+
   packages/testing-utils:
     dependencies:
       '@types/jest':


### PR DESCRIPTION
Resolves CI failure due to outdated pnpm-lock.yaml after merging multiple branches.