### PR TITLE
fix(build): Exclude test files from TypeScript compilation

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -24,5 +24,6 @@
     "allowSyntheticDefaultImports": true
   },
   "include": ["src"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.spec.tsx", "src/**/*.test.ts", "src/**/*.test.tsx"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/services/ai-service/tsconfig.json
+++ b/services/ai-service/tsconfig.json
@@ -9,5 +9,5 @@
     "types": ["jest", "node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/services/api-gateway/tsconfig.json
+++ b/services/api-gateway/tsconfig.json
@@ -8,5 +8,5 @@
     "experimentalDecorators": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/services/discussion-service/tsconfig.json
+++ b/services/discussion-service/tsconfig.json
@@ -8,5 +8,5 @@
     "experimentalDecorators": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/services/fact-check-service/tsconfig.json
+++ b/services/fact-check-service/tsconfig.json
@@ -8,5 +8,5 @@
     "experimentalDecorators": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/services/moderation-service/tsconfig.json
+++ b/services/moderation-service/tsconfig.json
@@ -8,5 +8,5 @@
     "experimentalDecorators": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/services/notification-service/tsconfig.json
+++ b/services/notification-service/tsconfig.json
@@ -8,5 +8,5 @@
     "experimentalDecorators": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/services/recommendation-service/tsconfig.json
+++ b/services/recommendation-service/tsconfig.json
@@ -8,5 +8,5 @@
     "experimentalDecorators": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/services/user-service/tsconfig.json
+++ b/services/user-service/tsconfig.json
@@ -8,5 +8,5 @@
     "experimentalDecorators": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
Fixes TypeScript build errors caused by test files being included in compilation. Test files use testing-library dependencies not available during build.