### PR TITLE
fix(ci): Remove publishHTML calls due to missing Jenkins plugin

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -106,14 +106,6 @@ pipeline {
             post {
                 always {
                     junit allowEmptyResults: true, testResults: 'coverage/junit.xml'
-                    publishHTML(target: [
-                        allowMissing: true,
-                        alwaysLinkToLastBuild: true,
-                        keepAll: true,
-                        reportDir: 'coverage',
-                        reportFiles: 'index.html',
-                        reportName: 'Unit Test Coverage'
-                    ])
                 }
             }
         }
@@ -176,14 +168,6 @@ pipeline {
             post {
                 always {
                     sh 'docker-compose down -v || true'
-                    publishHTML(target: [
-                        allowMissing: true,
-                        alwaysLinkToLastBuild: true,
-                        keepAll: true,
-                        reportDir: 'frontend/playwright-report',
-                        reportFiles: 'index.html',
-                        reportName: 'Playwright E2E Report'
-                    ])
                 }
             }
         }


### PR DESCRIPTION
The HTML Publisher plugin is not available on this Jenkins instance, causing NoSuchMethodError failures in the build.

## Changes
- Removed publishHTML() calls from Unit Tests post section  
- Removed publishHTML() calls from E2E Tests post section

## Why
These Jenkins-specific HTML publishing steps were failing because the required plugin is not installed. The test reports are still generated and available:
- JUnit reports published via junit step  
- Coverage reports generated by vitest in ./coverage directory
- Playwright reports in ./frontend/playwright-report  
- Allure reports published separately in the post section

This fix allows the Jenkins builds to complete successfully.