### PR TITLE
fix(ci): Remove Allure reporting configuration to fix test runner failures

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -180,67 +180,11 @@ pipeline {
     }
 
     post {
-        always {
-            // Publish Allure reports from all test suites
-            script {
-                def allureResults = []
-
-                // Check for unit test results
-                if (fileExists('allure-results') && sh(script: 'test -n "$(ls -A allure-results 2>/dev/null)"', returnStatus: true) == 0) {
-                    allureResults.add([path: 'allure-results'])
-                    echo 'Unit test Allure results found'
-                }
-
-                // Check for integration test results
-                if (fileExists('allure-results/integration') && sh(script: 'test -n "$(ls -A allure-results/integration 2>/dev/null)"', returnStatus: true) == 0) {
-                    echo 'Integration test Allure results found'
-                }
-
-                // Check for contract test results
-                if (fileExists('allure-results/contract') && sh(script: 'test -n "$(ls -A allure-results/contract 2>/dev/null)"', returnStatus: true) == 0) {
-                    echo 'Contract test Allure results found'
-                }
-
-                // Check for e2e test results
-                if (fileExists('allure-results/e2e') && sh(script: 'test -n "$(ls -A allure-results/e2e 2>/dev/null)"', returnStatus: true) == 0) {
-                    echo 'E2E test Allure results found'
-                }
-
-                // Publish all results together
-                if (allureResults.size() > 0) {
-                    allure([
-                        includeProperties: false,
-                        jdk: '',
-                        results: allureResults
-                    ])
-                    echo "Allure report published successfully with ${allureResults.size()} result(s)"
-                } else {
-                    echo 'No Allure results found to publish'
-                }
-            }
-        }
         success {
             echo 'Build succeeded!'
         }
         failure {
-            echo 'Build failed! Analyzing failures and creating GitHub issues...'
-            script {
-                // Analyze Allure failures and create automated GitHub issues
-                if (fileExists('allure-results') && sh(script: 'test -n "$(ls -A allure-results 2>/dev/null)"', returnStatus: true) == 0) {
-                    echo 'Found Allure results, analyzing test failures...'
-                    try {
-                        analyzeAllureFailures(
-                            allureResultsDir: 'allure-results',
-                            maxIssues: 10,
-                            testType: 'Test'
-                        )
-                    } catch (Exception e) {
-                        echo "WARNING: Could not analyze Allure failures: ${e.message}"
-                    }
-                } else {
-                    echo 'No Allure results found for analysis'
-                }
-            }
+            echo 'Build failed!'
         }
     }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [['html', { outputFolder: 'playwright-report' }], ['list'], ['allure-playwright']],
+  reporter: [['html', { outputFolder: 'playwright-report' }], ['list']],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -54,7 +54,7 @@ export default defineConfig({
         statements: 80,
       },
     },
-    reporters: ['default', 'junit', 'allure'],
+    reporters: ['default', 'junit'],
     outputFile: {
       junit: './coverage/junit.xml',
     },

--- a/vitest.contract.config.ts
+++ b/vitest.contract.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     ],
     exclude: ['**/node_modules/**', '**/dist/**'],
     testTimeout: 15000,
-    reporters: ['default', 'junit', 'allure'],
+    reporters: ['default', 'junit'],
     outputFile: {
       junit: './coverage/contract-junit.xml',
     },

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
         singleFork: true,
       },
     },
-    reporters: ['default', 'junit', 'allure'],
+    reporters: ['default', 'junit'],
     outputFile: {
       junit: './coverage/integration-junit.xml',
     },


### PR DESCRIPTION
Removes problematic Allure reporter configurations that were causing vitest and Playwright to fail.

## Changes
- Removed 'allure' reporter from vitest.config.ts (unit tests)
- Removed 'allure' reporter from vitest.integration.config.ts (integration tests)
- Removed 'allure' reporter from vitest.contract.config.ts (contract tests)
- Removed 'allure-playwright' reporter from frontend/playwright.config.ts (e2e tests)
- Simplified Jenkins pipeline post section to remove Allure-specific checks

## Why
The Allure reporter configuration was causing 'Failed to load custom Reporter from allure' errors in vitest, preventing tests from running. Allure reporting requires additional setup and dependencies that are not properly configured.

## What Works Now
- Tests run successfully with JUnit reporting
- JUnit reports are published in Jenkins
- Test results are visible in Jenkins and GitHub CI status

Allure reporting can be re-enabled in the future with proper configuration and dependencies.