### PR TITLE
fix(ci): Filter to only trigger on push events

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -10,7 +10,7 @@
  * Webhook Setup:
  *   URL: https://jenkins.kindash.com/generic-webhook-trigger/invoke?token=uniteDiscord-ci
  *   Content type: application/json
- *   Events: Push events, Pull request events
+ *   Events: Push events only (pull_request events are filtered out to prevent duplicates)
  */
 
 @Library('unitediscord-lib@main') _
@@ -44,8 +44,10 @@ pipeline {
             printContributedVariables: true,
             printPostContent: false,
             silentResponse: false,
-            regexpFilterText: '$repository_name',
-            regexpFilterExpression: '^uniteDiscord$'
+            // Filter to only trigger on push events (which have ref), not pull_request events
+            // This prevents duplicate builds when PR is merged (which sends both events)
+            regexpFilterText: '$ref',
+            regexpFilterExpression: 'refs/heads/.*'
         )
     }
 


### PR DESCRIPTION
## Summary
- Filters Generic Webhook Trigger to only trigger on push events (not pull_request events)
- When a PR is merged, GitHub sends both events, causing duplicate builds where the second (pull_request) would abort the first and lack proper commit data

## Problem
When a PR was merged, both push and pull_request webhook events were triggering builds. With `disableConcurrentBuilds(abortPrevious: true)`, the pull_request build would abort the push build. The pull_request event lacks `$.ref` and `$.after`, causing STATUS_COMMIT_SHA to be empty.

## Solution
Filter on `$ref` matching `refs/heads/.*` which only matches push events, ensuring we always have the correct commit SHA.

## Test Results
- Build #569 successfully extracted variables:
  - `ref = refs/heads/fix/ci-filter-push-events`
  - `after = 742824f...`
- Status correctly reported to commit 742824f on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)