### PR TITLE
ci: add auto-merge workflow for PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,20 @@
+name: Auto-merge PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to automatically enable auto-merge on all PRs
- PRs will merge automatically when CI passes (no manual merge required)
- Uses squash merge strategy

## How it works
When a PR is opened/reopened/synchronized, the workflow enables auto-merge.
Once all required status checks pass, GitHub automatically merges the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)