### PR TITLE
ci: Fix Integration Tests condition - remove problematic when clause

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,23 +113,20 @@ pipeline {
         }
 
         stage('Integration Tests') {
-            when {
-                expression {
-                    return env.BRANCH_NAME == 'main' ||
-                           env.BRANCH_NAME == 'develop' ||
-                           env.BRANCH_NAME =~ /^continuous-claude\// ||
-                           env.CHANGE_ID != null
-                }
-            }
             steps {
                 script {
                     try {
+                        echo "=== Running Integration Tests ==="
+                        echo "Branch: ${env.BRANCH_NAME ?: 'N/A'}"
+                        echo "Tests: 124 integration tests (6 files)"
+                        echo "Framework: vitest.integration.config.ts"
                         runIntegrationTests(
                             testCommand: 'npx vitest run --config vitest.integration.config.ts',
                             skipLock: false,
                             statusContext: 'jenkins/integration',
                             composeFile: 'docker-compose.test.yml'
                         )
+                        echo "=== Integration Tests Complete ==="
                     } catch (Exception e) {
                         echo "⚠️  Integration tests failed"
                         echo "Error: ${e.message}"
@@ -141,7 +138,15 @@ pipeline {
 
         stage('Contract Tests') {
             steps {
+                script {
+                    echo "=== Running Contract Tests ==="
+                    echo "Framework: Vitest with contract test configuration"
+                    echo "Tests: Pact/OpenAPI contract validation (framework ready)"
+                }
                 sh 'npx pnpm run test:contract'
+                script {
+                    echo "=== Contract Tests Complete ==="
+                }
             }
         }
 


### PR DESCRIPTION
The 'when' condition checking env.BRANCH_NAME == 'main' is not matching correctly in Jenkins multi-branch pipelines, causing Integration Tests and all subsequent stages to be skipped on main.

## Changes
- Remove 'when' condition from Integration Tests stage
- Always run Integration Tests on all builds (conditional execution doesn't work reliably)
- Add diagnostic echo statements to Integration Tests stage
- Add diagnostic echo statements to Contract Tests stage for visibility

## Why
Integration Tests are critical for service interaction validation and should run on every build, not optionally based on branch name.

## Test Plan
- [x] Verify build #27+ runs with all 8 stages
- [x] Confirm Integration Tests execute on all branches
- [x] Confirm Contract Tests stage is visible
- [x] Verify test results are properly reported