### PR TITLE
fix(ci): remove infrastructure host ports to prevent E2E conflicts

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -18,8 +18,8 @@ services:
       POSTGRES_USER: unite_test
       POSTGRES_PASSWORD: unite_test
       POSTGRES_DB: unite_test
-    ports:
-      - '5434:5432'
+    # Host port removed to prevent CI conflicts - services communicate via Docker network
+    # For local debugging, uncomment: ports: ['5434:5432']
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U unite_test -d unite_test']
       interval: 5s
@@ -32,8 +32,8 @@ services:
 
   redis:
     image: redis:7-alpine
-    ports:
-      - '6381:6379'
+    # Host port removed to prevent CI conflicts - services communicate via Docker network
+    # For local debugging, uncomment: ports: ['6381:6379']
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
       interval: 5s
@@ -48,8 +48,8 @@ services:
       SERVICES: s3,sqs,sns
       DEBUG: 0
       DATA_DIR: ''
-    ports:
-      - '4568:4566'
+    # Host port removed to prevent CI conflicts - services communicate via Docker network
+    # For local debugging, uncomment: ports: ['4568:4566']
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:4566/_localstack/health']
       interval: 5s


### PR DESCRIPTION
## Summary
- Remove host port bindings for postgres (5434), redis (6381), and localstack (4568) from docker-compose.e2e.yml
- Infrastructure services only need Docker network communication for E2E tests
- Comments preserved showing how to re-enable ports for local debugging

## Root Cause
Main CI build #40 marked UNSTABLE due to:
```
Error response from daemon: failed to set up container networking: 
Bind for 0.0.0.0:5434 failed: port is already allocated
```

Hardcoded host ports conflict when previous builds don't clean up properly or orphaned containers hold ports.

## Solution
Remove host port exposure for infrastructure services. All E2E services communicate via Docker network (`unite-e2e`), so host ports are only needed for local debugging.

## Test plan
- [ ] CI build passes without port conflicts
- [ ] E2E tests run successfully in Jenkins

🤖 Generated with [Claude Code](https://claude.com/claude-code)