### PR TITLE
fix(tests): use fireEvent for EditResponseModal tests to prevent CI flakiness

### DIFF
--- a/frontend/src/components/responses/__tests__/EditResponseModal.test.tsx
+++ b/frontend/src/components/responses/__tests__/EditResponseModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import EditResponseModal from '../EditResponseModal';
 import type { Response } from '../../../types/response';
@@ -95,12 +95,11 @@ describe('EditResponseModal', () => {
     });
 
     it('should display character count with appropriate styling', async () => {
-      const user = userEvent.setup();
       render(<EditResponseModal {...defaultProps} maxLength={100} />);
 
       const textarea = screen.getByLabelText(/your response/i);
-      await user.clear(textarea);
-      await user.type(textarea, 'A'.repeat(95));
+      // Use fireEvent.change for large text input to avoid slow keystroke simulation
+      fireEvent.change(textarea, { target: { value: 'A'.repeat(95) } });
 
       const characterCount = screen.getByText(/95 \/ 100 characters/);
       expect(characterCount.className).toContain('text-secondary-600');
@@ -113,7 +112,8 @@ describe('EditResponseModal', () => {
       render(<EditResponseModal {...defaultProps} />);
 
       const sourceInput = screen.getByPlaceholderText(/https:\/\/example.com\/source/);
-      await user.type(sourceInput, 'https://newexample.com');
+      // Use fireEvent.change to avoid garbled text from userEvent.type in CI
+      fireEvent.change(sourceInput, { target: { value: 'https://newexample.com' } });
       await user.click(screen.getByRole('button', { name: /^add$/i }));
 
       expect(screen.getByText('https://newexample.com')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Fix flaky EditResponseModal tests that were causing main branch build failures
- The tests were failing in CI due to `userEvent.type()` being slow (simulates real keystrokes) and producing garbled text (race conditions)

## Changes
- Character count test: Use `fireEvent.change()` instead of typing 95 characters one-by-one
- Cited sources test: Use `fireEvent.change()` instead of `userEvent.type()` to avoid garbled text

## Context
Build #58 on main failed with 8 test failures (all in EditResponseModal). This fix was applied to the `002-skeleton-loaders` branch but wasn't included in the squash merge.

## Test plan
- [x] Ran EditResponseModal tests locally - all 23 pass
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)