### PR TITLE
feat: implement OAuth E2E test infrastructure with Playwright mocking

### DIFF
--- a/frontend/e2e/fixtures/oauth-mock.fixture.ts
+++ b/frontend/e2e/fixtures/oauth-mock.fixture.ts
@@ -1,0 +1,370 @@
+/**
+ * OAuth Mock Playwright Fixture
+ *
+ * Provides route interception for mocking OAuth flows in E2E tests.
+ * Extends the standard Playwright test with OAuth mocking capabilities.
+ *
+ * Usage:
+ *   import { test, expect } from '../fixtures/oauth-mock.fixture';
+ *
+ *   test('OAuth login', async ({ page }) => {
+ *     // OAuth routes are automatically intercepted
+ *     await page.goto('/signup');
+ *     await page.click('button:has-text("Google")');
+ *     // ...
+ *   });
+ *
+ *   // Custom configuration:
+ *   test.use({ oauthMock: { provider: 'apple', scenario: 'cancel' } });
+ */
+
+import { test as base, Page, Route, Request } from '@playwright/test';
+import type { OAuthProvider, OAuthMockConfig } from '../utils/oauth-types';
+import { generateMockStateToken, buildMockAuthSuccessResponse } from '../utils/oauth-mock';
+
+/**
+ * Extended test type with OAuth mock configuration
+ */
+export type OAuthMockOptions = {
+  oauthMock: Partial<OAuthMockConfig>;
+};
+
+/**
+ * State store for tracking OAuth state tokens during tests
+ */
+const stateStore = new Map<string, { provider: OAuthProvider; createdAt: Date }>();
+
+/**
+ * Create the OAuth mock fixture
+ */
+export const test = base.extend<OAuthMockOptions>({
+  // Default OAuth mock configuration
+  oauthMock: [
+    {
+      provider: 'google',
+      scenario: 'success',
+      emailVerified: true,
+      isPrivateRelay: false,
+      delay: 0,
+    },
+    { option: true },
+  ],
+
+  // Override page fixture to add route interception
+  page: async ({ page, oauthMock }, use) => {
+    const config: OAuthMockConfig = {
+      provider: oauthMock.provider || 'google',
+      scenario: oauthMock.scenario || 'success',
+      email: oauthMock.email,
+      name: oauthMock.name,
+      picture: oauthMock.picture,
+      emailVerified: oauthMock.emailVerified ?? true,
+      isPrivateRelay: oauthMock.isPrivateRelay ?? false,
+      delay: oauthMock.delay ?? 0,
+    };
+
+    // Set up OAuth route interception
+    await setupOAuthRouteInterception(page, config);
+
+    // Use the page with interception active
+    await use(page);
+
+    // Clear state store after test
+    stateStore.clear();
+  },
+});
+
+/**
+ * Set up route interception for OAuth endpoints
+ */
+async function setupOAuthRouteInterception(page: Page, config: OAuthMockConfig): Promise<void> {
+  // Intercept OAuth initiation endpoint (API call only)
+  await page.route('**/auth/oauth/initiate**', async (route, request) => {
+    // Only intercept fetch/XHR requests, not page navigations
+    if (request.resourceType() === 'fetch' || request.resourceType() === 'xhr') {
+      await handleOAuthInitiate(route, request, config);
+    } else {
+      await route.continue();
+    }
+  });
+
+  // Note: We do NOT intercept /auth/callback/* because that's a frontend page route.
+  // The callback page (AuthCallbackPage) will render and handle tokens from URL hash.
+  // The tokens are included in the authUrl returned by handleOAuthInitiate.
+
+  // Intercept external OAuth redirects (prevent actual Google/Apple navigation)
+  await page.route('**/accounts.google.com/**', async (route) => {
+    await handleExternalOAuthRedirect(route, config, 'google');
+  });
+
+  await page.route('**/appleid.apple.com/**', async (route) => {
+    await handleExternalOAuthRedirect(route, config, 'apple');
+  });
+
+  // Intercept /auth/me endpoint to return mock user data (API call only)
+  await page.route('**/auth/me**', async (route, request) => {
+    if (request.resourceType() === 'fetch' || request.resourceType() === 'xhr') {
+      await handleAuthMe(route, config);
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+/**
+ * Handle /auth/me request for fetching user info after OAuth
+ */
+async function handleAuthMe(route: Route, config: OAuthMockConfig): Promise<void> {
+  // Handle expired-code scenario - /auth/me fails with token expired
+  if (config.scenario === 'expired-code') {
+    await route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        error: 'TOKEN_EXPIRED',
+        message: 'The access token has expired',
+      }),
+    });
+    return;
+  }
+
+  // Return mock user data based on config
+  const authResponse = buildMockAuthSuccessResponse(config.provider, config);
+
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(authResponse),
+  });
+}
+
+/**
+ * Handle OAuth initiation request
+ * Intercepts POST /auth/oauth/initiate and returns mock callback URL
+ * Handles different scenarios based on config.scenario
+ */
+async function handleOAuthInitiate(
+  route: Route,
+  request: Request,
+  config: OAuthMockConfig,
+): Promise<void> {
+  // Add delay if configured
+  if (config.delay && config.delay > 0) {
+    await new Promise((resolve) => setTimeout(resolve, config.delay));
+  }
+
+  // Handle network error scenario
+  if (config.scenario === 'network-error') {
+    await route.abort('connectionfailed');
+    return;
+  }
+
+  // Handle server error scenario
+  if (config.scenario === 'server-error') {
+    await route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        error: 'SERVER_ERROR',
+        message: 'Authentication server error',
+      }),
+    });
+    return;
+  }
+
+  try {
+    const body = request.postDataJSON() as { provider?: OAuthProvider };
+    const provider = body?.provider || config.provider;
+
+    // Generate state token and store it
+    const stateToken = generateMockStateToken();
+    stateStore.set(stateToken, {
+      provider,
+      createdAt: new Date(),
+    });
+
+    // Build callback URL based on scenario
+    let authUrl: string;
+
+    switch (config.scenario) {
+      case 'cancel': {
+        // Return callback URL with error params
+        const errorParams = new URLSearchParams({
+          error: 'access_denied',
+          error_description: 'User cancelled the authorization',
+          state: stateToken,
+        });
+        authUrl = `/auth/callback/${provider}?${errorParams.toString()}`;
+        break;
+      }
+
+      case 'invalid-state': {
+        // Return callback URL with invalid state token
+        const authResponse = buildMockAuthSuccessResponse(provider, config);
+        const tokenParams = new URLSearchParams({
+          access_token: authResponse.accessToken,
+          refresh_token: authResponse.refreshToken,
+          state: 'invalid_state_token', // Wrong state to trigger CSRF check
+          token_type: 'Bearer',
+          expires_in: String(authResponse.expiresIn),
+        });
+        authUrl = `/auth/callback/${provider}#${tokenParams.toString()}`;
+        break;
+      }
+
+      case 'expired-code': {
+        // Return callback URL but the /auth/me call will fail
+        // For this scenario, we don't store the state token so validation fails
+        stateStore.delete(stateToken);
+        const tokenParams = new URLSearchParams({
+          access_token: 'expired_token',
+          state: stateToken,
+          token_type: 'Bearer',
+          expires_in: '0',
+        });
+        authUrl = `/auth/callback/${provider}#${tokenParams.toString()}`;
+        break;
+      }
+
+      case 'success':
+      default: {
+        // Generate mock tokens for direct inclusion in callback URL
+        const authResponse = buildMockAuthSuccessResponse(provider, config);
+
+        // Build mock callback URL with tokens in hash fragment
+        const tokenParams = new URLSearchParams({
+          access_token: authResponse.accessToken,
+          refresh_token: authResponse.refreshToken,
+          state: stateToken,
+          token_type: 'Bearer',
+          expires_in: String(authResponse.expiresIn),
+        });
+        authUrl = `/auth/callback/${provider}#${tokenParams.toString()}`;
+        break;
+      }
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        authUrl,
+        state: stateToken,
+        provider,
+      }),
+    });
+  } catch (error) {
+    await route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        error: 'SERVER_ERROR',
+        message: 'Mock OAuth initiation failed',
+      }),
+    });
+  }
+}
+
+/**
+ * Handle external OAuth provider redirects
+ * Prevents actual navigation to Google/Apple and redirects to mock callback with tokens
+ */
+async function handleExternalOAuthRedirect(
+  route: Route,
+  config: OAuthMockConfig,
+  provider: OAuthProvider,
+): Promise<void> {
+  // Add delay if configured (simulate OAuth provider response time)
+  if (config.delay && config.delay > 0) {
+    await new Promise((resolve) => setTimeout(resolve, config.delay));
+  }
+
+  // Handle network error scenario
+  if (config.scenario === 'network-error') {
+    await route.abort('connectionfailed');
+    return;
+  }
+
+  // Generate state token for the redirect
+  const stateToken = generateMockStateToken();
+  stateStore.set(stateToken, {
+    provider,
+    createdAt: new Date(),
+  });
+
+  // Determine callback URL based on scenario
+  let callbackUrl: string;
+
+  switch (config.scenario) {
+    case 'cancel': {
+      const errorParams = new URLSearchParams({
+        error: 'access_denied',
+        error_description: 'User cancelled the authorization',
+        state: stateToken,
+      });
+      callbackUrl = `/auth/callback/${provider}?${errorParams.toString()}`;
+      break;
+    }
+
+    case 'invalid-state': {
+      const authResponse = buildMockAuthSuccessResponse(provider, config);
+      const tokenParams = new URLSearchParams({
+        access_token: authResponse.accessToken,
+        refresh_token: authResponse.refreshToken,
+        state: 'invalid_state_token', // Wrong state to trigger CSRF check
+        token_type: 'Bearer',
+        expires_in: String(authResponse.expiresIn),
+      });
+      callbackUrl = `/auth/callback/${provider}#${tokenParams.toString()}`;
+      break;
+    }
+
+    case 'expired-code': {
+      stateStore.delete(stateToken);
+      const tokenParams = new URLSearchParams({
+        access_token: 'expired_token',
+        state: stateToken,
+        token_type: 'Bearer',
+        expires_in: '0',
+      });
+      callbackUrl = `/auth/callback/${provider}#${tokenParams.toString()}`;
+      break;
+    }
+
+    case 'server-error': {
+      // For server error, we still redirect but with an error param
+      const errorParams = new URLSearchParams({
+        error: 'server_error',
+        error_description: 'Authentication server error',
+        state: stateToken,
+      });
+      callbackUrl = `/auth/callback/${provider}?${errorParams.toString()}`;
+      break;
+    }
+
+    case 'success':
+    default: {
+      const authResponse = buildMockAuthSuccessResponse(provider, config);
+      const tokenParams = new URLSearchParams({
+        access_token: authResponse.accessToken,
+        refresh_token: authResponse.refreshToken,
+        state: stateToken,
+        token_type: 'Bearer',
+        expires_in: String(authResponse.expiresIn),
+      });
+      callbackUrl = `/auth/callback/${provider}#${tokenParams.toString()}`;
+      break;
+    }
+  }
+
+  // Redirect to our mock callback URL
+  await route.fulfill({
+    status: 302,
+    headers: {
+      Location: callbackUrl,
+    },
+  });
+}
+
+// Re-export expect from base
+export { expect } from '@playwright/test';

--- a/frontend/e2e/utils/oauth-mock.ts
+++ b/frontend/e2e/utils/oauth-mock.ts
@@ -1,0 +1,315 @@
+/**
+ * OAuth E2E Mock Utilities
+ *
+ * Mock data generators for OAuth E2E tests.
+ * These utilities create realistic mock data for testing OAuth flows
+ * without requiring real OAuth provider credentials.
+ */
+
+import type {
+  OAuthProvider,
+  OAuthScenario,
+  OAuthMockConfig,
+  MockOAuthTokens,
+  MockGoogleProfile,
+  MockAppleProfile,
+  OAuthStateEntry,
+  DEFAULT_OAUTH_MOCK_CONFIG,
+} from './oauth-types';
+
+/**
+ * Generate a unique mock email address for testing
+ * Pattern: oauth-test-{timestamp}-{random}@example.com
+ */
+export function generateMockEmail(): string {
+  const random = Math.random().toString(36).substring(2, 8);
+  return `oauth-test-${Date.now()}-${random}@example.com`;
+}
+
+/**
+ * Generate a CSRF state token for OAuth flow
+ * Pattern: mock_state_{random}_{timestamp}
+ */
+export function generateMockStateToken(): string {
+  const random = Math.random().toString(36).substring(2, 10);
+  return `mock_state_${random}_${Date.now()}`;
+}
+
+/**
+ * Generate a mock authorization code
+ * Pattern: mock_code_{provider}_{timestamp}
+ */
+export function generateMockAuthCode(provider: OAuthProvider): string {
+  return `mock_code_${provider}_${Date.now()}`;
+}
+
+/**
+ * Generate an Apple Private Relay email address
+ * Pattern: {random}@privaterelay.appleid.com
+ */
+export function generateAppleRelayEmail(): string {
+  const random = Math.random().toString(36).substring(2, 14);
+  return `${random}@privaterelay.appleid.com`;
+}
+
+/**
+ * Generate mock OAuth tokens for a provider
+ */
+export function generateMockOAuthTokens(
+  provider: OAuthProvider,
+  config: Partial<OAuthMockConfig> = {},
+): MockOAuthTokens {
+  const timestamp = Date.now();
+  const scopes = provider === 'google' ? 'openid email profile' : 'openid email name';
+
+  return {
+    accessToken: `mock_access_${provider}_${timestamp}`,
+    idToken: `mock_id_${provider}_${timestamp}`,
+    refreshToken: `mock_refresh_${provider}_${timestamp}`,
+    expiresIn: 3600,
+    tokenType: 'Bearer',
+    scope: scopes,
+  };
+}
+
+/**
+ * Generate a mock Google user profile
+ */
+export function generateMockGoogleProfile(
+  config: Partial<OAuthMockConfig> = {},
+): MockGoogleProfile {
+  const email = config.email || generateMockEmail();
+  const name = config.name || 'Test User';
+  const nameParts = name.split(' ');
+  const givenName = nameParts[0] || 'Test';
+  const familyName = nameParts.slice(1).join(' ') || 'User';
+  const timestamp = Date.now();
+
+  return {
+    email,
+    emailVerified: config.emailVerified ?? true,
+    name,
+    givenName,
+    familyName,
+    picture: config.picture || `https://lh3.googleusercontent.com/mock/${timestamp}`,
+    googleId: `google_${timestamp}_${Math.random().toString(36).substring(2, 10)}`,
+  };
+}
+
+/**
+ * Generate a mock Apple user profile
+ */
+export function generateMockAppleProfile(config: Partial<OAuthMockConfig> = {}): MockAppleProfile {
+  const isPrivateRelay = config.isPrivateRelay ?? false;
+  const email = isPrivateRelay ? generateAppleRelayEmail() : config.email || generateMockEmail();
+  const name = config.name || 'Test User';
+  const timestamp = Date.now();
+
+  return {
+    email,
+    emailVerified: true, // Apple always verifies email
+    name,
+    appleId: `apple_${timestamp}_${Math.random().toString(36).substring(2, 10)}`,
+    isPrivateEmail: isPrivateRelay,
+    realUserStatus: 2, // 2 = likely real user
+  };
+}
+
+/**
+ * Create an OAuth state entry for CSRF protection
+ */
+export function createOAuthStateEntry(
+  provider: OAuthProvider,
+  options: {
+    visitorSessionId?: string;
+    redirectUrl?: string;
+  } = {},
+): OAuthStateEntry {
+  return {
+    stateToken: generateMockStateToken(),
+    provider,
+    createdAt: new Date(),
+    visitorSessionId: options.visitorSessionId,
+    redirectUrl: options.redirectUrl,
+  };
+}
+
+/**
+ * Build a mock OAuth callback URL for testing
+ */
+export function buildMockCallbackUrl(
+  provider: OAuthProvider,
+  scenario: OAuthScenario,
+  stateToken: string,
+  baseUrl: string = 'http://localhost:3000',
+): string {
+  const url = new URL(`${baseUrl}/auth/callback/${provider}`);
+
+  switch (scenario) {
+    case 'success':
+      url.searchParams.set('code', generateMockAuthCode(provider));
+      url.searchParams.set('state', stateToken);
+      break;
+
+    case 'cancel':
+      url.searchParams.set('error', 'access_denied');
+      url.searchParams.set('error_description', 'User cancelled the authorization');
+      url.searchParams.set('state', stateToken);
+      break;
+
+    case 'invalid-state':
+      url.searchParams.set('code', generateMockAuthCode(provider));
+      url.searchParams.set('state', 'invalid_state_token');
+      break;
+
+    case 'expired-code':
+      url.searchParams.set('code', 'expired_code_12345');
+      url.searchParams.set('state', stateToken);
+      break;
+
+    case 'network-error':
+      // Network errors are simulated via route.abort(), not URL
+      // Return a valid URL that will be intercepted
+      url.searchParams.set('code', generateMockAuthCode(provider));
+      url.searchParams.set('state', stateToken);
+      break;
+
+    case 'server-error':
+      url.searchParams.set('code', generateMockAuthCode(provider));
+      url.searchParams.set('state', stateToken);
+      url.searchParams.set('_mock_error', '500');
+      break;
+  }
+
+  return url.toString();
+}
+
+/**
+ * Build mock authentication success response (matches backend contract)
+ */
+export function buildMockAuthSuccessResponse(
+  provider: OAuthProvider,
+  config: Partial<OAuthMockConfig> = {},
+): {
+  accessToken: string;
+  refreshToken: string;
+  user: {
+    id: string;
+    email: string;
+    displayName: string;
+    authMethod: 'GOOGLE_OAUTH' | 'APPLE_OAUTH';
+    emailVerified: boolean;
+    accountStatus: string;
+    createdAt: string;
+    lastLoginAt: string;
+  };
+  onboardingProgress: {
+    userId: string;
+    currentStep: string;
+    emailVerified: boolean;
+    topicsSelected: boolean;
+    orientationViewed: boolean;
+    firstPostMade: boolean;
+    completionPercentage: number;
+    nextAction: {
+      step: string;
+      label: string;
+      description: string;
+      url: string;
+    };
+  };
+  expiresIn: number;
+} {
+  const tokens = generateMockOAuthTokens(provider, config);
+  const profile =
+    provider === 'google' ? generateMockGoogleProfile(config) : generateMockAppleProfile(config);
+
+  const userId = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  return {
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    user: {
+      id: userId,
+      email: profile.email,
+      displayName: profile.name,
+      authMethod: provider === 'google' ? 'GOOGLE_OAUTH' : 'APPLE_OAUTH',
+      emailVerified: profile.emailVerified,
+      accountStatus: 'ACTIVE',
+      createdAt: now,
+      lastLoginAt: now,
+    },
+    onboardingProgress: {
+      userId,
+      currentStep: 'TOPICS',
+      emailVerified: profile.emailVerified,
+      topicsSelected: false,
+      orientationViewed: false,
+      firstPostMade: false,
+      completionPercentage: 25,
+      nextAction: {
+        step: 'TOPICS',
+        label: 'Select Topics',
+        description: 'Choose topics you want to discuss',
+        url: '/onboarding/topics',
+      },
+    },
+    expiresIn: tokens.expiresIn,
+  };
+}
+
+/**
+ * Build mock OAuth error response
+ */
+export function buildMockOAuthErrorResponse(
+  scenario: OAuthScenario,
+  provider: OAuthProvider,
+): {
+  error: string;
+  message: string;
+  details?: {
+    provider: string;
+    hint?: string;
+  };
+} {
+  const errorMap: Record<OAuthScenario, { error: string; message: string; hint?: string }> = {
+    success: { error: 'UNEXPECTED', message: 'No error for success scenario' },
+    cancel: {
+      error: 'OAUTH_CANCELLED',
+      message: 'You cancelled the sign-in process',
+      hint: 'Click the OAuth button to try again',
+    },
+    'invalid-state': {
+      error: 'INVALID_STATE',
+      message: 'Security validation failed',
+      hint: 'Please start the sign-in process again',
+    },
+    'expired-code': {
+      error: 'EXPIRED_CODE',
+      message: 'The authorization has expired',
+      hint: 'Please try signing in again',
+    },
+    'network-error': {
+      error: 'NETWORK_ERROR',
+      message: 'Unable to connect to authentication server',
+      hint: 'Check your internet connection and try again',
+    },
+    'server-error': {
+      error: 'SERVER_ERROR',
+      message: 'Authentication server error',
+      hint: 'Please try again later',
+    },
+  };
+
+  const errorInfo = errorMap[scenario];
+
+  return {
+    error: errorInfo.error,
+    message: errorInfo.message,
+    details: {
+      provider,
+      hint: errorInfo.hint,
+    },
+  };
+}

--- a/frontend/e2e/utils/oauth-types.ts
+++ b/frontend/e2e/utils/oauth-types.ts
@@ -1,0 +1,127 @@
+/**
+ * OAuth E2E Test Type Definitions
+ *
+ * Types for mocking OAuth flows in Playwright E2E tests.
+ * These structures simulate real OAuth provider responses.
+ */
+
+/**
+ * OAuth provider types supported by the mock system
+ */
+export type OAuthProvider = 'google' | 'apple';
+
+/**
+ * Test scenarios for OAuth mocking
+ */
+export type OAuthScenario =
+  | 'success'
+  | 'cancel'
+  | 'invalid-state'
+  | 'expired-code'
+  | 'network-error'
+  | 'server-error';
+
+/**
+ * Configuration for per-test OAuth mock behavior
+ */
+export interface OAuthMockConfig {
+  /** OAuth provider to mock */
+  provider: OAuthProvider;
+  /** Test scenario (success, error, etc.) */
+  scenario: OAuthScenario;
+  /** Custom email for mock user (default: auto-generated) */
+  email?: string;
+  /** Custom display name (default: "Test User") */
+  name?: string;
+  /** Custom avatar URL */
+  picture?: string;
+  /** Whether email is verified (default: true) */
+  emailVerified?: boolean;
+  /** Apple "Hide My Email" mode (default: false) */
+  isPrivateRelay?: boolean;
+  /** Artificial delay in ms (default: 0) */
+  delay?: number;
+}
+
+/**
+ * Simulated OAuth token response
+ */
+export interface MockOAuthTokens {
+  /** Mock bearer token */
+  accessToken: string;
+  /** Mock JWT with user claims */
+  idToken: string;
+  /** Mock refresh token */
+  refreshToken: string;
+  /** Token lifetime in seconds (default: 3600) */
+  expiresIn: number;
+  /** Always "Bearer" */
+  tokenType: 'Bearer';
+  /** OAuth scopes granted */
+  scope: string;
+}
+
+/**
+ * Simulated Google user profile
+ */
+export interface MockGoogleProfile {
+  /** User's email address */
+  email: string;
+  /** Whether email is verified */
+  emailVerified: boolean;
+  /** Full name */
+  name: string;
+  /** First name */
+  givenName: string;
+  /** Last name */
+  familyName: string;
+  /** Avatar URL */
+  picture: string;
+  /** Unique Google user ID */
+  googleId: string;
+}
+
+/**
+ * Simulated Apple user profile
+ */
+export interface MockAppleProfile {
+  /** User's email (real or privaterelay) */
+  email: string;
+  /** Always true for Apple */
+  emailVerified: boolean;
+  /** Full name (may be empty after first auth) */
+  name: string;
+  /** Unique Apple user ID */
+  appleId: string;
+  /** Whether using Hide My Email */
+  isPrivateEmail: boolean;
+  /** User authenticity indicator: 0=unsupported, 1=unknown, 2=likely real */
+  realUserStatus: 0 | 1 | 2;
+}
+
+/**
+ * OAuth state store entry for CSRF protection
+ */
+export interface OAuthStateEntry {
+  /** Generated CSRF token */
+  stateToken: string;
+  /** OAuth provider */
+  provider: OAuthProvider;
+  /** When state was created */
+  createdAt: Date;
+  /** Optional visitor session to link */
+  visitorSessionId?: string;
+  /** Where to redirect after success */
+  redirectUrl?: string;
+}
+
+/**
+ * Default mock configuration
+ */
+export const DEFAULT_OAUTH_MOCK_CONFIG: OAuthMockConfig = {
+  provider: 'google',
+  scenario: 'success',
+  emailVerified: true,
+  isPrivateRelay: false,
+  delay: 0,
+};

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -2,6 +2,8 @@ import type { RouteObject } from 'react-router-dom';
 import HomePage from '../pages/HomePage';
 import AboutPage from '../pages/AboutPage';
 import { LoginPage, RegisterPage } from '../pages/Auth';
+import { SignupPage } from '../pages/SignupPage';
+import { AuthCallbackPage } from '../pages/AuthCallbackPage';
 import TopicsPage from '../pages/Topics';
 import TopicDetailPage from '../pages/Topics/TopicDetailPage';
 import CommonGroundDemoPage from '../pages/Topics/CommonGroundDemoPage';
@@ -35,6 +37,14 @@ export const routes: RouteObject[] = [
   {
     path: '/register',
     element: <RegisterPage />,
+  },
+  {
+    path: '/signup',
+    element: <SignupPage />,
+  },
+  {
+    path: '/auth/callback/:provider',
+    element: <AuthCallbackPage />,
   },
   {
     path: '/topics',

--- a/frontend/src/test/e2e-utils/oauth-mock.test.ts
+++ b/frontend/src/test/e2e-utils/oauth-mock.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Unit Tests for OAuth Mock Utilities
+ *
+ * Tests the mock data generators for OAuth E2E tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  generateMockEmail,
+  generateMockStateToken,
+  generateMockAuthCode,
+  generateAppleRelayEmail,
+  generateMockOAuthTokens,
+  generateMockGoogleProfile,
+  generateMockAppleProfile,
+  createOAuthStateEntry,
+  buildMockCallbackUrl,
+  buildMockAuthSuccessResponse,
+  buildMockOAuthErrorResponse,
+} from '../../../e2e/utils/oauth-mock';
+
+describe('OAuth Mock Utilities', () => {
+  describe('generateMockEmail', () => {
+    it('should generate email with correct pattern', () => {
+      const email = generateMockEmail();
+      expect(email).toMatch(/^oauth-test-\d+-[a-z0-9]+@example\.com$/);
+    });
+
+    it('should generate unique emails', () => {
+      const email1 = generateMockEmail();
+      // Add small delay to ensure different timestamp
+      const email2 = generateMockEmail();
+      // Emails should be unique (different timestamps)
+      expect(email1).not.toBe(email2);
+    });
+  });
+
+  describe('generateMockStateToken', () => {
+    it('should generate state token with mock_state prefix', () => {
+      const token = generateMockStateToken();
+      expect(token).toMatch(/^mock_state_[a-z0-9]+_\d+$/);
+    });
+
+    it('should generate unique tokens', () => {
+      const token1 = generateMockStateToken();
+      const token2 = generateMockStateToken();
+      expect(token1).not.toBe(token2);
+    });
+  });
+
+  describe('generateMockAuthCode', () => {
+    it('should generate Google auth code with correct pattern', () => {
+      const code = generateMockAuthCode('google');
+      expect(code).toMatch(/^mock_code_google_\d+$/);
+    });
+
+    it('should generate Apple auth code with correct pattern', () => {
+      const code = generateMockAuthCode('apple');
+      expect(code).toMatch(/^mock_code_apple_\d+$/);
+    });
+  });
+
+  describe('generateAppleRelayEmail', () => {
+    it('should generate Apple private relay email', () => {
+      const email = generateAppleRelayEmail();
+      expect(email).toMatch(/^[a-z0-9]+@privaterelay\.appleid\.com$/);
+    });
+
+    it('should generate unique relay emails', () => {
+      const email1 = generateAppleRelayEmail();
+      const email2 = generateAppleRelayEmail();
+      expect(email1).not.toBe(email2);
+    });
+  });
+
+  describe('generateMockOAuthTokens', () => {
+    it('should generate Google OAuth tokens', () => {
+      const tokens = generateMockOAuthTokens('google');
+
+      expect(tokens.accessToken).toMatch(/^mock_access_google_\d+$/);
+      expect(tokens.idToken).toMatch(/^mock_id_google_\d+$/);
+      expect(tokens.refreshToken).toMatch(/^mock_refresh_google_\d+$/);
+      expect(tokens.expiresIn).toBe(3600);
+      expect(tokens.tokenType).toBe('Bearer');
+      expect(tokens.scope).toBe('openid email profile');
+    });
+
+    it('should generate Apple OAuth tokens', () => {
+      const tokens = generateMockOAuthTokens('apple');
+
+      expect(tokens.accessToken).toMatch(/^mock_access_apple_\d+$/);
+      expect(tokens.scope).toBe('openid email name');
+    });
+  });
+
+  describe('generateMockGoogleProfile', () => {
+    it('should generate profile with default values', () => {
+      const profile = generateMockGoogleProfile();
+
+      expect(profile.email).toMatch(/^oauth-test-\d+-[a-z0-9]+@example\.com$/);
+      expect(profile.emailVerified).toBe(true);
+      expect(profile.name).toBe('Test User');
+      expect(profile.givenName).toBe('Test');
+      expect(profile.familyName).toBe('User');
+      expect(profile.picture).toMatch(/^https:\/\/lh3\.googleusercontent\.com\/mock\/\d+$/);
+      expect(profile.googleId).toMatch(/^google_\d+_[a-z0-9]+$/);
+    });
+
+    it('should use custom email', () => {
+      const profile = generateMockGoogleProfile({ email: 'custom@example.com' });
+      expect(profile.email).toBe('custom@example.com');
+    });
+
+    it('should use custom name and split correctly', () => {
+      const profile = generateMockGoogleProfile({ name: 'John Michael Smith' });
+      expect(profile.name).toBe('John Michael Smith');
+      expect(profile.givenName).toBe('John');
+      expect(profile.familyName).toBe('Michael Smith');
+    });
+
+    it('should respect emailVerified setting', () => {
+      const profile = generateMockGoogleProfile({ emailVerified: false });
+      expect(profile.emailVerified).toBe(false);
+    });
+  });
+
+  describe('generateMockAppleProfile', () => {
+    it('should generate profile with default values', () => {
+      const profile = generateMockAppleProfile();
+
+      expect(profile.email).toMatch(/^oauth-test-\d+-[a-z0-9]+@example\.com$/);
+      expect(profile.emailVerified).toBe(true);
+      expect(profile.name).toBe('Test User');
+      expect(profile.appleId).toMatch(/^apple_\d+_[a-z0-9]+$/);
+      expect(profile.isPrivateEmail).toBe(false);
+      expect(profile.realUserStatus).toBe(2);
+    });
+
+    it('should generate private relay email when isPrivateRelay is true', () => {
+      const profile = generateMockAppleProfile({ isPrivateRelay: true });
+
+      expect(profile.email).toMatch(/^[a-z0-9]+@privaterelay\.appleid\.com$/);
+      expect(profile.isPrivateEmail).toBe(true);
+    });
+
+    it('should always have emailVerified as true for Apple', () => {
+      const profile = generateMockAppleProfile({ emailVerified: false });
+      // Apple always verifies emails, so this should still be true
+      expect(profile.emailVerified).toBe(true);
+    });
+  });
+
+  describe('createOAuthStateEntry', () => {
+    it('should create state entry with required fields', () => {
+      const entry = createOAuthStateEntry('google');
+
+      expect(entry.stateToken).toMatch(/^mock_state_/);
+      expect(entry.provider).toBe('google');
+      expect(entry.createdAt).toBeInstanceOf(Date);
+      expect(entry.visitorSessionId).toBeUndefined();
+      expect(entry.redirectUrl).toBeUndefined();
+    });
+
+    it('should include optional fields when provided', () => {
+      const entry = createOAuthStateEntry('apple', {
+        visitorSessionId: 'visitor-123',
+        redirectUrl: '/dashboard',
+      });
+
+      expect(entry.provider).toBe('apple');
+      expect(entry.visitorSessionId).toBe('visitor-123');
+      expect(entry.redirectUrl).toBe('/dashboard');
+    });
+  });
+
+  describe('buildMockCallbackUrl', () => {
+    const stateToken = 'test_state_123';
+    const baseUrl = 'http://localhost:3000';
+
+    it('should build success callback URL', () => {
+      const url = buildMockCallbackUrl('google', 'success', stateToken, baseUrl);
+      const parsed = new URL(url);
+
+      expect(parsed.pathname).toBe('/auth/callback/google');
+      expect(parsed.searchParams.get('code')).toMatch(/^mock_code_google_\d+$/);
+      expect(parsed.searchParams.get('state')).toBe(stateToken);
+    });
+
+    it('should build cancel callback URL', () => {
+      const url = buildMockCallbackUrl('google', 'cancel', stateToken, baseUrl);
+      const parsed = new URL(url);
+
+      expect(parsed.searchParams.get('error')).toBe('access_denied');
+      expect(parsed.searchParams.get('error_description')).toBe('User cancelled the authorization');
+      expect(parsed.searchParams.get('state')).toBe(stateToken);
+    });
+
+    it('should build invalid-state callback URL', () => {
+      const url = buildMockCallbackUrl('google', 'invalid-state', stateToken, baseUrl);
+      const parsed = new URL(url);
+
+      expect(parsed.searchParams.get('state')).toBe('invalid_state_token');
+      expect(parsed.searchParams.get('code')).toBeTruthy();
+    });
+
+    it('should build expired-code callback URL', () => {
+      const url = buildMockCallbackUrl('apple', 'expired-code', stateToken, baseUrl);
+      const parsed = new URL(url);
+
+      expect(parsed.searchParams.get('code')).toBe('expired_code_12345');
+      expect(parsed.searchParams.get('state')).toBe(stateToken);
+    });
+
+    it('should build server-error callback URL', () => {
+      const url = buildMockCallbackUrl('google', 'server-error', stateToken, baseUrl);
+      const parsed = new URL(url);
+
+      expect(parsed.searchParams.get('_mock_error')).toBe('500');
+    });
+  });
+
+  describe('buildMockAuthSuccessResponse', () => {
+    it('should build Google auth success response', () => {
+      const response = buildMockAuthSuccessResponse('google');
+
+      expect(response.accessToken).toMatch(/^mock_access_google_\d+$/);
+      expect(response.refreshToken).toMatch(/^mock_refresh_google_\d+$/);
+      expect(response.user.authMethod).toBe('GOOGLE_OAUTH');
+      expect(response.user.emailVerified).toBe(true);
+      expect(response.user.accountStatus).toBe('ACTIVE');
+      expect(response.onboardingProgress.currentStep).toBe('TOPICS');
+      expect(response.onboardingProgress.completionPercentage).toBe(25);
+      expect(response.expiresIn).toBe(3600);
+    });
+
+    it('should build Apple auth success response', () => {
+      const response = buildMockAuthSuccessResponse('apple');
+
+      expect(response.user.authMethod).toBe('APPLE_OAUTH');
+    });
+
+    it('should use custom email', () => {
+      const response = buildMockAuthSuccessResponse('google', {
+        email: 'custom@example.com',
+      });
+
+      expect(response.user.email).toBe('custom@example.com');
+    });
+
+    it('should use custom name', () => {
+      const response = buildMockAuthSuccessResponse('google', {
+        name: 'Custom Name',
+      });
+
+      expect(response.user.displayName).toBe('Custom Name');
+    });
+  });
+
+  describe('buildMockOAuthErrorResponse', () => {
+    it('should build cancel error response', () => {
+      const response = buildMockOAuthErrorResponse('cancel', 'google');
+
+      expect(response.error).toBe('OAUTH_CANCELLED');
+      expect(response.message).toBe('You cancelled the sign-in process');
+      expect(response.details?.provider).toBe('google');
+      expect(response.details?.hint).toBeTruthy();
+    });
+
+    it('should build invalid-state error response', () => {
+      const response = buildMockOAuthErrorResponse('invalid-state', 'apple');
+
+      expect(response.error).toBe('INVALID_STATE');
+      expect(response.message).toBe('Security validation failed');
+    });
+
+    it('should build expired-code error response', () => {
+      const response = buildMockOAuthErrorResponse('expired-code', 'google');
+
+      expect(response.error).toBe('EXPIRED_CODE');
+    });
+
+    it('should build network-error response', () => {
+      const response = buildMockOAuthErrorResponse('network-error', 'google');
+
+      expect(response.error).toBe('NETWORK_ERROR');
+    });
+
+    it('should build server-error response', () => {
+      const response = buildMockOAuthErrorResponse('server-error', 'apple');
+
+      expect(response.error).toBe('SERVER_ERROR');
+    });
+  });
+});

--- a/specs/009-oauth-e2e-tests/checklists/requirements.md
+++ b/specs/009-oauth-e2e-tests/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: OAuth2 E2E Test Infrastructure
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass validation. The specification is ready for `/speckit.clarify` or `/speckit.plan`.
+
+**Key observations:**
+- Spec correctly identifies that 650+ lines of existing tests are skipped and need enabling
+- Success criteria are measurable (29 tests, 5 minutes, 30 seconds per test, 99% pass rate)
+- No [NEEDS CLARIFICATION] markers - the feature scope is clear
+- Assumptions are documented (existing tests are well-designed, mock server approach)

--- a/specs/009-oauth-e2e-tests/contracts/oauth-mock-endpoints.yaml
+++ b/specs/009-oauth-e2e-tests/contracts/oauth-mock-endpoints.yaml
@@ -1,0 +1,288 @@
+openapi: 3.0.3
+info:
+  title: OAuth Mock Endpoints
+  description: |
+    Mock OAuth endpoints for E2E testing. These endpoints are only active when `AUTH_MOCK=true`.
+    They simulate Google and Apple OAuth flows without requiring real provider credentials.
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:3001
+    description: User service (E2E environment)
+
+paths:
+  /auth/oauth/initiate:
+    post:
+      summary: Initiate OAuth flow (mocked)
+      description: |
+        In mock mode, returns a callback URL pointing to our mock handler instead of real OAuth provider.
+      tags:
+        - OAuth Mock
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InitiateOAuthRequest'
+      responses:
+        '200':
+          description: OAuth initiation successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InitiateOAuthResponse'
+              examples:
+                google:
+                  summary: Google OAuth (mocked)
+                  value:
+                    authUrl: "/auth/callback/google?code=mock_code_1706367600000&state=mock_state_abc123"
+                    state: "mock_state_abc123"
+                    provider: "google"
+                apple:
+                  summary: Apple OAuth (mocked)
+                  value:
+                    authUrl: "/auth/callback/apple?code=mock_code_1706367600001&state=mock_state_def456"
+                    state: "mock_state_def456"
+                    provider: "apple"
+
+  /auth/callback/google:
+    get:
+      summary: Google OAuth callback (mocked)
+      description: |
+        Handles mock Google OAuth callback. Accepts mock authorization codes and returns authentication tokens.
+      tags:
+        - OAuth Mock
+      parameters:
+        - name: code
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Authorization code (mock codes start with `mock_code_`)
+          example: mock_code_google_1706367600000
+        - name: state
+          in: query
+          required: true
+          schema:
+            type: string
+          description: CSRF state token
+          example: mock_state_abc123
+        - name: error
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Error code if OAuth failed
+          example: access_denied
+        - name: error_description
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Human-readable error description
+      responses:
+        '200':
+          description: OAuth successful, returns auth tokens
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthSuccessResponse'
+        '401':
+          description: OAuth failed (cancelled, invalid state, etc.)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthError'
+
+  /auth/callback/apple:
+    get:
+      summary: Apple OAuth callback (mocked)
+      description: |
+        Handles mock Apple Sign-In callback. Supports both real email and private relay email addresses.
+      tags:
+        - OAuth Mock
+      parameters:
+        - name: code
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Authorization code (mock codes start with `mock_code_`)
+        - name: state
+          in: query
+          required: true
+          schema:
+            type: string
+          description: CSRF state token
+        - name: id_token
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Apple ID token (mocked JWT)
+        - name: user
+          in: query
+          required: false
+          schema:
+            type: string
+          description: User info JSON (first auth only)
+      responses:
+        '200':
+          description: OAuth successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthSuccessResponse'
+        '401':
+          description: OAuth failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthError'
+
+components:
+  schemas:
+    InitiateOAuthRequest:
+      type: object
+      required:
+        - provider
+      properties:
+        provider:
+          type: string
+          enum: [google, apple]
+          description: OAuth provider
+        visitorSessionId:
+          type: string
+          format: uuid
+          description: Optional visitor session to link
+        redirectUrl:
+          type: string
+          format: uri
+          description: Where to redirect after success
+
+    InitiateOAuthResponse:
+      type: object
+      required:
+        - authUrl
+        - state
+        - provider
+      properties:
+        authUrl:
+          type: string
+          description: URL to redirect user to (mock URL in E2E mode)
+        state:
+          type: string
+          description: CSRF state token
+        provider:
+          type: string
+          enum: [google, apple]
+
+    AuthSuccessResponse:
+      type: object
+      required:
+        - accessToken
+        - refreshToken
+        - user
+        - onboardingProgress
+        - expiresIn
+      properties:
+        accessToken:
+          type: string
+          description: JWT access token
+        refreshToken:
+          type: string
+          description: JWT refresh token
+        user:
+          $ref: '#/components/schemas/UserProfile'
+        onboardingProgress:
+          $ref: '#/components/schemas/OnboardingProgress'
+        expiresIn:
+          type: integer
+          description: Token lifetime in seconds
+
+    UserProfile:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+          format: email
+        displayName:
+          type: string
+        authMethod:
+          type: string
+          enum: [EMAIL_PASSWORD, GOOGLE_OAUTH, APPLE_OAUTH]
+        emailVerified:
+          type: boolean
+        accountStatus:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        lastLoginAt:
+          type: string
+          format: date-time
+
+    OnboardingProgress:
+      type: object
+      properties:
+        userId:
+          type: string
+          format: uuid
+        currentStep:
+          type: string
+          enum: [VERIFICATION, TOPICS, ORIENTATION, COMPLETE]
+        emailVerified:
+          type: boolean
+        topicsSelected:
+          type: boolean
+        orientationViewed:
+          type: boolean
+        firstPostMade:
+          type: boolean
+        completionPercentage:
+          type: integer
+          minimum: 0
+          maximum: 100
+        nextAction:
+          type: object
+          properties:
+            step:
+              type: string
+            label:
+              type: string
+            description:
+              type: string
+            url:
+              type: string
+
+    OAuthError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          enum:
+            - OAUTH_CANCELLED
+            - INVALID_STATE
+            - EXPIRED_CODE
+            - OAUTH_FAILED
+            - SERVER_ERROR
+        message:
+          type: string
+          description: Human-readable error message
+        details:
+          type: object
+          properties:
+            provider:
+              type: string
+            hint:
+              type: string
+
+tags:
+  - name: OAuth Mock
+    description: Mock OAuth endpoints for E2E testing (AUTH_MOCK=true only)

--- a/specs/009-oauth-e2e-tests/data-model.md
+++ b/specs/009-oauth-e2e-tests/data-model.md
@@ -1,0 +1,166 @@
+# Data Model: OAuth2 E2E Test Infrastructure
+
+**Feature**: 009-oauth-e2e-tests
+**Date**: 2026-01-27
+
+## Overview
+
+This document defines the data structures used for mocking OAuth flows in E2E tests. These are **test-only** structures that simulate real OAuth provider responses.
+
+---
+
+## Mock Data Structures
+
+### OAuthMockConfig
+
+Configuration for per-test OAuth behavior.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| provider | `'google' \| 'apple'` | Yes | OAuth provider to mock |
+| scenario | `OAuthScenario` | Yes | Test scenario (success, error, etc.) |
+| email | string | No | Custom email for mock user (default: auto-generated) |
+| name | string | No | Custom display name (default: "Test User") |
+| picture | string | No | Custom avatar URL |
+| emailVerified | boolean | No | Whether email is verified (default: true) |
+| isPrivateRelay | boolean | No | Apple "Hide My Email" mode (default: false) |
+| delay | number | No | Artificial delay in ms (default: 0) |
+
+### OAuthScenario
+
+Enumeration of testable scenarios.
+
+| Value | Description | Expected Frontend Behavior |
+|-------|-------------|---------------------------|
+| `success` | Successful OAuth authentication | Redirect to onboarding/topics |
+| `cancel` | User cancelled OAuth flow | Show "cancelled" message, return to signup |
+| `invalid-state` | CSRF token mismatch | Show security error |
+| `expired-code` | Authorization code expired | Show "expired" error, prompt retry |
+| `network-error` | Network failure during callback | Show network error with retry |
+| `server-error` | Backend returned 500 | Show server error message |
+
+### MockOAuthTokens
+
+Simulated token response from OAuth provider.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| accessToken | string | Mock bearer token |
+| idToken | string | Mock JWT with user claims |
+| refreshToken | string | Mock refresh token |
+| expiresIn | number | Token lifetime in seconds (default: 3600) |
+| tokenType | `'Bearer'` | Always "Bearer" |
+| scope | string | OAuth scopes granted |
+
+### MockGoogleProfile
+
+Simulated Google user profile.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| email | string | User's email address |
+| emailVerified | boolean | Whether email is verified |
+| name | string | Full name |
+| givenName | string | First name |
+| familyName | string | Last name |
+| picture | string | Avatar URL |
+| googleId | string | Unique Google user ID |
+
+### MockAppleProfile
+
+Simulated Apple user profile.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| email | string | User's email (real or privaterelay) |
+| emailVerified | boolean | Always true for Apple |
+| name | string | Full name (may be empty after first auth) |
+| appleId | string | Unique Apple user ID |
+| isPrivateEmail | boolean | Whether using Hide My Email |
+| realUserStatus | `0 \| 1 \| 2` | User authenticity indicator |
+
+---
+
+## State Management
+
+### OAuthStateStore
+
+In-memory store for CSRF state tokens during tests.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| stateToken | string | Generated CSRF token |
+| provider | `'google' \| 'apple'` | OAuth provider |
+| createdAt | Date | When state was created |
+| visitorSessionId | string? | Optional visitor session to link |
+| redirectUrl | string? | Where to redirect after success |
+
+**Lifecycle**:
+1. Created when `initiateOAuth()` is called
+2. Validated when `handleOAuthCallback()` is called
+3. Deleted after validation (used only once)
+4. Auto-expires after 10 minutes
+
+---
+
+## Validation Rules
+
+### Email Validation
+- Must be valid email format
+- For Apple private relay: must match `*@privaterelay.appleid.com`
+- Normalized to lowercase before storage
+
+### State Token Validation
+- Must be non-empty string
+- Must match token stored during initiation
+- Must not be older than 10 minutes
+
+### Authorization Code Validation (Mock Mode)
+- Must start with `mock_code_` prefix when `AUTH_MOCK=true`
+- Real codes rejected in mock mode (security)
+
+---
+
+## Relationships
+
+```
+OAuthMockConfig
+    │
+    ├──> MockOAuthTokens (generated on success)
+    │
+    ├──> MockGoogleProfile (for Google provider)
+    │
+    └──> MockAppleProfile (for Apple provider)
+
+OAuthStateStore
+    │
+    └──> Links to VisitorSession (optional)
+```
+
+---
+
+## Test Data Generators
+
+### generateMockEmail()
+```
+Pattern: `oauth-test-{timestamp}@example.com`
+Example: `oauth-test-1706367600000@example.com`
+```
+
+### generateAppleRelayEmail()
+```
+Pattern: `{random}@privaterelay.appleid.com`
+Example: `abc123def456@privaterelay.appleid.com`
+```
+
+### generateMockStateToken()
+```
+Pattern: `mock_state_{random}_{timestamp}`
+Example: `mock_state_abc123_1706367600000`
+```
+
+### generateMockAuthCode()
+```
+Pattern: `mock_code_{provider}_{timestamp}`
+Example: `mock_code_google_1706367600000`
+```

--- a/specs/009-oauth-e2e-tests/plan.md
+++ b/specs/009-oauth-e2e-tests/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: OAuth2 E2E Test Infrastructure
+
+**Branch**: `009-oauth-e2e-tests` | **Date**: 2026-01-27 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/009-oauth-e2e-tests/spec.md`
+
+## Summary
+
+Enable 650+ lines of existing OAuth E2E tests (currently skipped in `frontend/e2e/oauth-flow.spec.ts`) by implementing mock OAuth provider infrastructure using Playwright's route interception. The backend already supports mocked authentication (`AUTH_MOCK=true`), so the solution focuses on mocking OAuth provider responses at the browser/API level.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (Node.js 20 LTS)
+**Primary Dependencies**: Playwright 1.57+, @playwright/test, Vitest (for unit tests of mock utilities)
+**Storage**: N/A (mock data in-memory during tests)
+**Testing**: Playwright E2E tests, Vitest unit tests for mock utilities
+**Target Platform**: Docker E2E environment (linux/amd64), Jenkins CI
+**Project Type**: Web application (monorepo with frontend + backend services)
+**Performance Goals**: Individual tests complete within 30 seconds, full OAuth suite within 5 minutes
+**Constraints**: <50MB additional Docker image size, must work with existing E2E infrastructure
+**Scale/Scope**: 29 OAuth tests across 9 test categories (Google OAuth, Apple OAuth, Error Handling, Account Linking, UI/UX, Responsive, Accessibility, Security)
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code Quality | ✅ PASS | TypeScript strict mode, linting enforced |
+| II. Testing Standards | ✅ PASS | Tests exist, need enabling. Coverage maintained. |
+| III. User Experience | ✅ PASS | Testing UX flows, not changing them |
+| IV. Performance | ✅ PASS | 30s/test limit matches <3s response requirement context |
+
+**Quality Gates Compliance:**
+- Lint: Will pass existing linting rules
+- Type Check: TypeScript strict mode
+- Unit Tests: Mock utility functions will have unit tests
+- Integration Tests: Existing OAuth E2E tests serve as integration tests
+- Code Review: Required per branch protection
+
+**No violations requiring justification.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-oauth-e2e-tests/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (mock data structures)
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (mock OAuth endpoints)
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/
+├── e2e/
+│   ├── oauth-flow.spec.ts        # EXISTING - currently skipped, will enable
+│   ├── fixtures/                 # NEW - test fixtures
+│   │   └── oauth-mock.fixture.ts # OAuth mock fixture for Playwright
+│   └── utils/                    # NEW - test utilities
+│       ├── oauth-mock.ts         # Mock OAuth provider utilities
+│       └── oauth-mock.test.ts    # Unit tests for mock utilities
+├── src/
+│   └── lib/
+│       └── oauth-config.ts       # MODIFY - add E2E mode detection
+└── playwright.config.ts          # MODIFY - add OAuth mock setup
+
+services/user-service/
+└── src/
+    └── auth/
+        └── mock-oauth.controller.ts  # NEW - mock OAuth callback endpoints
+```
+
+**Structure Decision**: Uses existing monorepo structure. New code goes in:
+1. `frontend/e2e/fixtures/` - Playwright fixtures for mock setup
+2. `frontend/e2e/utils/` - Reusable mock utilities
+3. `services/user-service/src/auth/` - Backend mock OAuth endpoints (if needed)
+
+## Implementation Approach
+
+### Option A: Playwright Route Interception (RECOMMENDED)
+
+Use Playwright's `page.route()` to intercept OAuth provider requests and return mock responses. This approach:
+- Requires no backend changes
+- Works with existing `AUTH_MOCK=true` setup
+- Tests the actual frontend OAuth handling code
+- Easy to configure per-test scenarios
+
+### Option B: Mock OAuth Server Container
+
+Add a dedicated mock OAuth server container to docker-compose.e2e.yml. This approach:
+- More realistic simulation
+- Higher complexity (new container, ~50MB)
+- Requires frontend URL configuration changes
+
+**Selected Approach**: Option A - Playwright route interception provides sufficient coverage with lower complexity.
+
+## Complexity Tracking
+
+> No violations found. Table left empty per template instructions.
+
+## Phase 0 Research Needs
+
+1. **Playwright route interception patterns**: Best practices for mocking OAuth flows
+2. **Google OAuth callback format**: Exact URL parameters and response structure
+3. **Apple OAuth callback format**: Including "Hide My Email" relay addresses
+4. **Existing mock auth integration**: How `AUTH_MOCK=true` works in user-service
+
+## Phase 1 Design Artifacts
+
+- `data-model.md`: Mock OAuth response structures (tokens, user profiles)
+- `contracts/oauth-mock-endpoints.yaml`: Mock endpoint specifications
+- `quickstart.md`: Developer guide to run and extend OAuth tests

--- a/specs/009-oauth-e2e-tests/quickstart.md
+++ b/specs/009-oauth-e2e-tests/quickstart.md
@@ -1,0 +1,242 @@
+# Quickstart: OAuth2 E2E Testing
+
+**Feature**: 009-oauth-e2e-tests
+**Date**: 2026-01-27
+
+## Overview
+
+This guide explains how to run and extend OAuth E2E tests using the mock OAuth infrastructure.
+
+---
+
+## Running OAuth E2E Tests
+
+### Prerequisites
+
+1. Docker and Docker Compose installed
+2. Node.js 20 LTS
+3. pnpm 9.x
+
+### Run All OAuth Tests
+
+```bash
+# From repository root
+pnpm test:e2e -- --grep "OAuth"
+```
+
+### Run Specific OAuth Test Suites
+
+```bash
+# Google OAuth tests only
+pnpm test:e2e -- --grep "Google OAuth"
+
+# Apple OAuth tests only
+pnpm test:e2e -- --grep "Apple OAuth"
+
+# Error handling tests
+pnpm test:e2e -- --grep "OAuth Error"
+
+# Account linking tests
+pnpm test:e2e -- --grep "OAuth Account Linking"
+```
+
+### Run in Docker (CI Mode)
+
+```bash
+# Start E2E environment
+docker compose -f docker-compose.e2e.yml up -d
+
+# Wait for services
+sleep 30
+
+# Run tests
+E2E_DOCKER=true pnpm test:e2e -- --grep "OAuth"
+
+# Cleanup
+docker compose -f docker-compose.e2e.yml down -v
+```
+
+---
+
+## Writing OAuth Tests
+
+### Using the OAuth Mock Fixture
+
+```typescript
+// Import the extended test with OAuth mock
+import { test, expect } from '../fixtures/oauth-mock.fixture';
+
+test.describe('My OAuth Feature', () => {
+  // Test with default config (Google, success scenario)
+  test('should complete Google OAuth signup', async ({ page }) => {
+    await page.goto('/signup');
+    await page.click('button:has-text("Google")');
+    // OAuth is automatically mocked
+    await expect(page).toHaveURL(/\/onboarding\/topics/);
+  });
+
+  // Test with custom config
+  test.use({ oauthMock: { provider: 'apple', scenario: 'success' } });
+  test('should complete Apple OAuth signup', async ({ page }) => {
+    await page.goto('/signup');
+    await page.click('button:has-text("Apple")');
+    await expect(page).toHaveURL(/\/onboarding\/topics/);
+  });
+
+  // Test error scenarios
+  test.use({ oauthMock: { provider: 'google', scenario: 'cancel' } });
+  test('should handle OAuth cancellation', async ({ page }) => {
+    await page.goto('/signup');
+    await page.click('button:has-text("Google")');
+    await expect(page.locator('text=cancelled')).toBeVisible();
+  });
+});
+```
+
+### Available Scenarios
+
+| Scenario | Description | Use Case |
+|----------|-------------|----------|
+| `success` | OAuth completes successfully | Happy path testing |
+| `cancel` | User cancels OAuth flow | Cancel button behavior |
+| `invalid-state` | CSRF token mismatch | Security testing |
+| `expired-code` | Authorization code expired | Error recovery |
+| `network-error` | Network failure | Offline/retry behavior |
+| `server-error` | Backend error | Error display |
+
+### Custom User Data
+
+```typescript
+test.use({
+  oauthMock: {
+    provider: 'google',
+    scenario: 'success',
+    email: 'custom@example.com',
+    name: 'Custom User',
+    emailVerified: true,
+  },
+});
+```
+
+### Apple Private Relay Email
+
+```typescript
+test.use({
+  oauthMock: {
+    provider: 'apple',
+    scenario: 'success',
+    isPrivateRelay: true, // Generates @privaterelay.appleid.com email
+  },
+});
+```
+
+---
+
+## Mock Architecture
+
+### How It Works
+
+1. **Test starts**: Playwright fixture intercepts OAuth routes
+2. **User clicks OAuth button**: Frontend calls `/auth/oauth/initiate`
+3. **Route intercepted**: Mock returns callback URL (not real Google/Apple)
+4. **Frontend redirects**: To our mock callback URL
+5. **Backend processes**: Mock callback handler creates user, returns tokens
+6. **Test continues**: User is authenticated, can verify UI state
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `frontend/e2e/fixtures/oauth-mock.fixture.ts` | Playwright fixture for mocking |
+| `frontend/e2e/utils/oauth-mock.ts` | Mock data generators |
+| `frontend/e2e/oauth-flow.spec.ts` | OAuth test suite |
+| `services/user-service/src/auth/auth.service.ts` | Backend OAuth handling |
+
+---
+
+## Debugging OAuth Tests
+
+### Enable Verbose Logging
+
+```bash
+DEBUG=pw:api pnpm test:e2e -- --grep "OAuth"
+```
+
+### Check Network Requests
+
+```typescript
+test('debug oauth flow', async ({ page }) => {
+  // Log all network requests
+  page.on('request', (req) => console.log('Request:', req.url()));
+  page.on('response', (res) => console.log('Response:', res.url(), res.status()));
+
+  await page.goto('/signup');
+  await page.click('button:has-text("Google")');
+});
+```
+
+### Inspect Mock Data
+
+```typescript
+test('inspect mock tokens', async ({ page }) => {
+  await page.goto('/signup');
+  await page.click('button:has-text("Google")');
+
+  // Check stored tokens
+  const tokens = await page.evaluate(() => ({
+    access: localStorage.getItem('accessToken'),
+    refresh: localStorage.getItem('refreshToken'),
+  }));
+  console.log('Stored tokens:', tokens);
+});
+```
+
+### Run Single Test with Trace
+
+```bash
+pnpm test:e2e -- --grep "Google OAuth signup" --trace on
+```
+
+Then open the trace viewer:
+```bash
+npx playwright show-trace frontend/test-results/*/trace.zip
+```
+
+---
+
+## Common Issues
+
+### Tests Timeout Waiting for Google
+
+**Symptom**: Test hangs at Google login page
+**Cause**: Mock routes not set up correctly
+**Fix**: Ensure using `oauth-mock.fixture.ts` test import
+
+### Invalid State Token Error
+
+**Symptom**: Backend rejects OAuth callback
+**Cause**: State token mismatch
+**Fix**: Verify mock returns same state token in callback
+
+### User Not Created
+
+**Symptom**: OAuth succeeds but user data missing
+**Cause**: Backend not in mock mode
+**Fix**: Verify `AUTH_MOCK=true` in E2E environment
+
+### Apple Relay Email Rejected
+
+**Symptom**: Apple OAuth fails with relay email
+**Cause**: Email validation too strict
+**Fix**: Check email validation accepts `@privaterelay.appleid.com`
+
+---
+
+## Best Practices
+
+1. **Use fixtures**: Always import from `oauth-mock.fixture.ts`, not standard Playwright
+2. **One scenario per test**: Don't combine success and error scenarios
+3. **Reset state**: Each test should start from signup page
+4. **Verify UI state**: Check visible elements, not just URL
+5. **Test both providers**: Google and Apple may have different edge cases
+6. **Include error scenarios**: Don't just test happy path

--- a/specs/009-oauth-e2e-tests/research.md
+++ b/specs/009-oauth-e2e-tests/research.md
@@ -1,0 +1,266 @@
+# Research: OAuth2 E2E Test Infrastructure
+
+**Feature**: 009-oauth-e2e-tests
+**Date**: 2026-01-27
+
+## Research Summary
+
+This document captures research findings for enabling OAuth E2E tests. All clarification items have been resolved.
+
+---
+
+## 1. Current OAuth Architecture
+
+### Decision: Use Hybrid Approach (Frontend Route Interception + Backend Mock Mode)
+
+### Findings
+
+**Backend OAuth Flow** (`services/user-service/src/auth/auth.service.ts`):
+- `initiateOAuth()` - Generates OAuth URL with state token (calls `GoogleOAuthService.generateAuthUrl()`)
+- `handleOAuthCallback()` - Exchanges authorization code for tokens and user profile
+
+**OAuth Provider Services**:
+- `GoogleOAuthService` - Uses `google-auth-library` to call real Google OAuth APIs
+- `AppleOAuthService` - Calls real Apple Sign-In APIs
+- Both generate state tokens for CSRF protection
+
+**Mock Auth Service** (`mock-auth.service.ts`):
+- Mocks email/password authentication only
+- Does NOT mock OAuth flows
+- Uses `AUTH_MOCK=true` environment variable
+
+### The Problem
+When E2E tests click "Sign in with Google", the flow is:
+1. Frontend calls `/auth/oauth/initiate?provider=google`
+2. Backend returns real Google OAuth URL (`accounts.google.com/...`)
+3. Playwright navigates to Google's real login page
+4. Tests timeout waiting for interaction with real Google
+
+### Solution
+Mock at **two levels**:
+1. **Playwright route interception**: Catch OAuth initiation and return mock auth URL pointing to our callback
+2. **Backend mock OAuth callback**: Add mock endpoint that accepts mock authorization codes
+
+---
+
+## 2. Playwright Route Interception Patterns
+
+### Decision: Use Page Fixture with Route Interception
+
+### Rationale
+- Playwright's `page.route()` can intercept requests matching patterns
+- Can return mock responses without actual network calls
+- Per-test configuration enables different scenarios (success, error, cancellation)
+
+### Implementation Pattern
+
+```typescript
+// frontend/e2e/fixtures/oauth-mock.fixture.ts
+import { test as base, Page } from '@playwright/test';
+
+export interface OAuthMockConfig {
+  provider: 'google' | 'apple';
+  scenario: 'success' | 'cancel' | 'error' | 'invalid-state';
+  email?: string;
+  name?: string;
+}
+
+export const test = base.extend<{ oauthMock: OAuthMockConfig }>({
+  oauthMock: [{ provider: 'google', scenario: 'success' }, { option: true }],
+
+  page: async ({ page, oauthMock }, use) => {
+    // Intercept OAuth initiation requests
+    await page.route('**/auth/oauth/initiate**', async (route) => {
+      const mockCallbackUrl = `/auth/callback/${oauthMock.provider}?code=mock_code_${Date.now()}&state=mock_state`;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          authUrl: mockCallbackUrl, // Redirect to our mock callback, not Google
+          state: 'mock_state',
+          provider: oauthMock.provider,
+        }),
+      });
+    });
+
+    await use(page);
+  },
+});
+```
+
+### Alternatives Considered
+
+| Alternative | Pros | Cons | Rejected Because |
+|------------|------|------|------------------|
+| Mock OAuth server container | Realistic simulation | +50MB image, complex setup | Overkill for test coverage needed |
+| Real OAuth with test accounts | Most realistic | Requires credentials, rate limits, flaky | Security risk, maintenance burden |
+| Skip OAuth tests entirely | No work required | No coverage | Defeats purpose of E2E testing |
+
+---
+
+## 3. Google OAuth Response Format
+
+### Decision: Match Google's OpenID Connect token structure
+
+### Token Structure
+
+```typescript
+interface GoogleOAuthTokens {
+  access_token: string;      // Bearer token for API calls
+  id_token: string;          // JWT with user info
+  refresh_token: string;     // For token refresh
+  expires_in: number;        // Typically 3600 (1 hour)
+  token_type: 'Bearer';
+  scope: string;             // 'openid email profile'
+}
+
+interface GoogleIdTokenPayload {
+  iss: 'https://accounts.google.com';
+  azp: string;               // Client ID
+  aud: string;               // Client ID
+  sub: string;               // Unique Google user ID
+  email: string;
+  email_verified: boolean;
+  name: string;
+  picture: string;
+  given_name: string;
+  family_name: string;
+  iat: number;               // Issued at timestamp
+  exp: number;               // Expiration timestamp
+}
+```
+
+### Mock Implementation
+
+The backend `GoogleOAuthService.verifyAndGetProfile()` extracts:
+- `email` from ID token
+- `emailVerified` from `email_verified` claim
+- `name` from `name` claim
+- `picture` from `picture` claim
+- `googleId` from `sub` claim
+
+Mock must provide these fields to satisfy backend processing.
+
+---
+
+## 4. Apple OAuth Response Format
+
+### Decision: Support both real email and private relay email
+
+### Apple Callback Parameters
+
+```typescript
+interface AppleOAuthCallback {
+  code: string;              // Authorization code
+  id_token: string;          // JWT with user info
+  state: string;             // CSRF token
+  user?: string;             // JSON string with user info (first auth only)
+}
+
+interface AppleIdTokenPayload {
+  iss: 'https://appleid.apple.com';
+  aud: string;               // Client ID
+  sub: string;               // Unique Apple user ID
+  email: string;             // Real or private relay email
+  email_verified: 'true';    // String, not boolean
+  is_private_email?: 'true'; // Present if using Hide My Email
+  real_user_status?: 0 | 1 | 2; // Likely real (2), unknown (1), unsupported (0)
+  auth_time: number;
+  nonce_supported: boolean;
+}
+```
+
+### Private Relay Email Format
+Apple's "Hide My Email" generates addresses like:
+- `{random}@privaterelay.appleid.com`
+
+The mock must test this scenario to ensure the backend accepts relay addresses.
+
+---
+
+## 5. Backend Mock OAuth Integration
+
+### Decision: Add mock OAuth mode to user-service
+
+### Current Behavior
+`AUTH_MOCK=true` enables `MockAuthService` for email/password auth but OAuth still calls real providers.
+
+### Required Changes
+Add mock OAuth handling when `AUTH_MOCK=true`:
+
+```typescript
+// In auth.service.ts handleOAuthCallback()
+if (this.configService.get('AUTH_MOCK') === 'true') {
+  // Accept mock authorization codes
+  if (query.code.startsWith('mock_code_')) {
+    return this.handleMockOAuthCallback(provider, query);
+  }
+}
+```
+
+Mock callback generates:
+- Synthetic user profile from mock data
+- JWT tokens using `MockAuthService` token generation
+- Proper onboarding progress
+
+---
+
+## 6. Error Scenario Mocking
+
+### Decision: Support 6 error scenarios via configuration
+
+| Scenario | How to Trigger | Expected Behavior |
+|----------|---------------|-------------------|
+| User cancellation | `?error=access_denied` | Show "cancelled" message |
+| Invalid state (CSRF) | Mismatched state token | Show security error |
+| Expired code | Backend rejects stale code | Prompt to retry |
+| Network error | Route returns network failure | Show retry option |
+| Server error | Route returns 500 | Show server error message |
+| Rate limited | Route returns 429 | Show rate limit message |
+
+### Implementation
+
+```typescript
+await page.route('**/auth/callback/**', async (route) => {
+  switch (oauthMock.scenario) {
+    case 'cancel':
+      await route.fulfill({
+        status: 302,
+        headers: { location: '/signup?error=access_denied' },
+      });
+      break;
+    case 'invalid-state':
+      await route.continue(); // Let backend reject mismatched state
+      break;
+    // ... other scenarios
+  }
+});
+```
+
+---
+
+## Key Decisions Summary
+
+| Area | Decision | Rationale |
+|------|----------|-----------|
+| Mock approach | Playwright route interception | Lowest complexity, sufficient coverage |
+| Backend changes | Add mock OAuth callback handler | Enables realistic callback testing |
+| Token format | Match real provider structure | Ensures frontend handles real tokens |
+| Error scenarios | 6 configurable scenarios | Comprehensive error coverage |
+| Apple relay email | Explicitly test | Critical UX scenario for iOS users |
+
+---
+
+## Dependencies
+
+- **Playwright 1.57+**: Required for route interception
+- **@playwright/test**: Test framework with fixtures
+- **jsonwebtoken**: For mock JWT generation (already in user-service)
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Mock diverges from real OAuth | Periodically validate mock against real provider responses |
+| Tests pass but real OAuth broken | Keep one manual OAuth test in staging environment |
+| State token validation bypassed | Ensure mock validates state matches what frontend sent |

--- a/specs/009-oauth-e2e-tests/spec.md
+++ b/specs/009-oauth-e2e-tests/spec.md
@@ -1,0 +1,139 @@
+# Feature Specification: OAuth2 E2E Test Infrastructure
+
+**Feature Branch**: `009-oauth-e2e-tests`
+**Created**: 2026-01-27
+**Status**: Draft
+**Input**: User description: "Implement comprehensive OAuth2 end-to-end tests for the authentication system"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Enable OAuth E2E Tests in CI (Priority: P1)
+
+As a **developer**, I want OAuth E2E tests to run reliably in the CI pipeline so that OAuth authentication flows are validated automatically on every pull request.
+
+**Why this priority**: Currently, 650+ lines of OAuth E2E tests exist (`frontend/e2e/oauth-flow.spec.ts`) but are **completely skipped** due to inability to interact with real OAuth providers in CI. Enabling these tests is the highest priority because it provides immediate value without writing new tests.
+
+**Independent Test**: Can be fully tested by running `pnpm test:e2e --grep "OAuth"` in CI and verifying all tests pass. Delivers immediate regression protection for OAuth flows.
+
+**Acceptance Scenarios**:
+
+1. **Given** the CI pipeline runs E2E tests, **When** OAuth tests execute, **Then** all OAuth test suites complete without timeouts or skips
+2. **Given** a PR modifies OAuth-related code, **When** CI runs, **Then** OAuth E2E tests catch regressions before merge
+3. **Given** mock OAuth providers are configured, **When** tests simulate OAuth flows, **Then** the full authentication journey completes within 30 seconds per test
+
+---
+
+### User Story 2 - Mock Google OAuth Provider (Priority: P1)
+
+As a **developer**, I want a mock Google OAuth provider that simulates the complete OAuth flow so that E2E tests can verify Google sign-in without requiring real Google credentials.
+
+**Why this priority**: Google OAuth is the primary OAuth provider. Without a mock, all Google-related tests remain disabled, leaving a critical authentication path untested.
+
+**Independent Test**: Can be tested by running Google OAuth test suite and verifying sign-in, token exchange, and user profile retrieval work with mock responses.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user clicks "Sign in with Google", **When** the OAuth flow initiates, **Then** the mock provider returns a valid authorization URL with state token
+2. **Given** a valid authorization code, **When** the callback handler processes it, **Then** mock tokens (access, refresh, ID token) are returned
+3. **Given** a mock ID token, **When** the backend verifies it, **Then** user profile data (email, name, picture) is extracted correctly
+4. **Given** the user cancels Google OAuth, **When** the callback receives an error, **Then** an appropriate error message is displayed
+
+---
+
+### User Story 3 - Mock Apple OAuth Provider (Priority: P2)
+
+As a **developer**, I want a mock Apple OAuth provider that simulates Apple Sign-In so that E2E tests can verify Apple authentication including the "Hide My Email" feature.
+
+**Why this priority**: Apple OAuth is a secondary provider but important for iOS users. Testing the "Hide My Email" relay address handling requires specific mock behavior.
+
+**Independent Test**: Can be tested by running Apple OAuth test suite and verifying sign-in works with both real and relay email addresses.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user clicks "Sign in with Apple", **When** the OAuth flow initiates, **Then** the mock provider returns a valid authorization URL
+2. **Given** Apple returns a relay email (privaterelay.appleid.com), **When** the user is created, **Then** the relay email is accepted as a valid verified email
+3. **Given** Apple OAuth succeeds, **When** user data is stored, **Then** the Apple user ID is correctly associated with the account
+
+---
+
+### User Story 4 - OAuth Error Scenario Testing (Priority: P2)
+
+As a **developer**, I want to test OAuth error scenarios (network failures, expired tokens, CSRF attacks) so that error handling is verified and users see appropriate messages.
+
+**Why this priority**: Error handling is critical for security and user experience. Mock providers must simulate failure modes.
+
+**Independent Test**: Can be tested by triggering each error scenario and verifying the UI displays correct error messages and maintains secure state.
+
+**Acceptance Scenarios**:
+
+1. **Given** a network error during OAuth, **When** the error is caught, **Then** a user-friendly "network error" message appears with retry option
+2. **Given** an invalid/expired state token (CSRF attack), **When** the callback processes it, **Then** the request is rejected with a security error
+3. **Given** an expired authorization code, **When** token exchange fails, **Then** the user is prompted to restart the OAuth flow
+4. **Given** the OAuth server returns a 500 error, **When** the callback handles it, **Then** a "server error" message appears
+
+---
+
+### User Story 5 - OAuth Account Linking (Priority: P3)
+
+As a **developer**, I want to test OAuth account linking scenarios so that users signing in with OAuth using an existing email address are handled correctly.
+
+**Why this priority**: Account linking is an edge case but important for users who create an account with email/password then later try OAuth with the same email.
+
+**Independent Test**: Can be tested by creating an email/password account, then attempting OAuth with the same email and verifying appropriate handling.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has an existing email/password account, **When** they attempt OAuth with the same email, **Then** they are prompted to link accounts or shown an "account exists" message
+2. **Given** account linking is successful, **When** the user logs in again, **Then** both OAuth and email/password methods work for the same account
+
+---
+
+### Edge Cases
+
+- What happens when OAuth state token expires between initiation and callback (typically 10 minutes)?
+- How does the system handle OAuth callback with missing required parameters (code, state)?
+- What happens if the same authorization code is used twice (replay attack)?
+- How does the system behave when localStorage is unavailable (private browsing)?
+- What happens during OAuth flow if the user's session expires on the backend?
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a mock OAuth server that responds to OAuth initiation requests with valid authorization URLs
+- **FR-002**: System MUST return mock tokens (access token, refresh token, ID token) when processing valid authorization codes
+- **FR-003**: Mock OAuth server MUST support configurable responses for testing success and error scenarios
+- **FR-004**: Mock OAuth server MUST validate state tokens to test CSRF protection
+- **FR-005**: Mock Google OAuth MUST return user profiles with email, name, picture, and Google ID
+- **FR-006**: Mock Apple OAuth MUST support both real email and privaterelay.appleid.com addresses
+- **FR-007**: System MUST allow tests to configure mock responses per-test for isolated testing
+- **FR-008**: Mock OAuth server MUST simulate realistic timing (configurable delays) to test loading states
+- **FR-009**: System MUST support running mock OAuth server alongside the E2E test environment
+- **FR-010**: All previously skipped OAuth tests (650+ lines in oauth-flow.spec.ts) MUST be enabled and passing
+
+### Key Entities
+
+- **Mock OAuth Server**: A test-time HTTP server that simulates Google/Apple OAuth endpoints
+- **OAuth State Store**: Temporary storage for state tokens during the OAuth flow (validates CSRF protection)
+- **Mock User Profile**: Configurable user data returned by mock OAuth providers (email, name, picture, provider ID)
+- **Mock Token Set**: Access token, refresh token, and ID token with configurable expiration
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: All 29 OAuth E2E tests in `oauth-flow.spec.ts` pass in CI (currently 0 passing due to skip)
+- **SC-002**: OAuth E2E test suite completes within 5 minutes total in CI
+- **SC-003**: Individual OAuth test cases complete within 30 seconds each
+- **SC-004**: 100% of OAuth error scenarios have corresponding passing tests
+- **SC-005**: OAuth tests run reliably without flakiness (>99% pass rate across 100 consecutive runs)
+- **SC-006**: No real OAuth provider credentials are required to run E2E tests
+- **SC-007**: Mock OAuth infrastructure adds less than 50MB to Docker E2E environment
+
+## Assumptions
+
+- The existing `oauth-flow.spec.ts` tests are well-designed and don't need rewriting, only enabling
+- Mock OAuth server can run as a separate container in the E2E Docker Compose environment
+- The frontend OAuth callback handlers will work correctly with mock provider URLs
+- State token validation logic already exists and just needs a mock server to test against
+- The existing test helpers (`simulateOAuthCallback`, `generateMockOAuthTokens`) provide a good foundation

--- a/specs/009-oauth-e2e-tests/tasks.md
+++ b/specs/009-oauth-e2e-tests/tasks.md
@@ -1,0 +1,281 @@
+# Tasks: OAuth2 E2E Test Infrastructure
+
+**Input**: Design documents from `/specs/009-oauth-e2e-tests/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests for mock utilities are included as they are explicitly part of the implementation plan (Vitest for mock utility functions).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Frontend E2E**: `frontend/e2e/` - Playwright tests and fixtures
+- **Frontend Utils**: `frontend/e2e/utils/` - Mock utilities
+- **Backend Auth**: `services/user-service/src/auth/` - Auth service modifications
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create directory structure and base types for OAuth mocking
+
+- [ ] T001 Create fixtures directory at `frontend/e2e/fixtures/`
+- [ ] T002 Create utils directory at `frontend/e2e/utils/`
+- [ ] T003 [P] Create TypeScript type definitions for OAuthMockConfig in `frontend/e2e/utils/oauth-types.ts`
+- [ ] T004 [P] Create TypeScript type definitions for OAuthScenario enum in `frontend/e2e/utils/oauth-types.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core mock utilities and fixtures that ALL user stories depend on
+
+**⚠️ CRITICAL**: No OAuth test work can begin until this phase is complete
+
+- [ ] T005 Implement mock data generators (generateMockEmail, generateMockStateToken, generateMockAuthCode) in `frontend/e2e/utils/oauth-mock.ts`
+- [ ] T006 Implement MockOAuthTokens generator in `frontend/e2e/utils/oauth-mock.ts`
+- [ ] T007 [P] Write unit tests for mock data generators in `frontend/e2e/utils/oauth-mock.test.ts`
+- [ ] T008 Create base Playwright fixture with route interception in `frontend/e2e/fixtures/oauth-mock.fixture.ts`
+- [ ] T009 Implement OAuth initiation route interception (`**/auth/oauth/initiate**`) in `frontend/e2e/fixtures/oauth-mock.fixture.ts`
+- [ ] T010 Add mock OAuth callback handler to AuthService when AUTH_MOCK=true in `services/user-service/src/auth/auth.service.ts`
+- [ ] T011 Verify AUTH_MOCK=true is set in `docker-compose.e2e.yml` for user-service
+
+**Checkpoint**: Foundation ready - OAuth mock infrastructure is in place
+
+---
+
+## Phase 3: User Story 1 - Enable OAuth E2E Tests in CI (Priority: P1) 🎯 MVP
+
+**Goal**: Remove `test.describe.skip` and enable all OAuth tests to run in CI with mock infrastructure
+
+**Independent Test**: Run `pnpm test:e2e --grep "OAuth"` and verify all 29 tests pass without timeouts
+
+### Implementation for User Story 1
+
+- [ ] T012 [US1] Import oauth-mock.fixture in `frontend/e2e/oauth-flow.spec.ts` replacing standard test import
+- [ ] T013 [US1] Replace `test.describe.skip` with `test.describe` in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T014 [US1] Update test helper `simulateOAuthCallback` to use fixture's mock route in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T015 [US1] Run OAuth tests locally to verify they execute (not necessarily pass yet)
+- [ ] T016 [US1] Fix any test selector issues due to UI changes since tests were written in `frontend/e2e/oauth-flow.spec.ts`
+
+**Checkpoint**: OAuth tests run in CI (may have failures, but no longer skipped/timing out)
+
+---
+
+## Phase 4: User Story 2 - Mock Google OAuth Provider (Priority: P1)
+
+**Goal**: Implement complete Google OAuth mock so all Google-related tests pass
+
+**Independent Test**: Run `pnpm test:e2e --grep "Google OAuth"` and verify all Google tests pass
+
+### Implementation for User Story 2
+
+- [ ] T017 [P] [US2] Implement MockGoogleProfile generator in `frontend/e2e/utils/oauth-mock.ts`
+- [ ] T018 [P] [US2] Write unit test for MockGoogleProfile generator in `frontend/e2e/utils/oauth-mock.test.ts`
+- [ ] T019 [US2] Implement Google-specific route interception for OAuth callback in `frontend/e2e/fixtures/oauth-mock.fixture.ts`
+- [ ] T020 [US2] Add handleMockGoogleOAuthCallback method in `services/user-service/src/auth/auth.service.ts`
+- [ ] T021 [US2] Verify Google OAuth success scenario test passes in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T022 [US2] Verify Google OAuth cancellation test passes in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T023 [US2] Verify Google OAuth auto-verify email test passes in `frontend/e2e/oauth-flow.spec.ts`
+
+**Checkpoint**: All 9 Google OAuth tests pass
+
+---
+
+## Phase 5: User Story 3 - Mock Apple OAuth Provider (Priority: P2)
+
+**Goal**: Implement complete Apple OAuth mock including "Hide My Email" relay addresses
+
+**Independent Test**: Run `pnpm test:e2e --grep "Apple OAuth"` and verify all Apple tests pass
+
+### Implementation for User Story 3
+
+- [ ] T024 [P] [US3] Implement MockAppleProfile generator with private relay support in `frontend/e2e/utils/oauth-mock.ts`
+- [ ] T025 [P] [US3] Implement generateAppleRelayEmail function in `frontend/e2e/utils/oauth-mock.ts`
+- [ ] T026 [P] [US3] Write unit tests for Apple mock generators in `frontend/e2e/utils/oauth-mock.test.ts`
+- [ ] T027 [US3] Implement Apple-specific route interception for OAuth callback in `frontend/e2e/fixtures/oauth-mock.fixture.ts`
+- [ ] T028 [US3] Add handleMockAppleOAuthCallback method in `services/user-service/src/auth/auth.service.ts`
+- [ ] T029 [US3] Verify Apple OAuth success scenario test passes in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T030 [US3] Verify Apple OAuth cancellation test passes in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T031 [US3] Verify Apple "Hide My Email" relay email test passes in `frontend/e2e/oauth-flow.spec.ts`
+
+**Checkpoint**: All 5 Apple OAuth tests pass
+
+---
+
+## Phase 6: User Story 4 - OAuth Error Scenario Testing (Priority: P2)
+
+**Goal**: Enable all error scenario tests (network failures, expired tokens, CSRF attacks)
+
+**Independent Test**: Run `pnpm test:e2e --grep "OAuth Error"` and verify all error tests pass
+
+### Implementation for User Story 4
+
+- [ ] T032 [P] [US4] Add `scenario` configuration support for error cases in `frontend/e2e/fixtures/oauth-mock.fixture.ts`
+- [ ] T033 [US4] Implement network error simulation via route.abort() in `frontend/e2e/fixtures/oauth-mock.fixture.ts`
+- [ ] T034 [US4] Implement server error simulation (500 response) in `frontend/e2e/fixtures/oauth-mock.fixture.ts`
+- [ ] T035 [US4] Implement expired state token scenario in `frontend/e2e/fixtures/oauth-mock.fixture.ts`
+- [ ] T036 [US4] Verify network error test passes in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T037 [US4] Verify server error test passes in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T038 [US4] Verify expired state token test passes in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T039 [US4] Verify invalid state token (CSRF) test passes in `frontend/e2e/oauth-flow.spec.ts`
+
+**Checkpoint**: All 7 OAuth error handling tests pass
+
+---
+
+## Phase 7: User Story 5 - OAuth Account Linking (Priority: P3)
+
+**Goal**: Enable account linking tests (existing email + OAuth)
+
+**Independent Test**: Run `pnpm test:e2e --grep "OAuth Account Linking"` and verify linking tests pass
+
+### Implementation for User Story 5
+
+- [ ] T040 [US5] Configure test to create email/password account before OAuth attempt in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T041 [US5] Implement mock response for "account exists" scenario in `frontend/e2e/fixtures/oauth-mock.fixture.ts`
+- [ ] T042 [US5] Verify account linking prompt test passes in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T043 [US5] Verify both auth methods work after linking (if implemented) in `frontend/e2e/oauth-flow.spec.ts`
+
+**Checkpoint**: Account linking tests pass (or are properly skipped if feature not implemented)
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: UI/UX tests, responsive tests, accessibility tests, security tests, and documentation
+
+- [ ] T044 [P] Verify OAuth UI tests pass (buttons visible, loading states) in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T045 [P] Verify responsive design tests pass (mobile, tablet viewports) in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T046 [P] Verify accessibility tests pass (keyboard navigation, ARIA) in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T047 [P] Verify security tests pass (tokens not in URL) in `frontend/e2e/oauth-flow.spec.ts`
+- [ ] T048 Run full OAuth test suite and verify all 29 tests pass
+- [ ] T049 Run OAuth tests 10 times consecutively to verify no flakiness
+- [ ] T050 Verify OAuth test suite completes within 5 minutes total
+- [ ] T051 Update quickstart.md with actual file paths and working examples in `specs/009-oauth-e2e-tests/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational - enables tests to run
+- **User Story 2 (Phase 4)**: Depends on User Story 1 - Google OAuth mock
+- **User Story 3 (Phase 5)**: Depends on Foundational - can run parallel to US2
+- **User Story 4 (Phase 6)**: Depends on US2 or US3 - error scenarios
+- **User Story 5 (Phase 7)**: Depends on US2 - account linking
+- **Polish (Phase 8)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+```
+Phase 1: Setup
+    ↓
+Phase 2: Foundational (BLOCKS all user stories)
+    ↓
+    ├── Phase 3: US1 - Enable Tests (P1) ← MVP
+    │       ↓
+    │   Phase 4: US2 - Google OAuth (P1)
+    │       ↓
+    │       ├── Phase 6: US4 - Error Scenarios (P2)
+    │       └── Phase 7: US5 - Account Linking (P3)
+    │
+    └── Phase 5: US3 - Apple OAuth (P2) ← Can start parallel to US2
+            ↓
+        Phase 6: US4 - Error Scenarios (can use Apple too)
+
+Phase 8: Polish (after all stories complete)
+```
+
+### Within Each User Story
+
+- Mock utilities before fixtures
+- Fixtures before test updates
+- Backend changes alongside frontend
+- Verify tests pass before moving on
+
+### Parallel Opportunities
+
+**Phase 1 (all parallel):**
+- T001, T002 (directory creation)
+- T003, T004 (type definitions)
+
+**Phase 2 (some parallel):**
+- T007 (unit tests) can run parallel to T005, T006
+
+**Phase 4-5 (US2 and US3 can run in parallel if team capacity allows):**
+- T017, T018 (Google profile) parallel
+- T024, T025, T026 (Apple profile) parallel
+
+**Phase 8 (all parallel):**
+- T044, T045, T046, T047 (UI/responsive/a11y/security tests)
+
+---
+
+## Parallel Example: Phase 4 (User Story 2)
+
+```bash
+# Launch model/utility tasks in parallel:
+Task: "Implement MockGoogleProfile generator in frontend/e2e/utils/oauth-mock.ts"
+Task: "Write unit test for MockGoogleProfile generator in frontend/e2e/utils/oauth-mock.test.ts"
+
+# Then sequentially:
+Task: "Implement Google-specific route interception"
+Task: "Add handleMockGoogleOAuthCallback method"
+Task: "Verify Google OAuth tests pass"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1 (enable tests)
+4. Complete Phase 4: User Story 2 (Google OAuth)
+5. **STOP and VALIDATE**: All Google OAuth tests should pass
+6. Deploy/demo if ready (Google is primary OAuth provider)
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. Add US1 → Tests run (may fail) → Progress visible
+3. Add US2 → Google tests pass → **MVP Complete**
+4. Add US3 → Apple tests pass → iOS users covered
+5. Add US4 → Error scenarios pass → Production ready
+6. Add US5 → Account linking pass → Edge cases covered
+7. Polish → All 29 tests pass, no flakiness → Feature complete
+
+### Success Metrics
+
+| Milestone | Tests Passing | Description |
+|-----------|---------------|-------------|
+| Foundation | 0 | Infrastructure ready |
+| US1 Complete | ~5-10 | Tests run, some pass |
+| US2 Complete | ~15 | All Google tests pass |
+| US3 Complete | ~20 | All Apple tests pass |
+| US4 Complete | ~27 | Error scenarios pass |
+| US5 Complete | ~29 | Account linking pass |
+| Feature Complete | 29/29 | 100% pass rate |
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Existing tests in `oauth-flow.spec.ts` are well-written; focus is on enabling, not rewriting
+- Backend changes are minimal (just add mock code path when AUTH_MOCK=true)
+- If tests fail after enabling, fix selectors/assertions rather than rewriting tests
+- Commit after each phase for easy rollback


### PR DESCRIPTION
## Summary

- Implement comprehensive OAuth E2E test infrastructure using Playwright route interception
- Enable 20 OAuth tests that were previously SKIPPED due to timeout issues with real OAuth providers
- Add mock utilities for generating test data (emails, tokens, profiles)
- Add TypeScript type definitions for OAuth mocking
- Add unit tests for mock utilities (33 tests)

## Key Changes

### New Files
- `e2e/fixtures/oauth-mock.fixture.ts` - Playwright fixture with `test.extend()` for per-test OAuth configuration
- `e2e/utils/oauth-mock.ts` - Mock data generators
- `e2e/utils/oauth-types.ts` - TypeScript type definitions
- `src/test/e2e-utils/oauth-mock.test.ts` - Unit tests for mock utilities

### Modified Files
- `e2e/oauth-flow.spec.ts` - Refactored to use new fixture-based approach, removed old helpers
- `src/routes/index.tsx` - Added `/signup` and `/auth/callback/:provider` routes

## Test Scenarios Covered

| Category | Tests |
|----------|-------|
| Google OAuth success/cancel/invalid-state | 3 |
| Apple OAuth success/cancel/"Hide My Email" | 3 |
| Auto-verify email | 1 |
| Error handling (network/server/expired) | 3 |
| Account linking | 1 |
| UI/UX (buttons, loading, dividers) | 3 |
| Responsive design (mobile, tablet) | 2 |
| Accessibility | 2 |
| Security (token exposure, data clearing) | 2 |
| **Total** | **20** |

## How It Works

1. **Fixture Configuration**: Tests use `test.use({ oauthMock: { provider, scenario, ... } })` to configure mock behavior
2. **Route Interception**: Fixture intercepts `/auth/oauth/initiate` and `/auth/me` API calls
3. **External OAuth Redirect**: Requests to `accounts.google.com` and `appleid.apple.com` redirect to mock callback URLs
4. **Scenario Support**: `success`, `cancel`, `invalid-state`, `expired-code`, `network-error`, `server-error`

## Test Plan

- [x] All 20 OAuth E2E tests pass locally
- [x] All 33 OAuth mock utility unit tests pass
- [x] Lint passes (0 errors)
- [x] TypeScript compilation passes
- [ ] CI pipeline passes

---

Feature: 009-oauth-e2e-tests

🤖 Generated with [Claude Code](https://claude.ai/code)