### PR TITLE
feat(infra): Add docker:test-up and docker:test-down make targets (closes #343)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: setup dev build test test-unit test-integration test-e2e lint lint-fix clean \
-        docker-up docker-down docker-test-up docker-test-down db-migrate db-studio logs
+        docker-up docker-down docker-test-up docker-test-down docker\:test-up docker\:test-down \
+        db-migrate db-studio logs
 
 # Development
 setup:
@@ -57,6 +58,11 @@ docker-test-up:
 
 docker-test-down:
 	docker-compose -f docker-compose.test.yml down -v
+
+# Alias targets with colon notation (escape colons in make)
+docker\:test-up: docker-test-up
+
+docker\:test-down: docker-test-down
 
 # Database
 db-migrate:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres-test:
     image: postgres:15-alpine


### PR DESCRIPTION
## Summary
Add colon-notation make targets (`docker:test-up`, `docker:test-down`) as aliases for the existing test Docker environment commands, matching the acceptance criteria naming convention.

## Changes Made
- `Makefile`: Added `docker:test-up` and `docker:test-down` targets as aliases for existing targets
- `docker-compose.test.yml`: Removed obsolete `version` attribute (docker compose v2 ignores this)

## Test Environment Features
The existing `docker-compose.test.yml` already provides:
- **PostgreSQL 15** on port 5433 (isolated from dev on 5432)
- **Redis 7** on port 6380 (isolated from dev on 6379)
- **LocalStack** on port 4567 (isolated from dev on 4566)
- **tmpfs** for PostgreSQL data (ephemeral, faster tests)
- **Healthchecks** for all services

## Test Results
```bash
$ make -n docker:test-up
docker-compose -f docker-compose.test.yml up -d

$ make -n docker:test-down
docker-compose -f docker-compose.test.yml down -v
```

## Testing Instructions
```bash
# Start test environment
make docker:test-up

# Verify containers are running
docker ps | grep unite.*test

# Stop and clean up
make docker:test-down
```

## Breaking Changes
None

Fixes #343

Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>