### PR TITLE
feat(feedback): Add ToneIndicator visualization component (#107)

### DIFF
--- a/frontend/src/components/feedback/ToneIndicator.tsx
+++ b/frontend/src/components/feedback/ToneIndicator.tsx
@@ -1,0 +1,248 @@
+import React from 'react';
+import type { ToneIndicatorProps, ToneLevel } from '../../types/feedback';
+
+/**
+ * Configuration for each tone level
+ */
+const TONE_CONFIG: Record<
+  ToneLevel,
+  {
+    label: string;
+    color: string;
+    bgColor: string;
+    borderColor: string;
+    description: string;
+    position: number;
+  }
+> = {
+  calm: {
+    label: 'Calm',
+    color: 'text-green-700',
+    bgColor: 'bg-green-500',
+    borderColor: 'border-green-500',
+    description: 'Constructive and measured tone',
+    position: 0,
+  },
+  neutral: {
+    label: 'Neutral',
+    color: 'text-blue-700',
+    bgColor: 'bg-blue-500',
+    borderColor: 'border-blue-500',
+    description: 'Balanced and objective tone',
+    position: 25,
+  },
+  assertive: {
+    label: 'Assertive',
+    color: 'text-yellow-700',
+    bgColor: 'bg-yellow-500',
+    borderColor: 'border-yellow-500',
+    description: 'Strong but respectful tone',
+    position: 50,
+  },
+  heated: {
+    label: 'Heated',
+    color: 'text-orange-700',
+    bgColor: 'bg-orange-500',
+    borderColor: 'border-orange-500',
+    description: 'Passionate and intense tone',
+    position: 75,
+  },
+  hostile: {
+    label: 'Hostile',
+    color: 'text-red-700',
+    bgColor: 'bg-red-500',
+    borderColor: 'border-red-500',
+    description: 'May contain inflammatory language',
+    position: 100,
+  },
+};
+
+/**
+ * Size configurations for the indicator
+ */
+const SIZE_CONFIG = {
+  sm: {
+    gaugeHeight: 'h-2',
+    markerSize: 'w-3 h-3',
+    fontSize: 'text-xs',
+    padding: 'p-2',
+  },
+  md: {
+    gaugeHeight: 'h-3',
+    markerSize: 'w-4 h-4',
+    fontSize: 'text-sm',
+    padding: 'p-3',
+  },
+  lg: {
+    gaugeHeight: 'h-4',
+    markerSize: 'w-5 h-5',
+    fontSize: 'text-base',
+    padding: 'p-4',
+  },
+};
+
+/**
+ * ToneIndicator - Visualizes the emotional tone of content
+ *
+ * Displays a gauge or compact indicator showing tone level from
+ * calm (green) to hostile (red). Supports multiple variants:
+ * - gauge: Full visual gauge with gradient and marker
+ * - compact: Badge-style indicator with color coding
+ * - inline: Minimal inline indicator for tight spaces
+ */
+const ToneIndicator: React.FC<ToneIndicatorProps> = ({
+  tone,
+  variant = 'gauge',
+  showSuggestion = true,
+  showConfidence = true,
+  className = '',
+  size = 'md',
+  onClick,
+}) => {
+  const config = TONE_CONFIG[tone.level];
+  const sizeConfig = SIZE_CONFIG[size];
+  const isInteractive = Boolean(onClick);
+
+  // Render inline variant
+  if (variant === 'inline') {
+    return (
+      <span
+        className={`inline-flex items-center gap-1.5 ${className}`}
+        role="status"
+        aria-label={`Tone: ${config.label}`}
+      >
+        <span
+          className={`inline-block w-2 h-2 rounded-full ${config.bgColor}`}
+          aria-hidden="true"
+        />
+        <span className={`${sizeConfig.fontSize} ${config.color} font-medium`}>{config.label}</span>
+      </span>
+    );
+  }
+
+  // Render compact variant
+  if (variant === 'compact') {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={!isInteractive}
+        className={`
+          inline-flex items-center gap-2 px-3 py-1.5 rounded-full
+          border ${config.borderColor} ${config.bgColor} bg-opacity-10
+          ${isInteractive ? 'cursor-pointer hover:bg-opacity-20 transition-colors' : 'cursor-default'}
+          ${className}
+        `}
+        role="status"
+        aria-label={`Tone: ${config.label}, ${Math.round(tone.confidenceScore * 100)}% confidence`}
+      >
+        <span className={`w-2.5 h-2.5 rounded-full ${config.bgColor}`} aria-hidden="true" />
+        <span className={`${sizeConfig.fontSize} ${config.color} font-semibold`}>
+          {config.label}
+        </span>
+        {showConfidence && (
+          <span className={`${sizeConfig.fontSize} text-gray-500`}>
+            {Math.round(tone.confidenceScore * 100)}%
+          </span>
+        )}
+      </button>
+    );
+  }
+
+  // Render full gauge variant
+  return (
+    <div
+      className={`${sizeConfig.padding} rounded-lg bg-white shadow-sm border border-gray-200 ${className}`}
+      role="region"
+      aria-label="Tone analysis indicator"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span className={`w-3 h-3 rounded-full ${config.bgColor}`} aria-hidden="true" />
+          <span className={`${sizeConfig.fontSize} font-semibold ${config.color}`}>
+            {config.label} Tone
+          </span>
+        </div>
+        {showConfidence && (
+          <span className={`${sizeConfig.fontSize} text-gray-500`}>
+            {Math.round(tone.confidenceScore * 100)}% confident
+          </span>
+        )}
+      </div>
+
+      {/* Gauge */}
+      <div className="relative mb-4">
+        {/* Gradient bar */}
+        <div
+          className={`${sizeConfig.gaugeHeight} rounded-full overflow-hidden`}
+          style={{
+            background: 'linear-gradient(to right, #22c55e, #3b82f6, #eab308, #f97316, #ef4444)',
+          }}
+          role="presentation"
+        />
+
+        {/* Marker */}
+        <div
+          className={`
+            absolute top-1/2 -translate-y-1/2 ${sizeConfig.markerSize}
+            rounded-full bg-white border-2 ${config.borderColor}
+            shadow-md transition-all duration-300
+          `}
+          style={{
+            left: `calc(${config.position}% - ${size === 'sm' ? 6 : size === 'md' ? 8 : 10}px)`,
+          }}
+          role="slider"
+          aria-valuenow={config.position}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuetext={config.label}
+        />
+      </div>
+
+      {/* Labels */}
+      <div className="flex justify-between text-xs text-gray-500 mb-3">
+        <span>Calm</span>
+        <span>Neutral</span>
+        <span>Assertive</span>
+        <span>Heated</span>
+        <span>Hostile</span>
+      </div>
+
+      {/* Description */}
+      <p className={`${sizeConfig.fontSize} text-gray-600 mb-2`}>{config.description}</p>
+
+      {/* Suggestion */}
+      {showSuggestion && tone.suggestion && (
+        <div className="mt-3 pt-3 border-t border-gray-100">
+          <p className={`${sizeConfig.fontSize} text-gray-700`}>
+            <span className="font-medium">Suggestion: </span>
+            {tone.suggestion}
+          </p>
+        </div>
+      )}
+
+      {/* Subtype indicator */}
+      {tone.subtype && (
+        <div className="mt-2 flex items-center gap-1">
+          <span className="text-xs px-2 py-0.5 rounded bg-red-100 text-red-700">
+            {tone.subtype.replace(/_/g, ' ')}
+          </span>
+        </div>
+      )}
+
+      {/* Interactive click area */}
+      {isInteractive && (
+        <button
+          type="button"
+          onClick={onClick}
+          className="mt-3 w-full text-center text-sm text-primary-600 hover:text-primary-800 transition-colors"
+        >
+          View details
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ToneIndicator;

--- a/frontend/src/components/feedback/__tests__/ToneIndicator.test.tsx
+++ b/frontend/src/components/feedback/__tests__/ToneIndicator.test.tsx
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ToneIndicator from '../ToneIndicator';
+import type { ToneAnalysis } from '../../../types/feedback';
+
+describe('ToneIndicator', () => {
+  const mockCalmTone: ToneAnalysis = {
+    level: 'calm',
+    confidenceScore: 0.92,
+    suggestion: 'Your tone is constructive and measured.',
+  };
+
+  const mockNeutralTone: ToneAnalysis = {
+    level: 'neutral',
+    confidenceScore: 0.88,
+    reasoning: 'The content maintains an objective perspective.',
+  };
+
+  const mockAssertiveTone: ToneAnalysis = {
+    level: 'assertive',
+    confidenceScore: 0.85,
+    suggestion: 'Strong but respectful argumentation.',
+  };
+
+  const mockHeatedTone: ToneAnalysis = {
+    level: 'heated',
+    confidenceScore: 0.78,
+    suggestion: 'Consider cooling the language slightly.',
+    reasoning: 'Passionate tone detected.',
+  };
+
+  const mockHostileTone: ToneAnalysis = {
+    level: 'hostile',
+    subtype: 'personal_attack',
+    confidenceScore: 0.95,
+    suggestion: 'Consider rephrasing to focus on ideas rather than personal characteristics.',
+    reasoning: 'Personal attack detected in the content.',
+  };
+
+  describe('Gauge Variant (default)', () => {
+    it('should render gauge variant by default', () => {
+      render(<ToneIndicator tone={mockCalmTone} />);
+
+      expect(screen.getByRole('region', { name: /tone analysis indicator/i })).toBeInTheDocument();
+    });
+
+    it('should display the tone level label', () => {
+      render(<ToneIndicator tone={mockCalmTone} />);
+
+      expect(screen.getByText('Calm Tone')).toBeInTheDocument();
+    });
+
+    it('should display confidence score as percentage', () => {
+      render(<ToneIndicator tone={mockCalmTone} />);
+
+      expect(screen.getByText('92% confident')).toBeInTheDocument();
+    });
+
+    it('should display suggestion when showSuggestion is true', () => {
+      render(<ToneIndicator tone={mockCalmTone} showSuggestion />);
+
+      expect(screen.getByText(/your tone is constructive and measured/i)).toBeInTheDocument();
+    });
+
+    it('should hide suggestion when showSuggestion is false', () => {
+      render(<ToneIndicator tone={mockCalmTone} showSuggestion={false} />);
+
+      expect(screen.queryByText(/your tone is constructive and measured/i)).not.toBeInTheDocument();
+    });
+
+    it('should render all tone level labels on the gauge', () => {
+      render(<ToneIndicator tone={mockNeutralTone} />);
+
+      expect(screen.getByText('Calm')).toBeInTheDocument();
+      expect(screen.getByText('Neutral')).toBeInTheDocument();
+      expect(screen.getByText('Assertive')).toBeInTheDocument();
+      expect(screen.getByText('Heated')).toBeInTheDocument();
+      expect(screen.getByText('Hostile')).toBeInTheDocument();
+    });
+
+    it('should display subtype badge when subtype is present', () => {
+      render(<ToneIndicator tone={mockHostileTone} />);
+
+      expect(screen.getByText('personal attack')).toBeInTheDocument();
+    });
+
+    it('should show view details button when onClick is provided', () => {
+      const onClick = vi.fn();
+      render(<ToneIndicator tone={mockCalmTone} onClick={onClick} />);
+
+      expect(screen.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    });
+
+    it('should call onClick when view details is clicked', async () => {
+      const user = userEvent.setup();
+      const onClick = vi.fn();
+      render(<ToneIndicator tone={mockCalmTone} onClick={onClick} />);
+
+      await user.click(screen.getByRole('button', { name: /view details/i }));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Compact Variant', () => {
+    it('should render compact badge variant', () => {
+      render(<ToneIndicator tone={mockCalmTone} variant="compact" />);
+
+      expect(screen.getByRole('status', { name: /tone: calm/i })).toBeInTheDocument();
+    });
+
+    it('should display tone level in compact variant', () => {
+      render(<ToneIndicator tone={mockNeutralTone} variant="compact" />);
+
+      expect(screen.getByText('Neutral')).toBeInTheDocument();
+    });
+
+    it('should display confidence in compact variant when showConfidence is true', () => {
+      render(<ToneIndicator tone={mockCalmTone} variant="compact" showConfidence />);
+
+      expect(screen.getByText('92%')).toBeInTheDocument();
+    });
+
+    it('should hide confidence in compact variant when showConfidence is false', () => {
+      render(<ToneIndicator tone={mockCalmTone} variant="compact" showConfidence={false} />);
+
+      expect(screen.queryByText('92%')).not.toBeInTheDocument();
+    });
+
+    it('should be clickable when onClick is provided', async () => {
+      const user = userEvent.setup();
+      const onClick = vi.fn();
+      render(<ToneIndicator tone={mockCalmTone} variant="compact" onClick={onClick} />);
+
+      await user.click(screen.getByRole('status'));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not be clickable when onClick is not provided', () => {
+      render(<ToneIndicator tone={mockCalmTone} variant="compact" />);
+
+      const button = screen.getByRole('status');
+      expect(button).toBeDisabled();
+    });
+  });
+
+  describe('Inline Variant', () => {
+    it('should render inline variant', () => {
+      render(<ToneIndicator tone={mockCalmTone} variant="inline" />);
+
+      expect(screen.getByRole('status', { name: /tone: calm/i })).toBeInTheDocument();
+    });
+
+    it('should display only tone level in inline variant', () => {
+      render(<ToneIndicator tone={mockNeutralTone} variant="inline" />);
+
+      expect(screen.getByText('Neutral')).toBeInTheDocument();
+      // Should not display confidence or suggestion in inline
+      expect(screen.queryByText('88%')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Tone Levels', () => {
+    it('should render calm tone with green styling', () => {
+      const { container } = render(<ToneIndicator tone={mockCalmTone} variant="compact" />);
+
+      const indicator = container.querySelector('.bg-green-500');
+      expect(indicator).toBeInTheDocument();
+    });
+
+    it('should render neutral tone with blue styling', () => {
+      const { container } = render(<ToneIndicator tone={mockNeutralTone} variant="compact" />);
+
+      const indicator = container.querySelector('.bg-blue-500');
+      expect(indicator).toBeInTheDocument();
+    });
+
+    it('should render assertive tone with yellow styling', () => {
+      const { container } = render(<ToneIndicator tone={mockAssertiveTone} variant="compact" />);
+
+      const indicator = container.querySelector('.bg-yellow-500');
+      expect(indicator).toBeInTheDocument();
+    });
+
+    it('should render heated tone with orange styling', () => {
+      const { container } = render(<ToneIndicator tone={mockHeatedTone} variant="compact" />);
+
+      const indicator = container.querySelector('.bg-orange-500');
+      expect(indicator).toBeInTheDocument();
+    });
+
+    it('should render hostile tone with red styling', () => {
+      const { container } = render(<ToneIndicator tone={mockHostileTone} variant="compact" />);
+
+      const indicator = container.querySelector('.bg-red-500');
+      expect(indicator).toBeInTheDocument();
+    });
+  });
+
+  describe('Size Variants', () => {
+    it('should render small size', () => {
+      render(<ToneIndicator tone={mockCalmTone} size="sm" />);
+
+      const container = screen.getByRole('region');
+      expect(container.className).toContain('p-2');
+    });
+
+    it('should render medium size (default)', () => {
+      render(<ToneIndicator tone={mockCalmTone} size="md" />);
+
+      const container = screen.getByRole('region');
+      expect(container.className).toContain('p-3');
+    });
+
+    it('should render large size', () => {
+      render(<ToneIndicator tone={mockCalmTone} size="lg" />);
+
+      const container = screen.getByRole('region');
+      expect(container.className).toContain('p-4');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have proper role="region" on gauge variant', () => {
+      render(<ToneIndicator tone={mockCalmTone} />);
+
+      expect(screen.getByRole('region', { name: /tone analysis indicator/i })).toBeInTheDocument();
+    });
+
+    it('should have proper role="status" on compact variant', () => {
+      render(<ToneIndicator tone={mockCalmTone} variant="compact" />);
+
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    it('should have proper aria-label on compact variant', () => {
+      render(<ToneIndicator tone={mockCalmTone} variant="compact" />);
+
+      expect(
+        screen.getByRole('status', { name: /tone: calm, 92% confidence/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('should have proper role="slider" on marker', () => {
+      render(<ToneIndicator tone={mockNeutralTone} />);
+
+      const slider = screen.getByRole('slider');
+      expect(slider).toHaveAttribute('aria-valuenow', '25');
+      expect(slider).toHaveAttribute('aria-valuemin', '0');
+      expect(slider).toHaveAttribute('aria-valuemax', '100');
+      expect(slider).toHaveAttribute('aria-valuetext', 'Neutral');
+    });
+
+    it('should have proper role="status" on inline variant', () => {
+      render(<ToneIndicator tone={mockCalmTone} variant="inline" />);
+
+      expect(screen.getByRole('status', { name: /tone: calm/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Custom className', () => {
+    it('should apply custom className to gauge variant', () => {
+      render(<ToneIndicator tone={mockCalmTone} className="custom-class" />);
+
+      const container = screen.getByRole('region');
+      expect(container.className).toContain('custom-class');
+    });
+
+    it('should apply custom className to compact variant', () => {
+      render(<ToneIndicator tone={mockCalmTone} variant="compact" className="custom-class" />);
+
+      const container = screen.getByRole('status');
+      expect(container.className).toContain('custom-class');
+    });
+
+    it('should apply custom className to inline variant', () => {
+      const { container } = render(
+        <ToneIndicator tone={mockCalmTone} variant="inline" className="custom-class" />,
+      );
+
+      expect(container.firstChild).toHaveClass('custom-class');
+    });
+  });
+
+  describe('Tone Level Descriptions', () => {
+    it('should show calm description', () => {
+      render(<ToneIndicator tone={mockCalmTone} />);
+
+      expect(screen.getByText('Constructive and measured tone')).toBeInTheDocument();
+    });
+
+    it('should show neutral description', () => {
+      render(<ToneIndicator tone={mockNeutralTone} />);
+
+      expect(screen.getByText('Balanced and objective tone')).toBeInTheDocument();
+    });
+
+    it('should show assertive description', () => {
+      render(<ToneIndicator tone={mockAssertiveTone} />);
+
+      expect(screen.getByText('Strong but respectful tone')).toBeInTheDocument();
+    });
+
+    it('should show heated description', () => {
+      render(<ToneIndicator tone={mockHeatedTone} />);
+
+      expect(screen.getByText('Passionate and intense tone')).toBeInTheDocument();
+    });
+
+    it('should show hostile description', () => {
+      render(<ToneIndicator tone={mockHostileTone} />);
+
+      expect(screen.getByText('May contain inflammatory language')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/feedback/index.ts
+++ b/frontend/src/components/feedback/index.ts
@@ -5,3 +5,4 @@ export { default as SuggestionCards } from './SuggestionCards';
 export type { SuggestionCardsProps } from './SuggestionCards';
 export { default as SuggestionPanel } from './SuggestionPanel';
 export type { SuggestionPanelProps } from './SuggestionPanel';
+export { default as ToneIndicator } from './ToneIndicator';

--- a/frontend/src/types/feedback.ts
+++ b/frontend/src/types/feedback.ts
@@ -127,3 +127,50 @@ export interface FeedbackPreferences {
     affirmation: boolean;
   };
 }
+
+/**
+ * Tone level representing the emotional temperature of content
+ * Ranges from calm (constructive) to hostile (inflammatory)
+ */
+export type ToneLevel = 'calm' | 'neutral' | 'assertive' | 'heated' | 'hostile';
+
+/**
+ * Tone subtype detected by the analyzer
+ */
+export type ToneSubtype = 'personal_attack' | 'hostile_tone' | 'personal_attack_with_hostile_tone';
+
+/**
+ * Result of tone analysis for content
+ */
+export interface ToneAnalysis {
+  /** Overall tone level */
+  level: ToneLevel;
+  /** Specific subtype if inflammatory language detected */
+  subtype?: ToneSubtype;
+  /** Confidence score from 0 to 1 */
+  confidenceScore: number;
+  /** Suggestion for improving tone (if needed) */
+  suggestion?: string;
+  /** Reasoning behind the analysis */
+  reasoning?: string;
+}
+
+/**
+ * Props for ToneIndicator component
+ */
+export interface ToneIndicatorProps {
+  /** Tone analysis data to visualize */
+  tone: ToneAnalysis;
+  /** Whether to show the full gauge or a compact indicator */
+  variant?: 'gauge' | 'compact' | 'inline';
+  /** Whether to show the suggestion text */
+  showSuggestion?: boolean;
+  /** Whether to show confidence score */
+  showConfidence?: boolean;
+  /** Custom className for the container */
+  className?: string;
+  /** Size of the indicator */
+  size?: 'sm' | 'md' | 'lg';
+  /** Callback when the indicator is clicked */
+  onClick?: () => void;
+}


### PR DESCRIPTION
## Summary

- Add ToneIndicator component with three display variants (gauge, compact, inline)
- Support five tone levels (calm, neutral, assertive, heated, hostile) with color-coded feedback
- Include comprehensive test suite with 38 passing tests
- Add TypeScript types for tone analysis integration

## Test plan

- [x] ToneIndicator component renders correctly in all three variants
- [x] Tone levels display appropriate colors (green → red spectrum)
- [x] Confidence scores display correctly
- [x] Suggestions appear when enabled
- [x] Accessibility roles and ARIA labels are properly set
- [x] All 38 unit tests pass
- [x] TypeScript types compile without errors
- [x] ESLint passes with no errors

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)