### PR TITLE
feat(common-ground): Add CommonGroundDetailModal component (#139)

### DIFF
--- a/frontend/src/components/common-ground/CommonGroundDetailModal.tsx
+++ b/frontend/src/components/common-ground/CommonGroundDetailModal.tsx
@@ -1,0 +1,409 @@
+import React from 'react';
+import Modal from '../ui/Modal';
+import Button from '../ui/Button';
+import type { AgreementZone, Misunderstanding, Disagreement } from '../../types/common-ground';
+
+/**
+ * Detail type discriminator for the modal
+ */
+export type DetailType = 'agreementZone' | 'misunderstanding' | 'disagreement';
+
+/**
+ * Props for displaying an agreement zone
+ */
+interface AgreementZoneDetailProps {
+  type: 'agreementZone';
+  data: AgreementZone;
+}
+
+/**
+ * Props for displaying a misunderstanding
+ */
+interface MisunderstandingDetailProps {
+  type: 'misunderstanding';
+  data: Misunderstanding;
+}
+
+/**
+ * Props for displaying a disagreement
+ */
+interface DisagreementDetailProps {
+  type: 'disagreement';
+  data: Disagreement;
+}
+
+/**
+ * Union type for detail content
+ */
+type DetailContent =
+  | AgreementZoneDetailProps
+  | MisunderstandingDetailProps
+  | DisagreementDetailProps;
+
+export interface CommonGroundDetailModalProps {
+  /**
+   * Whether the modal is open
+   */
+  isOpen: boolean;
+
+  /**
+   * Callback when the modal should be closed
+   */
+  onClose: () => void;
+
+  /**
+   * The detail content to display (null when closed)
+   */
+  detail: DetailContent | null;
+
+  /**
+   * Optional callback when navigating to a related item
+   */
+  onNavigateToRelated?: (type: DetailType, id: string) => void;
+}
+
+/**
+ * Get consensus level styling
+ */
+const getConsensusStyles = (level: 'high' | 'medium' | 'low') => {
+  const styles = {
+    high: {
+      bg: 'bg-green-50',
+      border: 'border-green-200',
+      text: 'text-green-800',
+      badge: 'bg-green-100 text-green-800',
+      progress: 'bg-green-500',
+    },
+    medium: {
+      bg: 'bg-yellow-50',
+      border: 'border-yellow-200',
+      text: 'text-yellow-800',
+      badge: 'bg-yellow-100 text-yellow-800',
+      progress: 'bg-yellow-500',
+    },
+    low: {
+      bg: 'bg-orange-50',
+      border: 'border-orange-200',
+      text: 'text-orange-800',
+      badge: 'bg-orange-100 text-orange-800',
+      progress: 'bg-orange-500',
+    },
+  };
+
+  return styles[level];
+};
+
+/**
+ * Renders agreement zone details
+ */
+const AgreementZoneDetail: React.FC<{ zone: AgreementZone }> = ({ zone }) => {
+  const styles = getConsensusStyles(zone.consensusLevel);
+
+  return (
+    <div className="space-y-6" data-testid="agreement-zone-detail">
+      {/* Header */}
+      <div className={`p-4 rounded-lg ${styles.bg} border ${styles.border}`}>
+        <div className="flex items-center justify-between mb-2">
+          <span
+            className={`text-xs font-semibold px-2 py-1 rounded ${styles.badge}`}
+            data-testid="consensus-level"
+          >
+            {zone.consensusLevel.toUpperCase()} CONSENSUS
+          </span>
+          <span className="text-sm text-gray-600" data-testid="participant-count">
+            {zone.participantCount} participants
+          </span>
+        </div>
+        <p className="text-gray-700 mt-2">{zone.description}</p>
+      </div>
+
+      {/* Propositions */}
+      {zone.propositions.length > 0 && (
+        <div>
+          <h4 className="text-sm font-semibold text-gray-900 mb-3">
+            Shared Propositions ({zone.propositions.length})
+          </h4>
+          <div className="space-y-3">
+            {zone.propositions.map((prop) => (
+              <div
+                key={prop.id}
+                className="bg-white border border-gray-200 rounded-lg p-4"
+                data-testid="proposition-item"
+              >
+                <p className="text-gray-800 mb-3">{prop.text}</p>
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm text-gray-600">Agreement</span>
+                  <span className="text-sm font-semibold text-gray-900">
+                    {prop.agreementPercentage}%
+                  </span>
+                </div>
+                <div className="w-full bg-gray-200 rounded-full h-2">
+                  <div
+                    className={`${styles.progress} h-2 rounded-full transition-all duration-300`}
+                    style={{ width: `${prop.agreementPercentage}%` }}
+                    role="progressbar"
+                    aria-valuenow={prop.agreementPercentage}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                  />
+                </div>
+                <div className="mt-3 flex gap-4 text-xs text-gray-500">
+                  <span>
+                    <span className="text-green-600 font-medium">
+                      {prop.supportingParticipants.length}
+                    </span>{' '}
+                    supporting
+                  </span>
+                  <span>
+                    <span className="text-red-600 font-medium">
+                      {prop.opposingParticipants.length}
+                    </span>{' '}
+                    opposing
+                  </span>
+                  <span>
+                    <span className="text-gray-600 font-medium">
+                      {prop.neutralParticipants.length}
+                    </span>{' '}
+                    neutral
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Renders misunderstanding details
+ */
+const MisunderstandingDetail: React.FC<{ misunderstanding: Misunderstanding }> = ({
+  misunderstanding,
+}) => {
+  return (
+    <div className="space-y-6" data-testid="misunderstanding-detail">
+      {/* Header */}
+      <div className="p-4 rounded-lg bg-purple-50 border border-purple-200">
+        <span className="inline-block text-xs font-semibold px-2 py-1 rounded bg-purple-100 text-purple-800">
+          TERM CONFUSION
+        </span>
+        <p className="text-gray-700 mt-3">
+          Participants are using the term <strong>"{misunderstanding.term}"</strong> with different
+          meanings, which may be causing confusion in the discussion.
+        </p>
+      </div>
+
+      {/* Definitions */}
+      <div>
+        <h4 className="text-sm font-semibold text-gray-900 mb-3">
+          Different Definitions ({misunderstanding.definitions.length})
+        </h4>
+        <div className="space-y-3">
+          {misunderstanding.definitions.map((def, idx) => (
+            <div
+              key={idx}
+              className="bg-white border border-gray-200 rounded-lg p-4"
+              data-testid="definition-item"
+            >
+              <blockquote className="text-gray-800 italic border-l-4 border-purple-300 pl-3 mb-3">
+                "{def.definition}"
+              </blockquote>
+              <div className="flex items-center gap-2 text-sm text-gray-600">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                  />
+                </svg>
+                <span>
+                  Used by <strong>{def.participants.length}</strong> participant(s)
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Clarification Suggestion */}
+      {misunderstanding.clarificationSuggestion && (
+        <div
+          className="bg-blue-50 border border-blue-200 rounded-lg p-4"
+          data-testid="clarification-suggestion"
+        >
+          <div className="flex items-start gap-3">
+            <div className="flex-shrink-0">
+              <svg
+                className="w-5 h-5 text-blue-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+                />
+              </svg>
+            </div>
+            <div>
+              <h4 className="text-sm font-semibold text-blue-900 mb-1">Suggested Clarification</h4>
+              <p className="text-sm text-blue-800">{misunderstanding.clarificationSuggestion}</p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Renders disagreement details
+ */
+const DisagreementDetail: React.FC<{ disagreement: Disagreement }> = ({ disagreement }) => {
+  return (
+    <div className="space-y-6" data-testid="disagreement-detail">
+      {/* Header */}
+      <div className="p-4 rounded-lg bg-blue-50 border border-blue-200">
+        <span className="inline-block text-xs font-semibold px-2 py-1 rounded bg-blue-100 text-blue-800">
+          VALUE DIFFERENCE
+        </span>
+        <p className="text-gray-700 mt-3">{disagreement.description}</p>
+      </div>
+
+      {/* Positions */}
+      <div>
+        <h4 className="text-sm font-semibold text-gray-900 mb-3">
+          Different Positions ({disagreement.positions.length})
+        </h4>
+        <div className="space-y-4">
+          {disagreement.positions.map((position, idx) => (
+            <div
+              key={idx}
+              className="bg-white border border-gray-200 rounded-lg p-4"
+              data-testid="position-item"
+            >
+              <div className="flex items-start justify-between mb-3">
+                <h5 className="font-medium text-gray-900">{position.stance}</h5>
+                <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
+                  {position.participants.length} participant(s)
+                </span>
+              </div>
+
+              <p className="text-gray-700 mb-4">{position.reasoning}</p>
+
+              {(position.underlyingValue || position.underlyingAssumption) && (
+                <div className="border-t border-gray-100 pt-3 space-y-2">
+                  {position.underlyingValue && (
+                    <div className="flex items-start gap-2">
+                      <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide min-w-[80px]">
+                        Core Value
+                      </span>
+                      <span className="text-sm text-gray-700">{position.underlyingValue}</span>
+                    </div>
+                  )}
+                  {position.underlyingAssumption && (
+                    <div className="flex items-start gap-2">
+                      <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide min-w-[80px]">
+                        Assumption
+                      </span>
+                      <span className="text-sm text-gray-700">{position.underlyingAssumption}</span>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Moral Foundations */}
+      {disagreement.moralFoundations && disagreement.moralFoundations.length > 0 && (
+        <div
+          className="bg-gray-50 border border-gray-200 rounded-lg p-4"
+          data-testid="moral-foundations"
+        >
+          <h4 className="text-sm font-semibold text-gray-900 mb-3">Related Moral Foundations</h4>
+          <div className="flex flex-wrap gap-2">
+            {disagreement.moralFoundations.map((foundation, idx) => (
+              <span
+                key={idx}
+                className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800"
+              >
+                {foundation}
+              </span>
+            ))}
+          </div>
+          <p className="text-xs text-gray-500 mt-3">
+            These moral foundations may help explain the underlying values driving this
+            disagreement.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Get modal title based on detail type
+ */
+const getModalTitle = (detail: DetailContent | null): string => {
+  if (!detail) return 'Details';
+
+  switch (detail.type) {
+    case 'agreementZone':
+      return detail.data.title;
+    case 'misunderstanding':
+      return `Term: "${detail.data.term}"`;
+    case 'disagreement':
+      return detail.data.topic;
+    default:
+      return 'Details';
+  }
+};
+
+/**
+ * CommonGroundDetailModal - Displays detailed information about agreement zones,
+ * misunderstandings, or disagreements from a common ground analysis.
+ *
+ * This modal provides an expanded view of:
+ * - Agreement zones with full proposition details and participant breakdown
+ * - Misunderstandings with all definitions and clarification suggestions
+ * - Disagreements with positions, underlying values, and moral foundations
+ */
+const CommonGroundDetailModal: React.FC<CommonGroundDetailModalProps> = ({
+  isOpen,
+  onClose,
+  detail,
+}) => {
+  if (!detail) {
+    return null;
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={getModalTitle(detail)}
+      size="lg"
+      data-testid="common-ground-detail-modal"
+      footer={
+        <Button variant="outline" onClick={onClose} data-testid="close-modal">
+          Close
+        </Button>
+      }
+    >
+      {detail.type === 'agreementZone' && <AgreementZoneDetail zone={detail.data} />}
+      {detail.type === 'misunderstanding' && (
+        <MisunderstandingDetail misunderstanding={detail.data} />
+      )}
+      {detail.type === 'disagreement' && <DisagreementDetail disagreement={detail.data} />}
+    </Modal>
+  );
+};
+
+export default CommonGroundDetailModal;

--- a/frontend/src/components/common-ground/__tests__/CommonGroundDetailModal.spec.tsx
+++ b/frontend/src/components/common-ground/__tests__/CommonGroundDetailModal.spec.tsx
@@ -1,0 +1,593 @@
+/**
+ * Unit tests for CommonGroundDetailModal component
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CommonGroundDetailModal from '../CommonGroundDetailModal';
+import type { AgreementZone, Misunderstanding, Disagreement } from '../../../types/common-ground';
+
+// Test fixtures
+const mockAgreementZone: AgreementZone = {
+  id: 'zone-1',
+  title: 'Climate Action Agreement',
+  description: 'Participants agree on the need for climate action',
+  consensusLevel: 'high',
+  participantCount: 15,
+  propositions: [
+    {
+      id: 'prop-1',
+      text: 'We should reduce carbon emissions',
+      agreementPercentage: 85,
+      supportingParticipants: ['user-1', 'user-2', 'user-3'],
+      opposingParticipants: ['user-4'],
+      neutralParticipants: ['user-5'],
+    },
+    {
+      id: 'prop-2',
+      text: 'Renewable energy should be prioritized',
+      agreementPercentage: 72,
+      supportingParticipants: ['user-1', 'user-2'],
+      opposingParticipants: ['user-3'],
+      neutralParticipants: ['user-4', 'user-5'],
+    },
+  ],
+};
+
+const mockMisunderstanding: Misunderstanding = {
+  id: 'misund-1',
+  term: 'sustainability',
+  definitions: [
+    {
+      definition: 'Environmental protection and conservation',
+      participants: ['user-1', 'user-2'],
+    },
+    {
+      definition: 'Long-term economic viability',
+      participants: ['user-3', 'user-4', 'user-5'],
+    },
+  ],
+  clarificationSuggestion:
+    'Consider distinguishing between environmental sustainability and economic sustainability in the discussion.',
+};
+
+const mockDisagreement: Disagreement = {
+  id: 'disagree-1',
+  topic: 'Nuclear Energy',
+  description: 'Participants disagree on whether nuclear energy should be part of the solution',
+  positions: [
+    {
+      stance: 'Pro-Nuclear',
+      reasoning: 'Nuclear provides reliable baseload power with zero carbon emissions',
+      participants: ['user-1', 'user-2'],
+      underlyingValue: 'Pragmatism and efficiency',
+      underlyingAssumption: 'Modern nuclear is safe',
+    },
+    {
+      stance: 'Anti-Nuclear',
+      reasoning: 'Nuclear waste remains dangerous for thousands of years',
+      participants: ['user-3', 'user-4', 'user-5'],
+      underlyingValue: 'Long-term safety',
+      underlyingAssumption: 'Renewables can scale fast enough',
+    },
+  ],
+  moralFoundations: ['care-harm', 'fairness-cheating', 'liberty-oppression'],
+};
+
+describe('CommonGroundDetailModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    detail: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Basic Rendering', () => {
+    it('should return null when detail is null', () => {
+      const { container } = render(<CommonGroundDetailModal {...defaultProps} detail={null} />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should not render when isOpen is false', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          isOpen={false}
+          detail={{ type: 'agreementZone', data: mockAgreementZone }}
+        />,
+      );
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('should render modal when isOpen is true and detail is provided', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'agreementZone', data: mockAgreementZone }}
+        />,
+      );
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('should call onClose when close button is clicked', async () => {
+      const onClose = vi.fn();
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          onClose={onClose}
+          detail={{ type: 'agreementZone', data: mockAgreementZone }}
+        />,
+      );
+
+      await userEvent.click(screen.getByTestId('close-modal'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Agreement Zone Detail', () => {
+    it('should render agreement zone with correct title', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'agreementZone', data: mockAgreementZone }}
+        />,
+      );
+
+      expect(screen.getByText('Climate Action Agreement')).toBeInTheDocument();
+    });
+
+    it('should display consensus level badge', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'agreementZone', data: mockAgreementZone }}
+        />,
+      );
+
+      const badge = screen.getByTestId('consensus-level');
+      expect(badge).toHaveTextContent('HIGH CONSENSUS');
+    });
+
+    it('should display participant count', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'agreementZone', data: mockAgreementZone }}
+        />,
+      );
+
+      const count = screen.getByTestId('participant-count');
+      expect(count).toHaveTextContent('15 participants');
+    });
+
+    it('should display description', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'agreementZone', data: mockAgreementZone }}
+        />,
+      );
+
+      expect(
+        screen.getByText('Participants agree on the need for climate action'),
+      ).toBeInTheDocument();
+    });
+
+    it('should display all propositions', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'agreementZone', data: mockAgreementZone }}
+        />,
+      );
+
+      const propositions = screen.getAllByTestId('proposition-item');
+      expect(propositions).toHaveLength(2);
+    });
+
+    it('should display proposition text and agreement percentage', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'agreementZone', data: mockAgreementZone }}
+        />,
+      );
+
+      expect(screen.getByText('We should reduce carbon emissions')).toBeInTheDocument();
+      expect(screen.getByText('85%')).toBeInTheDocument();
+    });
+
+    it('should display participant breakdown for propositions', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'agreementZone', data: mockAgreementZone }}
+        />,
+      );
+
+      // Each proposition shows supporting/opposing/neutral counts
+      const supportingLabels = screen.getAllByText('supporting');
+      expect(supportingLabels).toHaveLength(2); // One per proposition
+
+      const opposingLabels = screen.getAllByText('opposing');
+      expect(opposingLabels).toHaveLength(2);
+
+      const neutralLabels = screen.getAllByText('neutral');
+      expect(neutralLabels).toHaveLength(2);
+    });
+
+    it('should render progress bar with correct percentage', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'agreementZone', data: mockAgreementZone }}
+        />,
+      );
+
+      const progressBars = screen.getAllByRole('progressbar');
+      expect(progressBars[0]).toHaveAttribute('aria-valuenow', '85');
+      expect(progressBars[0]).toHaveAttribute('aria-valuemin', '0');
+      expect(progressBars[0]).toHaveAttribute('aria-valuemax', '100');
+    });
+
+    it('should apply correct styles for each consensus level', () => {
+      // Test medium consensus
+      const mediumZone = { ...mockAgreementZone, consensusLevel: 'medium' as const };
+      const { rerender } = render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'agreementZone', data: mediumZone }}
+        />,
+      );
+
+      expect(screen.getByTestId('consensus-level')).toHaveTextContent('MEDIUM CONSENSUS');
+
+      // Test low consensus
+      const lowZone = { ...mockAgreementZone, consensusLevel: 'low' as const };
+      rerender(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'agreementZone', data: lowZone }}
+        />,
+      );
+
+      expect(screen.getByTestId('consensus-level')).toHaveTextContent('LOW CONSENSUS');
+    });
+
+    it('should handle empty propositions array', () => {
+      const zoneWithNoProps = { ...mockAgreementZone, propositions: [] };
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'agreementZone', data: zoneWithNoProps }}
+        />,
+      );
+
+      expect(screen.queryByTestId('proposition-item')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Shared Propositions/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Misunderstanding Detail', () => {
+    it('should render misunderstanding with term in title', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'misunderstanding', data: mockMisunderstanding }}
+        />,
+      );
+
+      expect(screen.getByText('Term: "sustainability"')).toBeInTheDocument();
+    });
+
+    it('should display term confusion badge', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'misunderstanding', data: mockMisunderstanding }}
+        />,
+      );
+
+      expect(screen.getByText('TERM CONFUSION')).toBeInTheDocument();
+    });
+
+    it('should display explanation text with term highlighted', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'misunderstanding', data: mockMisunderstanding }}
+        />,
+      );
+
+      expect(screen.getByText('"sustainability"')).toBeInTheDocument();
+    });
+
+    it('should display all definitions', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'misunderstanding', data: mockMisunderstanding }}
+        />,
+      );
+
+      const definitions = screen.getAllByTestId('definition-item');
+      expect(definitions).toHaveLength(2);
+    });
+
+    it('should display definition text and participant count', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'misunderstanding', data: mockMisunderstanding }}
+        />,
+      );
+
+      expect(screen.getByText('"Environmental protection and conservation"')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    it('should display clarification suggestion when provided', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'misunderstanding', data: mockMisunderstanding }}
+        />,
+      );
+
+      const suggestion = screen.getByTestId('clarification-suggestion');
+      expect(suggestion).toBeInTheDocument();
+      expect(
+        within(suggestion).getByText(
+          'Consider distinguishing between environmental sustainability and economic sustainability in the discussion.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should not display clarification suggestion when not provided', () => {
+      const misundWithoutSuggestion = {
+        ...mockMisunderstanding,
+        clarificationSuggestion: undefined,
+      };
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'misunderstanding', data: misundWithoutSuggestion }}
+        />,
+      );
+
+      expect(screen.queryByTestId('clarification-suggestion')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Disagreement Detail', () => {
+    it('should render disagreement with topic as title', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'disagreement', data: mockDisagreement }}
+        />,
+      );
+
+      expect(screen.getByText('Nuclear Energy')).toBeInTheDocument();
+    });
+
+    it('should display value difference badge', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'disagreement', data: mockDisagreement }}
+        />,
+      );
+
+      expect(screen.getByText('VALUE DIFFERENCE')).toBeInTheDocument();
+    });
+
+    it('should display description', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'disagreement', data: mockDisagreement }}
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          'Participants disagree on whether nuclear energy should be part of the solution',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should display all positions', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'disagreement', data: mockDisagreement }}
+        />,
+      );
+
+      const positions = screen.getAllByTestId('position-item');
+      expect(positions).toHaveLength(2);
+    });
+
+    it('should display position stance and participant count', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'disagreement', data: mockDisagreement }}
+        />,
+      );
+
+      expect(screen.getByText('Pro-Nuclear')).toBeInTheDocument();
+      expect(screen.getByText('Anti-Nuclear')).toBeInTheDocument();
+      expect(screen.getByText('2 participant(s)')).toBeInTheDocument();
+      expect(screen.getByText('3 participant(s)')).toBeInTheDocument();
+    });
+
+    it('should display reasoning for each position', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'disagreement', data: mockDisagreement }}
+        />,
+      );
+
+      expect(
+        screen.getByText('Nuclear provides reliable baseload power with zero carbon emissions'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('Nuclear waste remains dangerous for thousands of years'),
+      ).toBeInTheDocument();
+    });
+
+    it('should display underlying values and assumptions', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'disagreement', data: mockDisagreement }}
+        />,
+      );
+
+      expect(screen.getByText('Pragmatism and efficiency')).toBeInTheDocument();
+      expect(screen.getByText('Modern nuclear is safe')).toBeInTheDocument();
+      expect(screen.getByText('Long-term safety')).toBeInTheDocument();
+      expect(screen.getByText('Renewables can scale fast enough')).toBeInTheDocument();
+    });
+
+    it('should display moral foundations when provided', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'disagreement', data: mockDisagreement }}
+        />,
+      );
+
+      const moralFoundations = screen.getByTestId('moral-foundations');
+      expect(moralFoundations).toBeInTheDocument();
+      expect(within(moralFoundations).getByText('care-harm')).toBeInTheDocument();
+      expect(within(moralFoundations).getByText('fairness-cheating')).toBeInTheDocument();
+      expect(within(moralFoundations).getByText('liberty-oppression')).toBeInTheDocument();
+    });
+
+    it('should not display moral foundations when not provided', () => {
+      const disagreementWithoutFoundations = { ...mockDisagreement, moralFoundations: undefined };
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'disagreement', data: disagreementWithoutFoundations }}
+        />,
+      );
+
+      expect(screen.queryByTestId('moral-foundations')).not.toBeInTheDocument();
+    });
+
+    it('should not display moral foundations when array is empty', () => {
+      const disagreementWithEmptyFoundations = { ...mockDisagreement, moralFoundations: [] };
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'disagreement', data: disagreementWithEmptyFoundations }}
+        />,
+      );
+
+      expect(screen.queryByTestId('moral-foundations')).not.toBeInTheDocument();
+    });
+
+    it('should handle positions without underlying values/assumptions', () => {
+      const simpleDisagreement: Disagreement = {
+        ...mockDisagreement,
+        positions: [
+          {
+            stance: 'Simple Position',
+            reasoning: 'Just a basic reason',
+            participants: ['user-1'],
+          },
+        ],
+      };
+
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'disagreement', data: simpleDisagreement }}
+        />,
+      );
+
+      expect(screen.getByText('Simple Position')).toBeInTheDocument();
+      expect(screen.queryByText('Core Value')).not.toBeInTheDocument();
+      expect(screen.queryByText('Assumption')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Modal Title', () => {
+    it('should use agreement zone title for agreement zones', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'agreementZone', data: mockAgreementZone }}
+        />,
+      );
+
+      expect(screen.getByText('Climate Action Agreement')).toBeInTheDocument();
+    });
+
+    it('should format term for misunderstandings', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'misunderstanding', data: mockMisunderstanding }}
+        />,
+      );
+
+      expect(screen.getByText('Term: "sustainability"')).toBeInTheDocument();
+    });
+
+    it('should use topic for disagreements', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'disagreement', data: mockDisagreement }}
+        />,
+      );
+
+      expect(screen.getByText('Nuclear Energy')).toBeInTheDocument();
+    });
+  });
+
+  describe('Data TestIds', () => {
+    it('should have agreement-zone-detail testid for agreement zones', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'agreementZone', data: mockAgreementZone }}
+        />,
+      );
+
+      expect(screen.getByTestId('agreement-zone-detail')).toBeInTheDocument();
+    });
+
+    it('should have misunderstanding-detail testid for misunderstandings', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'misunderstanding', data: mockMisunderstanding }}
+        />,
+      );
+
+      expect(screen.getByTestId('misunderstanding-detail')).toBeInTheDocument();
+    });
+
+    it('should have disagreement-detail testid for disagreements', () => {
+      render(
+        <CommonGroundDetailModal
+          {...defaultProps}
+          detail={{ type: 'disagreement', data: mockDisagreement }}
+        />,
+      );
+
+      expect(screen.getByTestId('disagreement-detail')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/common-ground/index.ts
+++ b/frontend/src/components/common-ground/index.ts
@@ -25,6 +25,9 @@ export type { CommonGroundHistoryProps } from './CommonGroundHistory';
 export { default as ShareModal } from './ShareModal';
 export type { ShareModalProps } from './ShareModal';
 
+export { default as CommonGroundDetailModal } from './CommonGroundDetailModal';
+export type { CommonGroundDetailModalProps, DetailType } from './CommonGroundDetailModal';
+
 export { default as ShareButton } from './ShareButton';
 export type { ShareButtonProps } from './ShareButton';
 


### PR DESCRIPTION
## Summary

Implements the common ground detail modal component for issue #139.

- Add `CommonGroundDetailModal` component that displays detailed information about:
  - **Agreement zones** with propositions, consensus levels (high/medium/low), and participant breakdown
  - **Misunderstandings** with term definitions and clarification suggestions
  - **Disagreements** with positions, underlying values/assumptions, and moral foundations
- Uses discriminated union types for type-safe detail rendering
- Includes comprehensive styling with color-coded badges and progress bars
- Exports from common-ground index for easy import

## Test Plan

- [x] 38 unit tests covering all three detail types
- [x] Tests for rendering, conditional sections, and edge cases
- [x] TypeScript types verified
- [x] Lint passes

## Changes

| File | Description |
|------|-------------|
| `CommonGroundDetailModal.tsx` | Main modal component with sub-components for each detail type |
| `CommonGroundDetailModal.spec.tsx` | 38 comprehensive unit tests |
| `index.ts` | Export the new component and types |

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)