### PR TITLE
fix(moderation-service): Enable all unit tests (#201)

### DIFF
--- a/services/moderation-service/vitest.config.ts
+++ b/services/moderation-service/vitest.config.ts
@@ -6,19 +6,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/**/*.integration.test.ts'],
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      // Module resolution issues - @reason-bridge/common not resolving
-      '**/moderation.controller.test.ts',
-      '**/moderation-queue.service.spec.ts',
-      '**/moderation-action.repository.spec.ts',
-      '**/ai-review.service.spec.ts',
-      '**/appeal.service.spec.ts',
-      '**/moderation-actions.service.spec.ts',
-      '**/moderation-actions.service.unit.test.ts',
-      '**/queue.service.test.ts',
-    ],
+    exclude: ['**/node_modules/**', '**/dist/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
## Summary
- Removed 8 test file exclusions from `services/moderation-service/vitest.config.ts`
- These files were excluded due to module resolution issues with `@reason-bridge/event-schemas`
- The issue was a build order problem - shared packages must be built before tests run
- CI already builds packages first via `pnpm -r run build`, so these exclusions were unnecessary

## Tests Enabled
| Test File | Tests |
|-----------|-------|
| appeal.service.spec.ts | 39 |
| moderation-actions.service.spec.ts | 49 |
| moderation-actions.service.unit.test.ts | 29 |
| moderation-queue.service.spec.ts | 20 |
| moderation-action.repository.spec.ts | 24 |
| ai-review.service.spec.ts | 22 |
| moderation.controller.test.ts | 42 |
| queue.service.test.ts | 17 |
| **Total additional tests** | **242** |

## Test plan
- [x] Ran `npx vitest run` in moderation-service worktree
- [x] All 319 tests pass (77 existing + 242 newly enabled)
- [x] Pre-commit hooks pass

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)