### PR TITLE
fix(ai-service): Fix ESM import for cache-manager-redis-store

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -185,6 +185,8 @@ services:
       NODE_ENV: test
       DATABASE_URL: postgresql://unite_test:unite_test@postgres:5432/unite_test
       REDIS_URL: redis://redis:6379
+      REDIS_HOST: redis
+      REDIS_PORT: '6379'
       AWS_ENDPOINT: http://localstack:4566
       AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: test

--- a/services/ai-service/src/cache/cache.module.ts
+++ b/services/ai-service/src/cache/cache.module.ts
@@ -1,6 +1,6 @@
 import { Module, Logger } from '@nestjs/common';
 import { CacheModule as NestCacheModule } from '@nestjs/cache-manager';
-import * as redisStore from 'cache-manager-redis-store';
+import { redisStore } from 'cache-manager-redis-store';
 import { QdrantClient } from '@qdrant/js-client-rest';
 import OpenAI from 'openai';
 


### PR DESCRIPTION
## Summary

Hotfix for the ESM import issue introduced in PR #747.

The `cache-manager-redis-store` CommonJS module exports `redisStore` as a named export, not a default. Using `import * as redisStore` creates a namespace object containing the function, causing the Redis cache initialization to fail silently during container startup.

## Changes

- Fix import to use `import { redisStore }` instead of `import * as`
- Add REDIS_HOST and REDIS_PORT env vars to docker-compose.e2e.yml (CacheModule expects these, not REDIS_URL)

## Test Plan

- [ ] E2E tests pass with ai-service container starting correctly
- [ ] Jenkins CI passes all stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)