### PR TITLE
fix(prisma): Add missing DATABASE_URL to datasource configuration

### DIFF
--- a/packages/db-models/prisma/schema.prisma
+++ b/packages/db-models/prisma/schema.prisma
@@ -7,6 +7,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 // ============================================================================


### PR DESCRIPTION
## Problem

E2E tests were failing in Jenkins with error:
```
db-migrate-1  | Error: The datasource.url property is required in your Prisma config file when using prisma migrate deploy.
```

## Root Cause

The Prisma schema `datasource db` block was missing the `url` field, so Prisma couldn't read the `DATABASE_URL` environment variable that was correctly configured in `docker-compose.e2e.yml`.

**Before:**
```prisma
datasource db {
  provider = "postgresql"
}
```

## Solution

Added the missing `url` field to read from the `DATABASE_URL` environment variable:

**After:**
```prisma
datasource db {
  provider = "postgresql"
  url      = env("DATABASE_URL")
}
```

## Testing

This fix should resolve the E2E test failures seen in recent Jenkins builds (e.g., PR #803, PR #804).

## Impact

- ✅ E2E database migrations will now work correctly
- ✅ All services can properly connect to PostgreSQL in E2E environment
- ✅ No breaking changes - environment variable was already configured

Fixes the infrastructure issue that caused E2E builds to be marked UNSTABLE.