### PR TITLE
fix(e2e): Fix metadata panel test to check for tabs instead of h2/h3

### DIFF
--- a/frontend/e2e/browse-topics-and-view-details.spec.ts
+++ b/frontend/e2e/browse-topics-and-view-details.spec.ts
@@ -97,10 +97,14 @@ test.describe('Browse Topics and View Details', () => {
     const rightPanel = page.locator('[role="complementary"]').first();
     await expect(rightPanel).toBeVisible();
 
-    // Check for metadata sections
-    const metadataSections = rightPanel.locator('h2, h3');
-    const sectionCount = await metadataSections.count();
-    expect(sectionCount).toBeGreaterThan(0);
+    // Check for metadata panel tabs (Propositions, Common Ground, Bridging)
+    const tablist = rightPanel.locator('[role="tablist"]');
+    await expect(tablist).toBeVisible();
+
+    // Verify at least one tab is present
+    const tabs = rightPanel.locator('[role="tab"]');
+    const tabCount = await tabs.count();
+    expect(tabCount).toBeGreaterThan(0);
   });
 
   // Skip: Timeout waiting for topic-title element - TopicCard may not have data-testid on title


### PR DESCRIPTION
## Summary

Fixes E2E test failure introduced by ESLint 10 upgrade PR #819. The test `should display topic metadata in right panel` was checking for `h2, h3` elements in the right panel, but the MetadataPanel component actually renders a tablist with tab elements.

### Changes
- Updated test to check for `[role="tablist"]` and `[role="tab"]` instead of `h2, h3`
- This aligns the test with the actual MetadataPanel DOM structure

### Root Cause
The ESLint 10 upgrade PR #819 was auto-merged before the E2E test fix could be included. This PR brings the fix that was committed to the dependabot branch after merge.

## Test plan
- [ ] CI passes with all E2E tests
- [ ] `browse-topics-and-view-details.spec.ts:87` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)