### PR TITLE
fix(hooks): Use POSIX-compatible redirection in post-merge hook

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -52,7 +52,7 @@ if [ $INSTALL_NEEDED -eq 0 ]; then
   MISSING_PACKAGES=0
 
   # Check for critical hook dependencies
-  if ! command -v jq &> /dev/null; then
+  if ! command -v jq >/dev/null 2>&1; then
     warning "⚠️  jq not found (needed for hook scripts)"
     MISSING_PACKAGES=1
   fi
@@ -79,7 +79,7 @@ if [ $INSTALL_NEEDED -eq 1 ]; then
 
   # Detect package manager
   if [ -f "pnpm-lock.yaml" ]; then
-    if ! command -v pnpm &> /dev/null; then
+    if ! command -v pnpm >/dev/null 2>&1; then
       error "pnpm is required but not installed"
       echo "Install pnpm: npm install -g pnpm"
       exit 1
@@ -87,7 +87,7 @@ if [ $INSTALL_NEEDED -eq 1 ]; then
     pnpm install --frozen-lockfile 2>&1 | tail -5
     INSTALL_STATUS=$?
   elif [ -f "yarn.lock" ]; then
-    if ! command -v yarn &> /dev/null; then
+    if ! command -v yarn >/dev/null 2>&1; then
       error "yarn is required but not installed"
       echo "Install yarn: npm install -g yarn"
       exit 1


### PR DESCRIPTION
## Summary
- Fixed bash-only `&>/dev/null` syntax in post-merge hook that uses `#!/bin/sh`
- On Ubuntu, `/bin/sh` is `dash` which doesn't support `&>` redirection
- Changed to POSIX-compatible `>/dev/null 2>&1` syntax

## Problem
After `git pull` or `git merge`, the post-merge hook would fail with:
```
❌ pnpm is required but not installed
```
...even when pnpm was installed at `/usr/bin/pnpm`.

## Test plan
- [x] Verified `sh -c 'command -v pnpm >/dev/null 2>&1'` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)