### PR TITLE
feat(topics): Implement topic linking API (T217)

### DIFF
--- a/services/discussion-service/src/topics/dto/topic-link.dto.ts
+++ b/services/discussion-service/src/topics/dto/topic-link.dto.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IsEnum, IsOptional, IsUUID } from 'class-validator';
+import { TopicRelationshipType, LinkSource, ConfirmationStatus } from '@prisma/client';
+
+// Re-export Prisma enums for convenience
+export { TopicRelationshipType, LinkSource, ConfirmationStatus };
+
+/**
+ * DTO for creating a new topic link
+ * Feature 016: Topic Management - Topic Linking (T217)
+ */
+export class CreateTopicLinkDto {
+  /**
+   * ID of the target topic to link to
+   */
+  @IsUUID()
+  targetTopicId!: string;
+
+  /**
+   * Type of relationship between the topics
+   */
+  @IsEnum(TopicRelationshipType, {
+    message:
+      'relationshipType must be one of: BUILDS_ON, RESPONDS_TO, CONTRADICTS, RELATED, SHARES_PROPOSITION',
+  })
+  relationshipType!: TopicRelationshipType;
+
+  /**
+   * Source of the link (AI suggested or user proposed)
+   * Defaults to USER_PROPOSED
+   */
+  @IsOptional()
+  @IsEnum(LinkSource, {
+    message: 'linkSource must be AI_SUGGESTED or USER_PROPOSED',
+  })
+  linkSource?: LinkSource;
+}
+
+/**
+ * DTO for updating a topic link's confirmation status
+ */
+export class UpdateTopicLinkStatusDto {
+  /**
+   * New confirmation status
+   */
+  @IsEnum(ConfirmationStatus, {
+    message: 'status must be PENDING, CONFIRMED, or REJECTED',
+  })
+  status!: ConfirmationStatus;
+}
+
+/**
+ * Query parameters for getting topic links
+ */
+export class GetTopicLinksQueryDto {
+  /**
+   * Filter by relationship type
+   */
+  @IsOptional()
+  @IsEnum(TopicRelationshipType)
+  relationshipType?: TopicRelationshipType;
+
+  /**
+   * Filter by confirmation status
+   */
+  @IsOptional()
+  @IsEnum(ConfirmationStatus)
+  status?: ConfirmationStatus;
+
+  /**
+   * Filter by link source
+   */
+  @IsOptional()
+  @IsEnum(LinkSource)
+  linkSource?: LinkSource;
+}
+
+/**
+ * Response DTO for a topic link
+ */
+export interface TopicLinkResponseDto {
+  id: string;
+  sourceTopicId: string;
+  targetTopicId: string;
+  relationshipType: TopicRelationshipType;
+  linkSource: LinkSource;
+  confirmationStatus: ConfirmationStatus;
+  proposerId: string | null;
+  confirmedByCount: number;
+  rejectedByCount: number;
+  createdAt: Date;
+  sourceTopic?: {
+    id: string;
+    title: string;
+    slug: string;
+  };
+  targetTopic?: {
+    id: string;
+    title: string;
+    slug: string;
+  };
+}
+
+/**
+ * Response DTO for linked topics (simplified view)
+ */
+export interface LinkedTopicResponseDto {
+  id: string;
+  title: string;
+  slug: string;
+  relationshipType: TopicRelationshipType;
+  linkId: string;
+  confirmationStatus: ConfirmationStatus;
+}

--- a/services/discussion-service/src/topics/topic-links.controller.ts
+++ b/services/discussion-service/src/topics/topic-links.controller.ts
@@ -1,0 +1,197 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  Headers,
+  Request,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+} from '@nestjs/common';
+import { TopicLinksService } from './topic-links.service.js';
+import {
+  CreateTopicLinkDto,
+  UpdateTopicLinkStatusDto,
+  GetTopicLinksQueryDto,
+  type TopicLinkResponseDto,
+  type LinkedTopicResponseDto,
+} from './dto/topic-link.dto.js';
+
+/**
+ * Controller for topic links API
+ * Feature 016: Topic Management - Topic Linking (T217)
+ *
+ * Endpoints:
+ * - POST   /topics/:topicId/links      - Create a link from this topic to another
+ * - GET    /topics/:topicId/links      - Get all links for a topic
+ * - GET    /topics/:topicId/linked     - Get simplified list of linked topics
+ * - GET    /topics/:topicId/links/:id  - Get a specific link
+ * - PATCH  /topics/:topicId/links/:id  - Update link confirmation status
+ * - DELETE /topics/:topicId/links/:id  - Delete a link
+ */
+@Controller('topics/:topicId/links')
+export class TopicLinksController {
+  constructor(private readonly topicLinksService: TopicLinksService) {}
+
+  /**
+   * Create a new link from this topic to another
+   *
+   * @param topicId - Source topic ID (from URL)
+   * @param dto - Link creation details (target topic, relationship type)
+   * @param userIdHeader - User ID from API gateway header
+   * @param req - Request object for fallback user extraction
+   * @returns Created topic link
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async createLink(
+    @Param('topicId') topicId: string,
+    @Body() dto: CreateTopicLinkDto,
+    @Headers('x-user-id') userIdHeader: string | undefined,
+    @Request() req: any,
+  ): Promise<TopicLinkResponseDto> {
+    const userId = userIdHeader || req.user?.id || req.userId;
+
+    if (!userId) {
+      throw new NotFoundException('User ID not found. Authentication required.');
+    }
+
+    return this.topicLinksService.createLink(topicId, dto, userId);
+  }
+
+  /**
+   * Get all links for a topic (both as source and target)
+   *
+   * @param topicId - Topic ID
+   * @param query - Filter options (relationshipType, status, linkSource)
+   * @returns Array of topic links
+   */
+  @Get()
+  async getLinks(
+    @Param('topicId') topicId: string,
+    @Query() query: GetTopicLinksQueryDto,
+  ): Promise<TopicLinkResponseDto[]> {
+    return this.topicLinksService.getLinksForTopic(topicId, query);
+  }
+
+  /**
+   * Get a specific link by ID
+   *
+   * @param topicId - Topic ID (for validation)
+   * @param linkId - Link ID
+   * @returns Topic link
+   */
+  @Get(':linkId')
+  async getLink(
+    @Param('topicId') topicId: string,
+    @Param('linkId') linkId: string,
+  ): Promise<TopicLinkResponseDto> {
+    const link = await this.topicLinksService.getLinkById(linkId);
+
+    if (!link) {
+      throw new NotFoundException(`Topic link ${linkId} not found`);
+    }
+
+    // Verify the link belongs to this topic
+    if (link.sourceTopicId !== topicId && link.targetTopicId !== topicId) {
+      throw new NotFoundException(`Topic link ${linkId} not found for topic ${topicId}`);
+    }
+
+    return link;
+  }
+
+  /**
+   * Update a link's confirmation status
+   *
+   * @param topicId - Topic ID (for validation)
+   * @param linkId - Link ID
+   * @param dto - Status update (PENDING, CONFIRMED, REJECTED)
+   * @param userIdHeader - User ID from API gateway header
+   * @param req - Request object for fallback user extraction
+   * @returns Updated topic link
+   */
+  @Patch(':linkId')
+  async updateLinkStatus(
+    @Param('topicId') topicId: string,
+    @Param('linkId') linkId: string,
+    @Body() dto: UpdateTopicLinkStatusDto,
+    @Headers('x-user-id') userIdHeader: string | undefined,
+    @Request() req: any,
+  ): Promise<TopicLinkResponseDto> {
+    const userId = userIdHeader || req.user?.id || req.userId;
+
+    if (!userId) {
+      throw new NotFoundException('User ID not found. Authentication required.');
+    }
+
+    // Verify link exists and belongs to topic
+    const existingLink = await this.topicLinksService.getLinkById(linkId);
+    if (!existingLink) {
+      throw new NotFoundException(`Topic link ${linkId} not found`);
+    }
+    if (existingLink.sourceTopicId !== topicId && existingLink.targetTopicId !== topicId) {
+      throw new NotFoundException(`Topic link ${linkId} not found for topic ${topicId}`);
+    }
+
+    return this.topicLinksService.updateLinkStatus(linkId, dto, userId);
+  }
+
+  /**
+   * Delete a topic link
+   *
+   * @param topicId - Topic ID (for validation)
+   * @param linkId - Link ID
+   * @returns Deleted link
+   */
+  @Delete(':linkId')
+  async deleteLink(
+    @Param('topicId') topicId: string,
+    @Param('linkId') linkId: string,
+  ): Promise<TopicLinkResponseDto> {
+    // Verify link exists and belongs to topic
+    const existingLink = await this.topicLinksService.getLinkById(linkId);
+    if (!existingLink) {
+      throw new NotFoundException(`Topic link ${linkId} not found`);
+    }
+    if (existingLink.sourceTopicId !== topicId && existingLink.targetTopicId !== topicId) {
+      throw new NotFoundException(`Topic link ${linkId} not found for topic ${topicId}`);
+    }
+
+    return this.topicLinksService.deleteLink(linkId);
+  }
+}
+
+/**
+ * Separate controller for the simplified linked topics endpoint
+ * Mounted at /topics/:topicId/linked (without /links prefix)
+ */
+@Controller('topics/:topicId/linked')
+export class LinkedTopicsController {
+  constructor(private readonly topicLinksService: TopicLinksService) {}
+
+  /**
+   * Get simplified list of linked topics for display
+   *
+   * @param topicId - Topic ID
+   * @param confirmedOnly - Only return confirmed links (default: true)
+   * @returns Array of linked topics with relationship info
+   */
+  @Get()
+  async getLinkedTopics(
+    @Param('topicId') topicId: string,
+    @Query('confirmedOnly') confirmedOnly?: string,
+  ): Promise<LinkedTopicResponseDto[]> {
+    const onlyConfirmed = confirmedOnly !== 'false';
+    return this.topicLinksService.getLinkedTopics(topicId, onlyConfirmed);
+  }
+}

--- a/services/discussion-service/src/topics/topic-links.service.test.ts
+++ b/services/discussion-service/src/topics/topic-links.service.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
+
+import { TopicLinksService } from './topic-links.service.js';
+import { TopicRelationshipType, LinkSource, ConfirmationStatus } from './dto/topic-link.dto.js';
+
+const createMockPrismaService = () => ({
+  discussionTopic: {
+    findUnique: vi.fn(),
+  },
+  topicLink: {
+    findUnique: vi.fn(),
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+});
+
+const createMockTopic = (overrides = {}) => ({
+  id: 'topic-1',
+  title: 'Test Topic',
+  slug: 'test-topic',
+  ...overrides,
+});
+
+const createMockLink = (overrides = {}) => ({
+  id: 'link-1',
+  sourceTopicId: 'topic-1',
+  targetTopicId: 'topic-2',
+  relationshipType: TopicRelationshipType.RELATED,
+  linkSource: LinkSource.USER_PROPOSED,
+  confirmationStatus: ConfirmationStatus.PENDING,
+  proposerId: 'user-1',
+  confirmedByCount: 0,
+  rejectedByCount: 0,
+  createdAt: new Date('2026-02-11'),
+  sourceTopic: createMockTopic({ id: 'topic-1', title: 'Source Topic', slug: 'source-topic' }),
+  targetTopic: createMockTopic({ id: 'topic-2', title: 'Target Topic', slug: 'target-topic' }),
+  ...overrides,
+});
+
+describe('TopicLinksService', () => {
+  let service: TopicLinksService;
+  let mockPrisma: ReturnType<typeof createMockPrismaService>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = createMockPrismaService();
+    service = new TopicLinksService(mockPrisma as any);
+  });
+
+  describe('createLink', () => {
+    it('should create a new topic link', async () => {
+      const sourceTopic = createMockTopic({ id: 'topic-1' });
+      const targetTopic = createMockTopic({ id: 'topic-2' });
+      const createdLink = createMockLink();
+
+      mockPrisma.discussionTopic.findUnique
+        .mockResolvedValueOnce(sourceTopic)
+        .mockResolvedValueOnce(targetTopic);
+      mockPrisma.topicLink.findFirst.mockResolvedValue(null);
+      mockPrisma.topicLink.create.mockResolvedValue(createdLink);
+
+      const result = await service.createLink(
+        'topic-1',
+        {
+          targetTopicId: 'topic-2',
+          relationshipType: TopicRelationshipType.RELATED,
+        },
+        'user-1',
+      );
+
+      expect(result.id).toBe('link-1');
+      expect(result.sourceTopicId).toBe('topic-1');
+      expect(result.targetTopicId).toBe('topic-2');
+      expect(result.relationshipType).toBe(TopicRelationshipType.RELATED);
+      expect(mockPrisma.topicLink.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            sourceTopicId: 'topic-1',
+            targetTopicId: 'topic-2',
+            relationshipType: TopicRelationshipType.RELATED,
+            linkSource: LinkSource.USER_PROPOSED,
+            proposerId: 'user-1',
+          }),
+        }),
+      );
+    });
+
+    it('should throw NotFoundException when source topic does not exist', async () => {
+      mockPrisma.discussionTopic.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.createLink(
+          'nonexistent-topic',
+          {
+            targetTopicId: 'topic-2',
+            relationshipType: TopicRelationshipType.RELATED,
+          },
+          'user-1',
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException when target topic does not exist', async () => {
+      const sourceTopic = createMockTopic({ id: 'topic-1' });
+      mockPrisma.discussionTopic.findUnique
+        .mockResolvedValueOnce(sourceTopic)
+        .mockResolvedValueOnce(null);
+
+      await expect(
+        service.createLink(
+          'topic-1',
+          {
+            targetTopicId: 'nonexistent-topic',
+            relationshipType: TopicRelationshipType.RELATED,
+          },
+          'user-1',
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException when linking topic to itself', async () => {
+      const topic = createMockTopic({ id: 'topic-1' });
+      mockPrisma.discussionTopic.findUnique
+        .mockResolvedValueOnce(topic)
+        .mockResolvedValueOnce(topic);
+
+      await expect(
+        service.createLink(
+          'topic-1',
+          {
+            targetTopicId: 'topic-1',
+            relationshipType: TopicRelationshipType.RELATED,
+          },
+          'user-1',
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw ConflictException when link already exists', async () => {
+      const sourceTopic = createMockTopic({ id: 'topic-1' });
+      const targetTopic = createMockTopic({ id: 'topic-2' });
+      const existingLink = createMockLink();
+
+      mockPrisma.discussionTopic.findUnique
+        .mockResolvedValueOnce(sourceTopic)
+        .mockResolvedValueOnce(targetTopic);
+      mockPrisma.topicLink.findFirst.mockResolvedValue(existingLink);
+
+      await expect(
+        service.createLink(
+          'topic-1',
+          {
+            targetTopicId: 'topic-2',
+            relationshipType: TopicRelationshipType.RELATED,
+          },
+          'user-1',
+        ),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('getLinksForTopic', () => {
+    it('should return all links for a topic', async () => {
+      const links = [createMockLink(), createMockLink({ id: 'link-2' })];
+      mockPrisma.topicLink.findMany.mockResolvedValue(links);
+
+      const result = await service.getLinksForTopic('topic-1');
+
+      expect(result).toHaveLength(2);
+      expect(mockPrisma.topicLink.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            OR: [{ sourceTopicId: 'topic-1' }, { targetTopicId: 'topic-1' }],
+          },
+        }),
+      );
+    });
+
+    it('should filter by relationship type', async () => {
+      mockPrisma.topicLink.findMany.mockResolvedValue([]);
+
+      await service.getLinksForTopic('topic-1', {
+        relationshipType: TopicRelationshipType.BUILDS_ON,
+      });
+
+      expect(mockPrisma.topicLink.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            relationshipType: TopicRelationshipType.BUILDS_ON,
+          }),
+        }),
+      );
+    });
+
+    it('should filter by confirmation status', async () => {
+      mockPrisma.topicLink.findMany.mockResolvedValue([]);
+
+      await service.getLinksForTopic('topic-1', {
+        status: ConfirmationStatus.CONFIRMED,
+      });
+
+      expect(mockPrisma.topicLink.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            confirmationStatus: ConfirmationStatus.CONFIRMED,
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('getLinkedTopics', () => {
+    it('should return linked topics with simplified view', async () => {
+      const links = [createMockLink()];
+      mockPrisma.topicLink.findMany.mockResolvedValue(links);
+
+      const result = await service.getLinkedTopics('topic-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: 'topic-2',
+        title: 'Target Topic',
+        slug: 'target-topic',
+        relationshipType: TopicRelationshipType.RELATED,
+        linkId: 'link-1',
+      });
+    });
+
+    it('should return source topic when queried from target side', async () => {
+      const links = [createMockLink()];
+      mockPrisma.topicLink.findMany.mockResolvedValue(links);
+
+      const result = await service.getLinkedTopics('topic-2');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: 'topic-1',
+        title: 'Source Topic',
+        slug: 'source-topic',
+      });
+    });
+
+    it('should filter confirmed links by default', async () => {
+      mockPrisma.topicLink.findMany.mockResolvedValue([]);
+
+      await service.getLinkedTopics('topic-1');
+
+      expect(mockPrisma.topicLink.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            confirmationStatus: ConfirmationStatus.CONFIRMED,
+          }),
+        }),
+      );
+    });
+
+    it('should include all links when confirmedOnly is false', async () => {
+      mockPrisma.topicLink.findMany.mockResolvedValue([]);
+
+      await service.getLinkedTopics('topic-1', false);
+
+      expect(mockPrisma.topicLink.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.not.objectContaining({
+            confirmationStatus: expect.anything(),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('getLinkById', () => {
+    it('should return a link by ID', async () => {
+      const link = createMockLink();
+      mockPrisma.topicLink.findUnique.mockResolvedValue(link);
+
+      const result = await service.getLinkById('link-1');
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe('link-1');
+    });
+
+    it('should return null when link does not exist', async () => {
+      mockPrisma.topicLink.findUnique.mockResolvedValue(null);
+
+      const result = await service.getLinkById('nonexistent-link');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('updateLinkStatus', () => {
+    it('should update link status to CONFIRMED', async () => {
+      const existingLink = createMockLink();
+      const updatedLink = createMockLink({
+        confirmationStatus: ConfirmationStatus.CONFIRMED,
+        confirmedByCount: 1,
+      });
+
+      mockPrisma.topicLink.findUnique.mockResolvedValue(existingLink);
+      mockPrisma.topicLink.update.mockResolvedValue(updatedLink);
+
+      const result = await service.updateLinkStatus(
+        'link-1',
+        { status: ConfirmationStatus.CONFIRMED },
+        'user-1',
+      );
+
+      expect(result.confirmationStatus).toBe(ConfirmationStatus.CONFIRMED);
+      expect(mockPrisma.topicLink.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            confirmationStatus: ConfirmationStatus.CONFIRMED,
+            confirmedByCount: { increment: 1 },
+          }),
+        }),
+      );
+    });
+
+    it('should update link status to REJECTED', async () => {
+      const existingLink = createMockLink();
+      const updatedLink = createMockLink({
+        confirmationStatus: ConfirmationStatus.REJECTED,
+        rejectedByCount: 1,
+      });
+
+      mockPrisma.topicLink.findUnique.mockResolvedValue(existingLink);
+      mockPrisma.topicLink.update.mockResolvedValue(updatedLink);
+
+      const result = await service.updateLinkStatus(
+        'link-1',
+        { status: ConfirmationStatus.REJECTED },
+        'user-1',
+      );
+
+      expect(result.confirmationStatus).toBe(ConfirmationStatus.REJECTED);
+      expect(mockPrisma.topicLink.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            confirmationStatus: ConfirmationStatus.REJECTED,
+            rejectedByCount: { increment: 1 },
+          }),
+        }),
+      );
+    });
+
+    it('should throw NotFoundException when link does not exist', async () => {
+      mockPrisma.topicLink.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.updateLinkStatus(
+          'nonexistent-link',
+          { status: ConfirmationStatus.CONFIRMED },
+          'user-1',
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deleteLink', () => {
+    it('should delete a link', async () => {
+      const link = createMockLink();
+      mockPrisma.topicLink.findUnique.mockResolvedValue(link);
+      mockPrisma.topicLink.delete.mockResolvedValue(link);
+
+      const result = await service.deleteLink('link-1');
+
+      expect(result.id).toBe('link-1');
+      expect(mockPrisma.topicLink.delete).toHaveBeenCalledWith({
+        where: { id: 'link-1' },
+      });
+    });
+
+    it('should throw NotFoundException when link does not exist', async () => {
+      mockPrisma.topicLink.findUnique.mockResolvedValue(null);
+
+      await expect(service.deleteLink('nonexistent-link')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/services/discussion-service/src/topics/topic-links.service.ts
+++ b/services/discussion-service/src/topics/topic-links.service.ts
@@ -1,0 +1,347 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import type {
+  CreateTopicLinkDto,
+  UpdateTopicLinkStatusDto,
+  GetTopicLinksQueryDto,
+  TopicLinkResponseDto,
+  LinkedTopicResponseDto,
+} from './dto/topic-link.dto.js';
+import { LinkSource, ConfirmationStatus } from './dto/topic-link.dto.js';
+import { Prisma } from '@prisma/client';
+
+/**
+ * Service for managing topic links
+ * Feature 016: Topic Management - Topic Linking (T217)
+ *
+ * Topic links create bidirectional relationships between related discussion topics
+ * to improve content organization and discoverability.
+ */
+@Injectable()
+export class TopicLinksService {
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Create a new link between two topics
+   *
+   * @param sourceTopicId - ID of the source topic
+   * @param dto - Link creation details
+   * @param proposerId - ID of the user proposing the link
+   * @returns Created topic link
+   * @throws NotFoundException if either topic doesn't exist
+   * @throws BadRequestException if linking a topic to itself
+   * @throws ConflictException if link already exists
+   */
+  async createLink(
+    sourceTopicId: string,
+    dto: CreateTopicLinkDto,
+    proposerId: string,
+  ): Promise<TopicLinkResponseDto> {
+    // Validate source topic exists
+    const sourceTopic = await this.prisma.discussionTopic.findUnique({
+      where: { id: sourceTopicId },
+      select: { id: true, title: true, slug: true },
+    });
+
+    if (!sourceTopic) {
+      throw new NotFoundException(`Source topic ${sourceTopicId} not found`);
+    }
+
+    // Validate target topic exists
+    const targetTopic = await this.prisma.discussionTopic.findUnique({
+      where: { id: dto.targetTopicId },
+      select: { id: true, title: true, slug: true },
+    });
+
+    if (!targetTopic) {
+      throw new NotFoundException(`Target topic ${dto.targetTopicId} not found`);
+    }
+
+    // Prevent self-linking
+    if (sourceTopicId === dto.targetTopicId) {
+      throw new BadRequestException('Cannot link a topic to itself');
+    }
+
+    // Check if link already exists (in either direction with same relationship)
+    const existingLink = await this.prisma.topicLink.findFirst({
+      where: {
+        OR: [
+          {
+            sourceTopicId,
+            targetTopicId: dto.targetTopicId,
+            relationshipType: dto.relationshipType,
+          },
+          {
+            sourceTopicId: dto.targetTopicId,
+            targetTopicId: sourceTopicId,
+            relationshipType: dto.relationshipType,
+          },
+        ],
+      },
+    });
+
+    if (existingLink) {
+      throw new ConflictException(
+        `A ${dto.relationshipType} link already exists between these topics`,
+      );
+    }
+
+    // Create the link
+    const link = await this.prisma.topicLink.create({
+      data: {
+        sourceTopicId,
+        targetTopicId: dto.targetTopicId,
+        relationshipType: dto.relationshipType,
+        linkSource: dto.linkSource || LinkSource.USER_PROPOSED,
+        proposerId,
+        confirmationStatus: ConfirmationStatus.PENDING,
+      },
+      include: {
+        sourceTopic: {
+          select: { id: true, title: true, slug: true },
+        },
+        targetTopic: {
+          select: { id: true, title: true, slug: true },
+        },
+      },
+    });
+
+    return this.mapToResponseDto(link);
+  }
+
+  /**
+   * Get all links for a topic (both as source and target)
+   *
+   * @param topicId - ID of the topic
+   * @param query - Filter options
+   * @returns Array of topic links
+   */
+  async getLinksForTopic(
+    topicId: string,
+    query: GetTopicLinksQueryDto = {},
+  ): Promise<TopicLinkResponseDto[]> {
+    const where: Prisma.TopicLinkWhereInput = {
+      OR: [{ sourceTopicId: topicId }, { targetTopicId: topicId }],
+    };
+
+    if (query.relationshipType) {
+      where.relationshipType = query.relationshipType;
+    }
+
+    if (query.status) {
+      where.confirmationStatus = query.status;
+    }
+
+    if (query.linkSource) {
+      where.linkSource = query.linkSource;
+    }
+
+    const links = await this.prisma.topicLink.findMany({
+      where,
+      include: {
+        sourceTopic: {
+          select: { id: true, title: true, slug: true },
+        },
+        targetTopic: {
+          select: { id: true, title: true, slug: true },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return links.map((link) => this.mapToResponseDto(link));
+  }
+
+  /**
+   * Get linked topics for display (simplified view)
+   *
+   * @param topicId - ID of the topic
+   * @param confirmedOnly - Only return confirmed links (default: true)
+   * @returns Array of linked topics with relationship info
+   */
+  async getLinkedTopics(topicId: string, confirmedOnly = true): Promise<LinkedTopicResponseDto[]> {
+    const where: Prisma.TopicLinkWhereInput = {
+      OR: [{ sourceTopicId: topicId }, { targetTopicId: topicId }],
+    };
+
+    if (confirmedOnly) {
+      where.confirmationStatus = ConfirmationStatus.CONFIRMED;
+    }
+
+    const links = await this.prisma.topicLink.findMany({
+      where,
+      include: {
+        sourceTopic: {
+          select: { id: true, title: true, slug: true },
+        },
+        targetTopic: {
+          select: { id: true, title: true, slug: true },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return links.map((link) => {
+      // Return the "other" topic (not the one we're querying for)
+      const isSource = link.sourceTopicId === topicId;
+      const linkedTopic = isSource ? link.targetTopic : link.sourceTopic;
+
+      return {
+        id: linkedTopic.id,
+        title: linkedTopic.title,
+        slug: linkedTopic.slug,
+        relationshipType: link.relationshipType,
+        linkId: link.id,
+        confirmationStatus: link.confirmationStatus,
+      };
+    });
+  }
+
+  /**
+   * Get a specific link by ID
+   *
+   * @param linkId - ID of the link
+   * @returns Topic link or null
+   */
+  async getLinkById(linkId: string): Promise<TopicLinkResponseDto | null> {
+    const link = await this.prisma.topicLink.findUnique({
+      where: { id: linkId },
+      include: {
+        sourceTopic: {
+          select: { id: true, title: true, slug: true },
+        },
+        targetTopic: {
+          select: { id: true, title: true, slug: true },
+        },
+      },
+    });
+
+    if (!link) {
+      return null;
+    }
+
+    return this.mapToResponseDto(link);
+  }
+
+  /**
+   * Update a link's confirmation status
+   *
+   * @param linkId - ID of the link
+   * @param dto - Status update details
+   * @param userId - ID of the user updating (for vote tracking)
+   * @returns Updated topic link
+   * @throws NotFoundException if link doesn't exist
+   */
+  async updateLinkStatus(
+    linkId: string,
+    dto: UpdateTopicLinkStatusDto,
+    userId: string,
+  ): Promise<TopicLinkResponseDto> {
+    const existingLink = await this.prisma.topicLink.findUnique({
+      where: { id: linkId },
+    });
+
+    if (!existingLink) {
+      throw new NotFoundException(`Topic link ${linkId} not found`);
+    }
+
+    // Update confirmation counts based on status change
+    const updateData: Prisma.TopicLinkUpdateInput = {
+      confirmationStatus: dto.status,
+    };
+
+    if (dto.status === ConfirmationStatus.CONFIRMED) {
+      updateData.confirmedByCount = { increment: 1 };
+    } else if (dto.status === ConfirmationStatus.REJECTED) {
+      updateData.rejectedByCount = { increment: 1 };
+    }
+
+    const link = await this.prisma.topicLink.update({
+      where: { id: linkId },
+      data: updateData,
+      include: {
+        sourceTopic: {
+          select: { id: true, title: true, slug: true },
+        },
+        targetTopic: {
+          select: { id: true, title: true, slug: true },
+        },
+      },
+    });
+
+    return this.mapToResponseDto(link);
+  }
+
+  /**
+   * Delete a topic link
+   *
+   * @param linkId - ID of the link
+   * @returns Deleted link
+   * @throws NotFoundException if link doesn't exist
+   */
+  async deleteLink(linkId: string): Promise<TopicLinkResponseDto> {
+    const existingLink = await this.prisma.topicLink.findUnique({
+      where: { id: linkId },
+      include: {
+        sourceTopic: {
+          select: { id: true, title: true, slug: true },
+        },
+        targetTopic: {
+          select: { id: true, title: true, slug: true },
+        },
+      },
+    });
+
+    if (!existingLink) {
+      throw new NotFoundException(`Topic link ${linkId} not found`);
+    }
+
+    await this.prisma.topicLink.delete({
+      where: { id: linkId },
+    });
+
+    return this.mapToResponseDto(existingLink);
+  }
+
+  /**
+   * Map Prisma TopicLink to response DTO
+   */
+  private mapToResponseDto(link: any): TopicLinkResponseDto {
+    return {
+      id: link.id,
+      sourceTopicId: link.sourceTopicId,
+      targetTopicId: link.targetTopicId,
+      relationshipType: link.relationshipType,
+      linkSource: link.linkSource,
+      confirmationStatus: link.confirmationStatus,
+      proposerId: link.proposerId,
+      confirmedByCount: link.confirmedByCount,
+      rejectedByCount: link.rejectedByCount,
+      createdAt: link.createdAt,
+      sourceTopic: link.sourceTopic
+        ? {
+            id: link.sourceTopic.id,
+            title: link.sourceTopic.title,
+            slug: link.sourceTopic.slug,
+          }
+        : undefined,
+      targetTopic: link.targetTopic
+        ? {
+            id: link.targetTopic.id,
+            title: link.targetTopic.title,
+            slug: link.targetTopic.slug,
+          }
+        : undefined,
+    };
+  }
+}

--- a/services/discussion-service/src/topics/topics.module.ts
+++ b/services/discussion-service/src/topics/topics.module.ts
@@ -6,8 +6,10 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { TopicsController } from './topics.controller.js';
 import { TopicDraftsController } from './topic-drafts.controller.js';
+import { TopicLinksController, LinkedTopicsController } from './topic-links.controller.js';
 import { TopicsService } from './topics.service.js';
 import { TopicDraftsService } from './topic-drafts.service.js';
+import { TopicLinksService } from './topic-links.service.js';
 import { CommonGroundExportService } from '../services/common-ground-export.service.js';
 import { TopicsSearchService } from './topics-search.service.js';
 import { SlugGeneratorService } from './slug-generator.service.js';
@@ -19,16 +21,22 @@ import { PropositionsModule } from '../propositions/propositions.module.js';
 
 @Module({
   imports: [PrismaModule, CacheModule, PropositionsModule],
-  controllers: [TopicsController, TopicDraftsController],
+  controllers: [
+    TopicsController,
+    TopicDraftsController,
+    TopicLinksController,
+    LinkedTopicsController,
+  ],
   providers: [
     TopicsService,
     TopicDraftsService,
+    TopicLinksService,
     CommonGroundExportService,
     TopicsSearchService,
     SlugGeneratorService,
     TopicsEditService,
     TopicsAnalyticsService,
   ],
-  exports: [TopicsService, TopicDraftsService],
+  exports: [TopicsService, TopicDraftsService, TopicLinksService],
 })
 export class TopicsModule {}


### PR DESCRIPTION
## Summary

- Add REST API for creating bidirectional links between discussion topics
- Implement 5 relationship types: BUILDS_ON, RESPONDS_TO, CONTRADICTS, RELATED, SHARES_PROPOSITION
- Add link confirmation workflow (PENDING → CONFIRMED/REJECTED) for user validation
- Support AI-suggested vs user-proposed link sources
- Include comprehensive unit tests (19 tests)

## Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/topics/:topicId/links` | Create link from topic to another |
| GET | `/topics/:topicId/links` | Get all links for a topic |
| GET | `/topics/:topicId/links/:id` | Get specific link |
| PATCH | `/topics/:topicId/links/:id` | Update link status |
| DELETE | `/topics/:topicId/links/:id` | Delete link |
| GET | `/topics/:topicId/linked` | Simplified linked topics view |

## Test plan

- [x] Unit tests for TopicLinksService (19 tests passing)
- [ ] CI passes (lint, unit tests, integration)
- [ ] Manual API testing with Postman/curl

Closes #213

🤖 Generated with [Claude Code](https://claude.ai/code)