### PR TITLE
feat(recommendations): Implement topic recommendations for creators (T222)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,6 +842,12 @@ importers:
       '@reason-bridge/db-models':
         specifier: workspace:*
         version: link:../../packages/db-models
+      class-transformer:
+        specifier: ^0.5.1
+        version: 0.5.1
+      class-validator:
+        specifier: ^0.14.2
+        version: 0.14.3
       fastify:
         specifier: ^5.7.4
         version: 5.7.4

--- a/services/recommendation-service/package.json
+++ b/services/recommendation-service/package.json
@@ -22,6 +22,8 @@
     "@nestjs/platform-fastify": "^11.1.13",
     "@prisma/client": "7.3.0",
     "@reason-bridge/db-models": "workspace:*",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.2",
     "fastify": "^5.7.4",
     "reflect-metadata": "^0.2.1",
     "rxjs": "^7.8.1",

--- a/services/recommendation-service/src/app.module.ts
+++ b/services/recommendation-service/src/app.module.ts
@@ -6,9 +6,10 @@
 import { Module } from '@nestjs/common';
 import { HealthModule } from './health/health.module.js';
 import { PrismaModule } from './prisma/prisma.module.js';
+import { TopicRecommendationsModule } from './topic-recommendations/topic-recommendations.module.js';
 
 @Module({
-  imports: [PrismaModule, HealthModule],
+  imports: [PrismaModule, HealthModule, TopicRecommendationsModule],
   controllers: [],
   providers: [],
 })

--- a/services/recommendation-service/src/topic-recommendations/dto/topic-recommendation.dto.ts
+++ b/services/recommendation-service/src/topic-recommendations/dto/topic-recommendation.dto.ts
@@ -1,0 +1,201 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IsString, IsOptional, IsArray, IsInt, Min, Max, IsUUID } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+/**
+ * Query parameters for getting topic recommendations
+ */
+export class GetTopicRecommendationsDto {
+  /** Search query for finding similar topics */
+  @IsOptional()
+  @IsString()
+  query?: string;
+
+  /** Tags to match against */
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @Transform(({ value }) => (typeof value === 'string' ? value.split(',') : value))
+  tags?: string[];
+
+  /** Maximum number of recommendations to return */
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  @Transform(({ value }) => parseInt(value, 10))
+  limit?: number = 10;
+
+  /** User ID for personalized recommendations */
+  @IsOptional()
+  @IsUUID()
+  userId?: string;
+}
+
+/**
+ * Query parameters for similar topics search
+ */
+export class GetSimilarTopicsDto {
+  /** Topic ID to find similar topics for */
+  @IsUUID()
+  topicId!: string;
+
+  /** Maximum number of similar topics to return */
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(20)
+  @Transform(({ value }) => parseInt(value, 10))
+  limit?: number = 5;
+}
+
+/**
+ * Query parameters for trending topics
+ */
+export class GetTrendingTopicsDto {
+  /** Time window for trending calculation (hours) */
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(168) // 1 week
+  @Transform(({ value }) => parseInt(value, 10))
+  hours?: number = 24;
+
+  /** Maximum number of trending topics to return */
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  @Transform(({ value }) => parseInt(value, 10))
+  limit?: number = 10;
+
+  /** Filter by tags */
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @Transform(({ value }) => (typeof value === 'string' ? value.split(',') : value))
+  tags?: string[];
+}
+
+/**
+ * Tag information in recommendations
+ */
+export interface TagInfo {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+/**
+ * A single topic recommendation
+ */
+export interface TopicRecommendationDto {
+  /** Topic ID */
+  id: string;
+  /** Topic title */
+  title: string;
+  /** URL-friendly slug */
+  slug: string;
+  /** Topic description */
+  description: string;
+  /** Number of participants */
+  participantCount: number;
+  /** Number of responses */
+  responseCount: number;
+  /** Activity level */
+  activityLevel: 'LOW' | 'MEDIUM' | 'HIGH';
+  /** Associated tags */
+  tags: TagInfo[];
+  /** Recommendation score (0-1) */
+  score: number;
+  /** Reason for recommendation */
+  reason: string;
+  /** When the topic was created */
+  createdAt: string;
+  /** When the topic had last activity */
+  lastActivityAt: string;
+}
+
+/**
+ * Response containing topic recommendations
+ */
+export interface TopicRecommendationsResponseDto {
+  /** List of recommended topics */
+  recommendations: TopicRecommendationDto[];
+  /** Total number of matching topics */
+  total: number;
+  /** Query used for recommendations */
+  query?: string;
+  /** Tags used for filtering */
+  tags?: string[];
+}
+
+/**
+ * Similar topic with similarity score
+ */
+export interface SimilarTopicDto {
+  /** Topic ID */
+  id: string;
+  /** Topic title */
+  title: string;
+  /** URL-friendly slug */
+  slug: string;
+  /** Topic description */
+  description: string;
+  /** Associated tags */
+  tags: TagInfo[];
+  /** Similarity score (0-1) */
+  similarityScore: number;
+  /** Shared tags with the source topic */
+  sharedTags: string[];
+}
+
+/**
+ * Response containing similar topics
+ */
+export interface SimilarTopicsResponseDto {
+  /** Source topic ID */
+  sourceTopicId: string;
+  /** List of similar topics */
+  similarTopics: SimilarTopicDto[];
+}
+
+/**
+ * Trending topic with activity metrics
+ */
+export interface TrendingTopicDto {
+  /** Topic ID */
+  id: string;
+  /** Topic title */
+  title: string;
+  /** URL-friendly slug */
+  slug: string;
+  /** Topic description */
+  description: string;
+  /** Associated tags */
+  tags: TagInfo[];
+  /** Recent response count (in time window) */
+  recentResponseCount: number;
+  /** Recent participant count (in time window) */
+  recentParticipantCount: number;
+  /** Trending score */
+  trendingScore: number;
+  /** Rank in trending list */
+  rank: number;
+}
+
+/**
+ * Response containing trending topics
+ */
+export interface TrendingTopicsResponseDto {
+  /** List of trending topics */
+  topics: TrendingTopicDto[];
+  /** Time window in hours */
+  timeWindowHours: number;
+  /** When the trending data was calculated */
+  calculatedAt: string;
+}

--- a/services/recommendation-service/src/topic-recommendations/topic-recommendations.controller.test.ts
+++ b/services/recommendation-service/src/topic-recommendations/topic-recommendations.controller.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TopicRecommendationsController } from './topic-recommendations.controller.js';
+import type { TopicRecommendationsService } from './topic-recommendations.service.js';
+
+describe('TopicRecommendationsController', () => {
+  let controller: TopicRecommendationsController;
+  let mockService: Partial<TopicRecommendationsService>;
+
+  const mockRecommendationsResponse = {
+    recommendations: [
+      {
+        id: '123',
+        title: 'Test Topic',
+        slug: 'test-topic',
+        description: 'A test topic',
+        participantCount: 10,
+        responseCount: 20,
+        activityLevel: 'MEDIUM' as const,
+        tags: [{ id: 'tag-1', name: 'test', slug: 'test' }],
+        score: 0.8,
+        reason: 'matches your search',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        lastActivityAt: '2026-02-10T00:00:00.000Z',
+      },
+    ],
+    total: 1,
+    query: 'test',
+    tags: undefined,
+  };
+
+  const mockSimilarTopicsResponse = {
+    sourceTopicId: '123',
+    similarTopics: [
+      {
+        id: '456',
+        title: 'Similar Topic',
+        slug: 'similar-topic',
+        description: 'A similar topic',
+        tags: [{ id: 'tag-1', name: 'test', slug: 'test' }],
+        similarityScore: 0.75,
+        sharedTags: ['test'],
+      },
+    ],
+  };
+
+  const mockTrendingTopicsResponse = {
+    topics: [
+      {
+        id: '789',
+        title: 'Trending Topic',
+        slug: 'trending-topic',
+        description: 'A trending topic',
+        tags: [{ id: 'tag-2', name: 'trending', slug: 'trending' }],
+        recentResponseCount: 50,
+        recentParticipantCount: 25,
+        trendingScore: 0.9,
+        rank: 1,
+      },
+    ],
+    timeWindowHours: 24,
+    calculatedAt: '2026-02-10T12:00:00.000Z',
+  };
+
+  beforeEach(() => {
+    mockService = {
+      getRecommendations: vi.fn().mockResolvedValue(mockRecommendationsResponse),
+      getSimilarTopics: vi.fn().mockResolvedValue(mockSimilarTopicsResponse),
+      getTrendingTopics: vi.fn().mockResolvedValue(mockTrendingTopicsResponse),
+    };
+
+    controller = new TopicRecommendationsController(mockService as TopicRecommendationsService);
+  });
+
+  describe('getRecommendations', () => {
+    it('should return recommendations', async () => {
+      const result = await controller.getRecommendations({
+        query: 'test',
+        limit: 10,
+      });
+
+      expect(result).toEqual(mockRecommendationsResponse);
+      expect(mockService.getRecommendations).toHaveBeenCalledWith({
+        query: 'test',
+        limit: 10,
+      });
+    });
+
+    it('should pass tags to service', async () => {
+      await controller.getRecommendations({
+        tags: ['environment', 'science'],
+        limit: 5,
+      });
+
+      expect(mockService.getRecommendations).toHaveBeenCalledWith({
+        tags: ['environment', 'science'],
+        limit: 5,
+      });
+    });
+  });
+
+  describe('getSimilarTopics', () => {
+    it('should return similar topics for a topic ID', async () => {
+      const result = await controller.getSimilarTopics('123', 5);
+
+      expect(result).toEqual(mockSimilarTopicsResponse);
+      expect(mockService.getSimilarTopics).toHaveBeenCalledWith({
+        topicId: '123',
+        limit: 5,
+      });
+    });
+
+    it('should handle undefined limit', async () => {
+      await controller.getSimilarTopics('123', undefined);
+
+      expect(mockService.getSimilarTopics).toHaveBeenCalledWith({
+        topicId: '123',
+        limit: undefined,
+      });
+    });
+
+    it('should convert string limit to number', async () => {
+      await controller.getSimilarTopics('123', '10' as any);
+
+      expect(mockService.getSimilarTopics).toHaveBeenCalledWith({
+        topicId: '123',
+        limit: 10,
+      });
+    });
+  });
+
+  describe('getTrendingTopics', () => {
+    it('should return trending topics', async () => {
+      const result = await controller.getTrendingTopics({
+        hours: 24,
+        limit: 10,
+      });
+
+      expect(result).toEqual(mockTrendingTopicsResponse);
+      expect(mockService.getTrendingTopics).toHaveBeenCalledWith({
+        hours: 24,
+        limit: 10,
+      });
+    });
+
+    it('should pass tags filter to service', async () => {
+      await controller.getTrendingTopics({
+        hours: 48,
+        tags: ['politics'],
+        limit: 5,
+      });
+
+      expect(mockService.getTrendingTopics).toHaveBeenCalledWith({
+        hours: 48,
+        tags: ['politics'],
+        limit: 5,
+      });
+    });
+
+    it('should handle empty query parameters', async () => {
+      await controller.getTrendingTopics({});
+
+      expect(mockService.getTrendingTopics).toHaveBeenCalledWith({});
+    });
+  });
+});

--- a/services/recommendation-service/src/topic-recommendations/topic-recommendations.controller.ts
+++ b/services/recommendation-service/src/topic-recommendations/topic-recommendations.controller.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Controller, Get, Query, Param } from '@nestjs/common';
+import { TopicRecommendationsService } from './topic-recommendations.service.js';
+import {
+  GetTopicRecommendationsDto,
+  GetSimilarTopicsDto,
+  GetTrendingTopicsDto,
+} from './dto/topic-recommendation.dto.js';
+import type {
+  TopicRecommendationsResponseDto,
+  SimilarTopicsResponseDto,
+  TrendingTopicsResponseDto,
+} from './dto/topic-recommendation.dto.js';
+
+/**
+ * Controller for topic recommendation endpoints.
+ * Feature 016: Topic Management (T222)
+ *
+ * Provides recommendations to help creators:
+ * - Find similar existing topics (duplicate detection)
+ * - Discover trending discussions
+ * - Get personalized topic suggestions
+ */
+@Controller('topic-recommendations')
+export class TopicRecommendationsController {
+  constructor(private readonly recommendationsService: TopicRecommendationsService) {}
+
+  /**
+   * Get topic recommendations based on query and tags.
+   * Useful when a creator is drafting a new topic.
+   *
+   * @example GET /topic-recommendations?query=climate&tags=environment,science&limit=10
+   */
+  @Get()
+  async getRecommendations(
+    @Query() query: GetTopicRecommendationsDto,
+  ): Promise<TopicRecommendationsResponseDto> {
+    return this.recommendationsService.getRecommendations(query);
+  }
+
+  /**
+   * Find topics similar to a given topic.
+   * Useful for detecting potential duplicates or related discussions.
+   *
+   * @example GET /topic-recommendations/similar/123e4567-e89b-12d3-a456-426614174000?limit=5
+   */
+  @Get('similar/:topicId')
+  async getSimilarTopics(
+    @Param('topicId') topicId: string,
+    @Query('limit') limit?: number,
+  ): Promise<SimilarTopicsResponseDto> {
+    const dto: GetSimilarTopicsDto = {
+      topicId,
+      limit: limit ? Number(limit) : undefined,
+    };
+    return this.recommendationsService.getSimilarTopics(dto);
+  }
+
+  /**
+   * Get trending topics within a time window.
+   * Useful for showing creators what's popular.
+   *
+   * @example GET /topic-recommendations/trending?hours=24&limit=10&tags=politics
+   */
+  @Get('trending')
+  async getTrendingTopics(
+    @Query() query: GetTrendingTopicsDto,
+  ): Promise<TrendingTopicsResponseDto> {
+    return this.recommendationsService.getTrendingTopics(query);
+  }
+}

--- a/services/recommendation-service/src/topic-recommendations/topic-recommendations.module.ts
+++ b/services/recommendation-service/src/topic-recommendations/topic-recommendations.module.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Module } from '@nestjs/common';
+import { TopicRecommendationsController } from './topic-recommendations.controller.js';
+import { TopicRecommendationsService } from './topic-recommendations.service.js';
+
+/**
+ * Module for topic recommendations functionality.
+ * Feature 016: Topic Management (T222)
+ *
+ * Provides:
+ * - Topic recommendations based on query/tags
+ * - Similar topic detection
+ * - Trending topics discovery
+ */
+@Module({
+  controllers: [TopicRecommendationsController],
+  providers: [TopicRecommendationsService],
+  exports: [TopicRecommendationsService],
+})
+export class TopicRecommendationsModule {}

--- a/services/recommendation-service/src/topic-recommendations/topic-recommendations.service.test.ts
+++ b/services/recommendation-service/src/topic-recommendations/topic-recommendations.service.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NotFoundException } from '@nestjs/common';
+import { TopicRecommendationsService } from './topic-recommendations.service.js';
+
+const createMockPrismaService = () => ({
+  discussionTopic: {
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    count: vi.fn(),
+  },
+});
+
+describe('TopicRecommendationsService', () => {
+  let service: TopicRecommendationsService;
+  let mockPrisma: ReturnType<typeof createMockPrismaService>;
+
+  const mockTopic = {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    title: 'Climate Change Discussion',
+    slug: 'climate-change-discussion',
+    description: 'A discussion about climate change impacts',
+    participantCount: 25,
+    responseCount: 50,
+    activityLevel: 'HIGH',
+    status: 'ACTIVE',
+    visibility: 'PUBLIC',
+    createdAt: new Date('2026-01-01'),
+    lastActivityAt: new Date('2026-02-10'),
+    tags: [
+      {
+        tag: {
+          id: 'tag-1',
+          name: 'environment',
+          slug: 'environment',
+        },
+      },
+      {
+        tag: {
+          id: 'tag-2',
+          name: 'science',
+          slug: 'science',
+        },
+      },
+    ],
+  };
+
+  const mockTopic2 = {
+    ...mockTopic,
+    id: '223e4567-e89b-12d3-a456-426614174001',
+    title: 'Renewable Energy Solutions',
+    slug: 'renewable-energy-solutions',
+    description: 'Discussing renewable energy options',
+    participantCount: 15,
+    responseCount: 30,
+    activityLevel: 'MEDIUM',
+    tags: [
+      {
+        tag: {
+          id: 'tag-1',
+          name: 'environment',
+          slug: 'environment',
+        },
+      },
+      {
+        tag: {
+          id: 'tag-3',
+          name: 'technology',
+          slug: 'technology',
+        },
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = createMockPrismaService();
+    service = new TopicRecommendationsService(mockPrisma as any);
+  });
+
+  describe('getRecommendations', () => {
+    it('should return recommendations based on query', async () => {
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([mockTopic]);
+      mockPrisma.discussionTopic.count.mockResolvedValue(1);
+
+      const result = await service.getRecommendations({
+        query: 'climate',
+        limit: 10,
+      });
+
+      expect(result.recommendations).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.query).toBe('climate');
+      expect(result.recommendations[0].title).toBe('Climate Change Discussion');
+    });
+
+    it('should filter by tags', async () => {
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([mockTopic]);
+      mockPrisma.discussionTopic.count.mockResolvedValue(1);
+
+      await service.getRecommendations({
+        tags: ['environment', 'science'],
+        limit: 10,
+      });
+
+      expect(mockPrisma.discussionTopic.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: 'ACTIVE',
+            visibility: 'PUBLIC',
+            tags: expect.objectContaining({
+              some: expect.any(Object),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('should calculate recommendation scores', async () => {
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([mockTopic, mockTopic2]);
+      mockPrisma.discussionTopic.count.mockResolvedValue(2);
+
+      const result = await service.getRecommendations({
+        query: 'energy',
+        limit: 10,
+      });
+
+      // Results should be sorted by score (highest first)
+      expect(result.recommendations.length).toBe(2);
+      expect(result.recommendations[0].score).toBeGreaterThanOrEqual(
+        result.recommendations[1].score,
+      );
+    });
+
+    it('should include recommendation reasons', async () => {
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([mockTopic]);
+      mockPrisma.discussionTopic.count.mockResolvedValue(1);
+
+      const result = await service.getRecommendations({
+        query: 'climate',
+        tags: ['environment'],
+        limit: 10,
+      });
+
+      expect(result.recommendations[0].reason).toBeTruthy();
+      expect(result.recommendations[0].reason).toContain('matches your search');
+    });
+
+    it('should respect limit parameter', async () => {
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([mockTopic]);
+      mockPrisma.discussionTopic.count.mockResolvedValue(1);
+
+      await service.getRecommendations({ limit: 5 });
+
+      expect(mockPrisma.discussionTopic.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 5,
+        }),
+      );
+    });
+
+    it('should use default limit of 10', async () => {
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([]);
+      mockPrisma.discussionTopic.count.mockResolvedValue(0);
+
+      await service.getRecommendations({});
+
+      expect(mockPrisma.discussionTopic.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 10,
+        }),
+      );
+    });
+  });
+
+  describe('getSimilarTopics', () => {
+    it('should return similar topics based on shared tags', async () => {
+      mockPrisma.discussionTopic.findUnique.mockResolvedValue(mockTopic);
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([mockTopic2]);
+
+      const result = await service.getSimilarTopics({
+        topicId: mockTopic.id,
+        limit: 5,
+      });
+
+      expect(result.sourceTopicId).toBe(mockTopic.id);
+      expect(result.similarTopics).toHaveLength(1);
+      expect(result.similarTopics[0].sharedTags).toContain('environment');
+    });
+
+    it('should throw NotFoundException if topic not found', async () => {
+      mockPrisma.discussionTopic.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.getSimilarTopics({
+          topicId: 'nonexistent-id',
+          limit: 5,
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should calculate similarity scores', async () => {
+      mockPrisma.discussionTopic.findUnique.mockResolvedValue(mockTopic);
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([mockTopic2]);
+
+      const result = await service.getSimilarTopics({
+        topicId: mockTopic.id,
+        limit: 5,
+      });
+
+      // mockTopic has ['environment', 'science'], mockTopic2 has ['environment', 'technology']
+      // Intersection: ['environment'] (1), Union: ['environment', 'science', 'technology'] (3)
+      // Jaccard: 1/3 ≈ 0.333
+      expect(result.similarTopics[0].similarityScore).toBeCloseTo(1 / 3, 2);
+    });
+
+    it('should sort by similarity score', async () => {
+      const topic3 = {
+        ...mockTopic,
+        id: 'topic-3',
+        tags: [
+          { tag: { id: 'tag-1', name: 'environment', slug: 'environment' } },
+          { tag: { id: 'tag-2', name: 'science', slug: 'science' } },
+        ],
+      };
+
+      mockPrisma.discussionTopic.findUnique.mockResolvedValue(mockTopic);
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([mockTopic2, topic3]);
+
+      const result = await service.getSimilarTopics({
+        topicId: mockTopic.id,
+        limit: 5,
+      });
+
+      // topic3 should rank higher (identical tags)
+      expect(result.similarTopics[0].similarityScore).toBeGreaterThan(
+        result.similarTopics[1].similarityScore,
+      );
+    });
+
+    it('should respect limit parameter', async () => {
+      mockPrisma.discussionTopic.findUnique.mockResolvedValue(mockTopic);
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([mockTopic2]);
+
+      const result = await service.getSimilarTopics({
+        topicId: mockTopic.id,
+        limit: 1,
+      });
+
+      expect(result.similarTopics.length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('getTrendingTopics', () => {
+    const mockTopicWithCount = {
+      ...mockTopic,
+      _count: {
+        responses: 15,
+      },
+    };
+
+    it('should return trending topics within time window', async () => {
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([mockTopicWithCount]);
+
+      const result = await service.getTrendingTopics({
+        hours: 24,
+        limit: 10,
+      });
+
+      expect(result.topics).toHaveLength(1);
+      expect(result.timeWindowHours).toBe(24);
+      expect(result.calculatedAt).toBeTruthy();
+    });
+
+    it('should filter by lastActivityAt within time window', async () => {
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([]);
+
+      await service.getTrendingTopics({
+        hours: 48,
+        limit: 10,
+      });
+
+      expect(mockPrisma.discussionTopic.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            lastActivityAt: expect.objectContaining({
+              gte: expect.any(Date),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('should filter by tags', async () => {
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([mockTopicWithCount]);
+
+      await service.getTrendingTopics({
+        hours: 24,
+        tags: ['environment'],
+        limit: 10,
+      });
+
+      expect(mockPrisma.discussionTopic.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tags: expect.any(Object),
+          }),
+        }),
+      );
+    });
+
+    it('should calculate trending scores', async () => {
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([mockTopicWithCount]);
+
+      const result = await service.getTrendingTopics({
+        hours: 24,
+        limit: 10,
+      });
+
+      expect(result.topics[0].trendingScore).toBeGreaterThan(0);
+    });
+
+    it('should assign ranks', async () => {
+      const topic2WithCount = {
+        ...mockTopic2,
+        _count: { responses: 5 },
+      };
+
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([mockTopicWithCount, topic2WithCount]);
+
+      const result = await service.getTrendingTopics({
+        hours: 24,
+        limit: 10,
+      });
+
+      expect(result.topics[0].rank).toBe(1);
+      expect(result.topics[1].rank).toBe(2);
+    });
+
+    it('should use default hours of 24', async () => {
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([]);
+
+      const result = await service.getTrendingTopics({});
+
+      expect(result.timeWindowHours).toBe(24);
+    });
+
+    it('should use default limit of 10', async () => {
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([]);
+
+      await service.getTrendingTopics({});
+
+      expect(mockPrisma.discussionTopic.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 20, // 2x the limit for scoring
+        }),
+      );
+    });
+  });
+});

--- a/services/recommendation-service/src/topic-recommendations/topic-recommendations.service.ts
+++ b/services/recommendation-service/src/topic-recommendations/topic-recommendations.service.ts
@@ -1,0 +1,394 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import type {
+  GetTopicRecommendationsDto,
+  GetSimilarTopicsDto,
+  GetTrendingTopicsDto,
+  TopicRecommendationsResponseDto,
+  TopicRecommendationDto,
+  SimilarTopicsResponseDto,
+  SimilarTopicDto,
+  TrendingTopicsResponseDto,
+  TrendingTopicDto,
+  TagInfo,
+} from './dto/topic-recommendation.dto.js';
+
+/**
+ * Service for generating topic recommendations for creators.
+ * Helps users discover similar topics, trending discussions, and
+ * relevant content when creating new topics.
+ */
+@Injectable()
+export class TopicRecommendationsService {
+  private readonly logger = new Logger(TopicRecommendationsService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Get topic recommendations based on query and tags.
+   * Useful when a creator is drafting a new topic.
+   */
+  async getRecommendations(
+    dto: GetTopicRecommendationsDto,
+  ): Promise<TopicRecommendationsResponseDto> {
+    const { query, tags, limit = 10 } = dto;
+
+    // Build the where clause
+    const where: Record<string, unknown> = {
+      status: 'ACTIVE',
+      visibility: 'PUBLIC',
+    };
+
+    // Text search on title and description
+    if (query) {
+      where['OR'] = [
+        { title: { contains: query, mode: 'insensitive' } },
+        { description: { contains: query, mode: 'insensitive' } },
+      ];
+    }
+
+    // Filter by tags
+    if (tags && tags.length > 0) {
+      where['tags'] = {
+        some: {
+          tag: {
+            OR: [
+              { name: { in: tags.map((t) => t.toLowerCase()) } },
+              { slug: { in: tags.map((t) => t.toLowerCase()) } },
+            ],
+          },
+        },
+      };
+    }
+
+    // Get matching topics
+    const [topics, total] = await Promise.all([
+      this.prisma.discussionTopic.findMany({
+        where,
+        include: {
+          tags: {
+            include: {
+              tag: true,
+            },
+          },
+        },
+        orderBy: [
+          { responseCount: 'desc' },
+          { participantCount: 'desc' },
+          { lastActivityAt: 'desc' },
+        ],
+        take: limit,
+      }),
+      this.prisma.discussionTopic.count({ where }),
+    ]);
+
+    // Calculate scores and format recommendations
+    const recommendations: TopicRecommendationDto[] = topics.map((topic, index) => {
+      const score = this.calculateRecommendationScore(topic, query, tags);
+      const reason = this.generateRecommendationReason(topic, query, tags);
+
+      return {
+        id: topic.id,
+        title: topic.title,
+        slug: topic.slug,
+        description: topic.description,
+        participantCount: topic.participantCount,
+        responseCount: topic.responseCount,
+        activityLevel: topic.activityLevel as 'LOW' | 'MEDIUM' | 'HIGH',
+        tags: topic.tags.map((tt) => ({
+          id: tt.tag.id,
+          name: tt.tag.name,
+          slug: tt.tag.slug,
+        })),
+        score,
+        reason,
+        createdAt: topic.createdAt.toISOString(),
+        lastActivityAt: topic.lastActivityAt.toISOString(),
+      };
+    });
+
+    // Sort by score
+    recommendations.sort((a, b) => b.score - a.score);
+
+    return {
+      recommendations,
+      total,
+      query,
+      tags,
+    };
+  }
+
+  /**
+   * Find topics similar to a given topic.
+   * Useful for detecting potential duplicates or related discussions.
+   */
+  async getSimilarTopics(dto: GetSimilarTopicsDto): Promise<SimilarTopicsResponseDto> {
+    const { topicId, limit = 5 } = dto;
+
+    // Get the source topic
+    const sourceTopic = await this.prisma.discussionTopic.findUnique({
+      where: { id: topicId },
+      include: {
+        tags: {
+          include: {
+            tag: true,
+          },
+        },
+      },
+    });
+
+    if (!sourceTopic) {
+      throw new NotFoundException(`Topic with ID ${topicId} not found`);
+    }
+
+    const sourceTagIds = sourceTopic.tags.map((tt) => tt.tag.id);
+    const sourceTagNames = sourceTopic.tags.map((tt) => tt.tag.name);
+
+    // Find topics with overlapping tags (excluding the source topic)
+    const similarTopics = await this.prisma.discussionTopic.findMany({
+      where: {
+        id: { not: topicId },
+        status: 'ACTIVE',
+        visibility: 'PUBLIC',
+        tags: {
+          some: {
+            tagId: { in: sourceTagIds },
+          },
+        },
+      },
+      include: {
+        tags: {
+          include: {
+            tag: true,
+          },
+        },
+      },
+      orderBy: [{ responseCount: 'desc' }, { lastActivityAt: 'desc' }],
+      take: limit * 2, // Get more to filter and rank
+    });
+
+    // Calculate similarity scores
+    const scoredTopics: SimilarTopicDto[] = similarTopics.map((topic) => {
+      const topicTagNames = topic.tags.map((tt) => tt.tag.name);
+      const sharedTags = topicTagNames.filter((name) => sourceTagNames.includes(name));
+      const similarityScore = this.calculateTagSimilarity(sourceTagNames, topicTagNames);
+
+      return {
+        id: topic.id,
+        title: topic.title,
+        slug: topic.slug,
+        description: topic.description,
+        tags: topic.tags.map((tt) => ({
+          id: tt.tag.id,
+          name: tt.tag.name,
+          slug: tt.tag.slug,
+        })),
+        similarityScore,
+        sharedTags,
+      };
+    });
+
+    // Sort by similarity and take top results
+    scoredTopics.sort((a, b) => b.similarityScore - a.similarityScore);
+
+    return {
+      sourceTopicId: topicId,
+      similarTopics: scoredTopics.slice(0, limit),
+    };
+  }
+
+  /**
+   * Get trending topics within a time window.
+   * Useful for showing creators what's popular.
+   */
+  async getTrendingTopics(dto: GetTrendingTopicsDto): Promise<TrendingTopicsResponseDto> {
+    const { hours = 24, limit = 10, tags } = dto;
+
+    const timeWindowStart = new Date(Date.now() - hours * 60 * 60 * 1000);
+
+    // Build where clause
+    const where: Record<string, unknown> = {
+      status: 'ACTIVE',
+      visibility: 'PUBLIC',
+      lastActivityAt: { gte: timeWindowStart },
+    };
+
+    if (tags && tags.length > 0) {
+      where['tags'] = {
+        some: {
+          tag: {
+            OR: [
+              { name: { in: tags.map((t) => t.toLowerCase()) } },
+              { slug: { in: tags.map((t) => t.toLowerCase()) } },
+            ],
+          },
+        },
+      };
+    }
+
+    // Get topics with recent activity
+    const topics = await this.prisma.discussionTopic.findMany({
+      where,
+      include: {
+        tags: {
+          include: {
+            tag: true,
+          },
+        },
+        _count: {
+          select: {
+            responses: {
+              where: {
+                createdAt: { gte: timeWindowStart },
+              },
+            },
+          },
+        },
+      },
+      orderBy: [{ responseCount: 'desc' }, { participantCount: 'desc' }],
+      take: limit * 2, // Get more to calculate scores
+    });
+
+    // Calculate trending scores
+    const trendingTopics: TrendingTopicDto[] = topics.map((topic) => {
+      const recentResponseCount = (topic._count as { responses: number }).responses;
+      const trendingScore = this.calculateTrendingScore(
+        recentResponseCount,
+        topic.participantCount,
+        topic.lastActivityAt,
+        timeWindowStart,
+      );
+
+      return {
+        id: topic.id,
+        title: topic.title,
+        slug: topic.slug,
+        description: topic.description,
+        tags: topic.tags.map((tt) => ({
+          id: tt.tag.id,
+          name: tt.tag.name,
+          slug: tt.tag.slug,
+        })),
+        recentResponseCount,
+        recentParticipantCount: topic.participantCount,
+        trendingScore,
+        rank: 0, // Will be set after sorting
+      };
+    });
+
+    // Sort by trending score and assign ranks
+    trendingTopics.sort((a, b) => b.trendingScore - a.trendingScore);
+    const rankedTopics = trendingTopics.slice(0, limit).map((topic, index) => ({
+      ...topic,
+      rank: index + 1,
+    }));
+
+    return {
+      topics: rankedTopics,
+      timeWindowHours: hours,
+      calculatedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Calculate a recommendation score for a topic.
+   */
+  private calculateRecommendationScore(
+    topic: { responseCount: number; participantCount: number; activityLevel: string },
+    query?: string,
+    tags?: string[],
+  ): number {
+    let score = 0;
+
+    // Base score from engagement
+    score += Math.min(topic.responseCount / 100, 0.3); // Max 0.3 from responses
+    score += Math.min(topic.participantCount / 50, 0.2); // Max 0.2 from participants
+
+    // Activity level bonus
+    if (topic.activityLevel === 'HIGH') score += 0.2;
+    else if (topic.activityLevel === 'MEDIUM') score += 0.1;
+
+    // Query match bonus (if query provided)
+    if (query) score += 0.15;
+
+    // Tag match bonus (if tags provided)
+    if (tags && tags.length > 0) score += 0.15;
+
+    return Math.min(score, 1); // Cap at 1
+  }
+
+  /**
+   * Generate a human-readable reason for the recommendation.
+   */
+  private generateRecommendationReason(
+    topic: { responseCount: number; participantCount: number; activityLevel: string },
+    query?: string,
+    tags?: string[],
+  ): string {
+    const reasons: string[] = [];
+
+    if (query) {
+      reasons.push('matches your search');
+    }
+
+    if (tags && tags.length > 0) {
+      reasons.push(`shares tags: ${tags.slice(0, 3).join(', ')}`);
+    }
+
+    if (topic.activityLevel === 'HIGH') {
+      reasons.push('highly active discussion');
+    } else if (topic.responseCount > 20) {
+      reasons.push('active discussion');
+    }
+
+    if (topic.participantCount > 10) {
+      reasons.push('diverse perspectives');
+    }
+
+    return reasons.length > 0 ? reasons.join(', ') : 'relevant to your interests';
+  }
+
+  /**
+   * Calculate tag-based similarity between two topics.
+   * Uses Jaccard similarity coefficient.
+   */
+  private calculateTagSimilarity(tags1: string[], tags2: string[]): number {
+    if (tags1.length === 0 || tags2.length === 0) return 0;
+
+    const set1 = new Set(tags1.map((t) => t.toLowerCase()));
+    const set2 = new Set(tags2.map((t) => t.toLowerCase()));
+
+    const intersection = new Set([...set1].filter((x) => set2.has(x)));
+    const union = new Set([...set1, ...set2]);
+
+    return intersection.size / union.size;
+  }
+
+  /**
+   * Calculate a trending score based on recent activity.
+   */
+  private calculateTrendingScore(
+    recentResponses: number,
+    participantCount: number,
+    lastActivity: Date,
+    windowStart: Date,
+  ): number {
+    // Recent activity weight
+    const responseScore = Math.log2(recentResponses + 1) * 0.4;
+
+    // Participant diversity weight
+    const participantScore = Math.log2(participantCount + 1) * 0.3;
+
+    // Recency weight (more recent = higher score)
+    const recencyMs = lastActivity.getTime() - windowStart.getTime();
+    const windowMs = Date.now() - windowStart.getTime();
+    const recencyScore = (recencyMs / windowMs) * 0.3;
+
+    return responseScore + participantScore + recencyScore;
+  }
+}

--- a/services/recommendation-service/vitest.config.ts
+++ b/services/recommendation-service/vitest.config.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    // Only include .test.ts files - .spec.ts is reserved for E2E/Playwright tests
+    include: ['src/**/*.test.ts'],
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/*.integration.test.ts', // Run in integration test phase
+    ],
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './coverage/junit.xml',
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Implements Issue #218 [T222] - Topic recommendations for creators.

- Add topic recommendations module to recommendation-service
- Implement three recommendation types:
  - **Query/tag-based recommendations**: Match topics by search query and tags
  - **Similar topics**: Find topics with overlapping tags (duplicate detection)
  - **Trending topics**: Discover popular discussions in configurable time windows
- Add comprehensive unit test coverage (26 tests)

## Technical Details

### Scoring Algorithms
- **Recommendation score**: Engagement-based (responses, participants, activity level)
- **Similarity score**: Jaccard coefficient for tag overlap (`|A∩B|/|A∪B|`)
- **Trending score**: Recency-weighted calculation combining recent responses, participant diversity, and freshness

### API Endpoints
- `GET /topic-recommendations` - Query/tag-based recommendations
- `GET /topic-recommendations/similar/:topicId` - Find similar topics
- `GET /topic-recommendations/trending` - Get trending topics

### Files Changed
- `services/recommendation-service/src/topic-recommendations/` - New module
- `services/recommendation-service/src/app.module.ts` - Module registration
- `services/recommendation-service/vitest.config.ts` - Test configuration
- `services/recommendation-service/package.json` - Added class-validator/transformer

## Test plan

- [x] Unit tests pass (26 tests)
- [x] TypeScript typecheck passes
- [ ] CI pipeline passes
- [ ] Manual verification of API endpoints

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)