### PR TITLE
fix(ai-service): Export EmbeddingService from CacheModule

### DIFF
--- a/services/ai-service/src/cache/cache.module.ts
+++ b/services/ai-service/src/cache/cache.module.ts
@@ -96,6 +96,6 @@ const logger = new Logger('CacheModule');
     RedisCacheService,
     SemanticCacheService,
   ],
-  exports: [SemanticCacheService, RedisCacheService, NestCacheModule],
+  exports: [EmbeddingService, SemanticCacheService, RedisCacheService, NestCacheModule],
 })
 export class CacheModule {}


### PR DESCRIPTION
## Summary
- Fixed NestJS dependency injection error causing ai-service to crash on startup
- The `TopicDuplicateDetectorService` requires `EmbeddingService`, but it wasn't exported from `CacheModule`
- This caused all E2E tests to fail because the ai-service container kept exiting

## Root Cause
PR #845 introduced `TopicDuplicateModule` which imports `CacheModule` to get `EmbeddingService`, but `EmbeddingService` was never added to the exports array in `CacheModule`.

## Fix
Add `EmbeddingService` to the exports array in `services/ai-service/src/cache/cache.module.ts`.

## Test plan
- [x] ai-service unit tests pass (211 tests)
- [ ] E2E tests should now be able to start the ai-service container

🤖 Generated with [Claude Code](https://claude.com/claude-code)