### PR TITLE
fix(tests): Wrap TagSelector create tag assertion in waitFor

### DIFF
--- a/frontend/src/components/topics/__tests__/TagSelector.test.tsx
+++ b/frontend/src/components/topics/__tests__/TagSelector.test.tsx
@@ -208,12 +208,15 @@ describe('TagSelector', () => {
 
       await user.click(screen.getByText(/create "newtag"/i));
 
-      expect(onChange).toHaveBeenCalledWith([
-        expect.objectContaining({
-          name: 'newtag',
-          slug: 'newtag',
-        }),
-      ]);
+      // Wait for React to process state updates from handleSelectTag and clear()
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith([
+          expect.objectContaining({
+            name: 'newtag',
+            slug: 'newtag',
+          }),
+        ]);
+      });
     });
 
     it('should not show create option for existing tag', async () => {


### PR DESCRIPTION
## Summary
- Fix flaky TagSelector test "should create new tag when no exact match"
- Wrap the onChange assertion in `waitFor` to ensure React processes all state updates before assertion

## Root Cause
The click on "Create newtag" triggers `handleSelectTag` which calls multiple state updates:
- `onChange([...selectedTags, newTag])`
- `clear()` (sets query, results, error, isLoading)
- `setIsOpen(false)`
- `setHighlightedIndex(-1)`

With fake timers, these async state updates may not complete before the test assertion runs, causing intermittent failures.

## Test plan
- [x] TagSelector tests pass locally
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)