### PR TITLE
[T252] E2E: Follow user and view activity

### DIFF
--- a/frontend/e2e/follow-user-activity-feed.spec.ts
+++ b/frontend/e2e/follow-user-activity-feed.spec.ts
@@ -1,0 +1,320 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E test suite for Follow User and Activity Feed (T252)
+ *
+ * Tests the complete flow of:
+ * - Following a user from their profile page
+ * - Viewing the activity feed
+ * - Verifying followed users' activities appear in the feed
+ */
+
+// Check if running in E2E Docker mode with full backend
+const isE2EDocker = process.env.E2E_DOCKER === 'true';
+
+/**
+ * Helper to login with a demo account
+ */
+async function loginWithDemoAccount(
+  page: import('@playwright/test').Page,
+  accountName: string = 'Admin Adams',
+) {
+  await page.goto('/');
+  await page.getByRole('button', { name: /log in/i }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+
+  // Select demo account
+  await page.getByText(accountName).click();
+  const dialog = page.getByRole('dialog');
+  await dialog.getByRole('button', { name: /^log in$/i }).click();
+
+  // Wait for login to complete and modal to close
+  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 10000 });
+
+  // Wait for navigation and authentication state to stabilize
+  await page.waitForURL(/(\/$|\/topics)/, { timeout: 10000 });
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(200); // Critical: Allow token storage and state propagation to complete
+}
+
+test.describe('Follow User and Activity Feed', () => {
+  test.describe('Activity Feed Page - UI Tests', () => {
+    test.beforeEach(async ({ page }) => {
+      await loginWithDemoAccount(page);
+    });
+
+    test('should navigate to activity feed page', async ({ page }) => {
+      // Navigate to feed
+      await page.goto('/feed');
+
+      // Verify page renders
+      await expect(page.getByRole('heading', { name: /activity feed/i })).toBeVisible();
+    });
+
+    test('should show empty state when not following anyone', async ({ page }) => {
+      await page.goto('/feed');
+
+      // Check for empty state or activity list
+      const hasActivities = await page.getByTestId('activity-card').count();
+      if (hasActivities === 0) {
+        // Should show empty state message
+        await expect(page.getByText(/no activity yet/i)).toBeVisible();
+        await expect(page.getByText(/follow other users/i)).toBeVisible();
+      }
+    });
+
+    test('should have link to explore topics from empty state', async ({ page }) => {
+      await page.goto('/feed');
+
+      // If empty state, should have explore link
+      const emptyState = page.getByText(/no activity yet/i);
+      if (await emptyState.isVisible()) {
+        const exploreLink = page.getByRole('link', { name: /explore topics/i });
+        await expect(exploreLink).toBeVisible();
+        await expect(exploreLink).toHaveAttribute('href', '/topics');
+      }
+    });
+  });
+
+  test.describe('User Profile - Follow Button', () => {
+    test.beforeEach(async ({ page }) => {
+      await loginWithDemoAccount(page);
+    });
+
+    test('should display follow button on other user profile', async ({ page }) => {
+      // Navigate to topics page to find a user to follow
+      await page.goto('/topics');
+
+      // Click on a topic to see authors
+      const topicCard = page.locator('[data-testid="topic-card"]').first();
+      if (await topicCard.isVisible()) {
+        await topicCard.click();
+        await page.waitForLoadState('networkidle');
+
+        // Find a user link (topic author or response author)
+        const userLink = page.locator('a[href^="/profile/"]').first();
+        if (await userLink.isVisible()) {
+          await userLink.click();
+          await page.waitForLoadState('networkidle');
+
+          // Check for follow button (only shows for other users, not self)
+          const followButton = page.getByTestId('follow-button');
+          // The button may or may not be visible depending on if it's the same user
+          // If visible, it should be clickable
+          if (await followButton.isVisible()) {
+            await expect(followButton).toBeEnabled();
+          }
+        }
+      }
+    });
+  });
+
+  test.describe('Follow User Flow - Backend Required', () => {
+    // Skip backend-dependent tests when not in E2E Docker mode
+    test.skip(!isE2EDocker, 'Requires backend - runs in E2E Docker mode only');
+
+    test.beforeEach(async ({ page }) => {
+      await loginWithDemoAccount(page);
+    });
+
+    test('should toggle follow button state when clicked', async ({ page }) => {
+      // Find another user to follow
+      await page.goto('/topics');
+
+      // Wait for topics to load
+      await page.waitForSelector('[data-testid="topic-card"]', { timeout: 10000 });
+
+      // Click on a topic
+      const topicCard = page.locator('[data-testid="topic-card"]').first();
+      await topicCard.click();
+
+      // Find and navigate to a user profile
+      const userLink = page.locator('a[href^="/profile/"]').first();
+      await expect(userLink).toBeVisible({ timeout: 10000 });
+      await userLink.click();
+
+      await page.waitForLoadState('networkidle');
+
+      // Check for follow button
+      const followButton = page.getByTestId('follow-button');
+      if (await followButton.isVisible()) {
+        // Get initial state
+        const initialText = await followButton.textContent();
+        const isCurrentlyFollowing = initialText?.includes('Following');
+
+        // Click to toggle
+        await followButton.click();
+
+        // Wait for API call to complete
+        await page.waitForLoadState('networkidle');
+
+        // Verify state changed
+        const newText = await followButton.textContent();
+        if (isCurrentlyFollowing) {
+          expect(newText).toContain('Follow');
+        } else {
+          expect(newText).toContain('Following');
+        }
+      }
+    });
+
+    test('should show followed user activity in feed', async ({ page }) => {
+      // Step 1: Find and follow a user
+      await page.goto('/topics');
+      await page.waitForSelector('[data-testid="topic-card"]', { timeout: 10000 });
+
+      const topicCard = page.locator('[data-testid="topic-card"]').first();
+      await topicCard.click();
+
+      const userLink = page.locator('a[href^="/profile/"]').first();
+      await expect(userLink).toBeVisible({ timeout: 10000 });
+
+      // Get the user name before clicking
+      const userName = await userLink.textContent();
+      await userLink.click();
+      await page.waitForLoadState('networkidle');
+
+      // Follow the user if not already following
+      const followButton = page.getByTestId('follow-button');
+      if (await followButton.isVisible()) {
+        const buttonText = await followButton.textContent();
+        if (buttonText?.includes('Follow') && !buttonText?.includes('Following')) {
+          await followButton.click();
+          await page.waitForLoadState('networkidle');
+          await expect(followButton).toContainText('Following');
+        }
+      }
+
+      // Step 2: Navigate to activity feed
+      await page.goto('/feed');
+      await expect(page.getByRole('heading', { name: /activity feed/i })).toBeVisible();
+
+      // Step 3: Check if activities are shown
+      // Note: Activities may or may not be present depending on what the followed user has done
+      const activityCards = page.getByTestId('activity-card');
+      const activityCount = await activityCards.count();
+
+      if (activityCount > 0) {
+        // Verify activity cards have expected structure
+        const firstActivity = activityCards.first();
+        await expect(firstActivity).toBeVisible();
+
+        // Activity should have a user link
+        const activityUserLink = firstActivity.locator('a[href^="/profile/"]');
+        await expect(activityUserLink).toBeVisible();
+
+        // Activity should have a target link (topic/response)
+        const activityTargetLink = firstActivity.locator(
+          'a[href*="/discussions"], a[href*="/topics"]',
+        );
+        if (await activityTargetLink.isVisible()) {
+          await expect(activityTargetLink).toBeEnabled();
+        }
+      }
+    });
+
+    test('should navigate to topic from activity card', async ({ page }) => {
+      await page.goto('/feed');
+
+      // Check if there are any activity cards
+      const activityCards = page.getByTestId('activity-card');
+      const activityCount = await activityCards.count();
+
+      if (activityCount > 0) {
+        // Find a topic link in the first activity
+        const firstActivity = activityCards.first();
+        const topicLink = firstActivity.locator('a[href*="/discussions"]');
+
+        if (await topicLink.isVisible()) {
+          await topicLink.click();
+          await page.waitForLoadState('networkidle');
+
+          // Should navigate to discussions page
+          await expect(page).toHaveURL(/\/discussions/);
+        }
+      }
+    });
+
+    test('should navigate to user profile from activity card', async ({ page }) => {
+      await page.goto('/feed');
+
+      // Check if there are any activity cards
+      const activityCards = page.getByTestId('activity-card');
+      const activityCount = await activityCards.count();
+
+      if (activityCount > 0) {
+        // Find a user link in the first activity
+        const firstActivity = activityCards.first();
+        const userLink = firstActivity.locator('a[href^="/profile/"]');
+
+        if (await userLink.isVisible()) {
+          await userLink.click();
+          await page.waitForLoadState('networkidle');
+
+          // Should navigate to profile page
+          await expect(page).toHaveURL(/\/profile\//);
+        }
+      }
+    });
+
+    test('should load more activities when clicking load more button', async ({ page }) => {
+      await page.goto('/feed');
+
+      // Check if load more button exists (only shows when there are more activities)
+      const loadMoreButton = page.getByRole('button', { name: /load more/i });
+
+      if (await loadMoreButton.isVisible()) {
+        // Get initial activity count
+        const initialCount = await page.getByTestId('activity-card').count();
+
+        // Click load more
+        await loadMoreButton.click();
+
+        // Wait for loading to complete
+        await page.waitForLoadState('networkidle');
+
+        // Check if more activities were loaded
+        const newCount = await page.getByTestId('activity-card').count();
+        expect(newCount).toBeGreaterThanOrEqual(initialCount);
+      }
+    });
+  });
+
+  test.describe('Follow Button Accessibility', () => {
+    test.beforeEach(async ({ page }) => {
+      await loginWithDemoAccount(page);
+    });
+
+    test('follow button should have appropriate aria attributes', async ({ page }) => {
+      // Navigate to a user profile
+      await page.goto('/topics');
+      await page.waitForSelector('[data-testid="topic-card"]', { timeout: 10000 });
+
+      const topicCard = page.locator('[data-testid="topic-card"]').first();
+      await topicCard.click();
+
+      const userLink = page.locator('a[href^="/profile/"]').first();
+      if (await userLink.isVisible()) {
+        await userLink.click();
+        await page.waitForLoadState('networkidle');
+
+        const followButton = page.getByTestId('follow-button');
+        if (await followButton.isVisible()) {
+          // Check aria-label
+          await expect(followButton).toHaveAttribute('aria-label', /(follow|unfollow) user/i);
+
+          // Check aria-pressed
+          await expect(followButton).toHaveAttribute('aria-pressed');
+
+          // Check button type
+          await expect(followButton).toHaveAttribute('type', 'button');
+        }
+      }
+    });
+  });
+});

--- a/frontend/src/pages/Profile/UserProfilePage.tsx
+++ b/frontend/src/pages/Profile/UserProfilePage.tsx
@@ -13,6 +13,7 @@ import { useDelayedLoading } from '../../hooks/useDelayedLoading';
 import Card, { CardHeader, CardBody } from '../../components/ui/Card';
 import Button from '../../components/ui/Button';
 import ProfileSkeleton from '../../components/ui/skeletons/ProfileSkeleton';
+import { FollowButton } from '../../components/users';
 
 function UserProfilePage() {
   const { id } = useParams<{ id: string }>();
@@ -86,9 +87,12 @@ function UserProfilePage() {
       {/* Profile Header */}
       <Card>
         <CardHeader>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-            {user.displayName}
-          </h1>
+          <div className="flex items-center justify-between">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              {user.displayName}
+            </h1>
+            {id && <FollowButton userId={id} />}
+          </div>
         </CardHeader>
         <CardBody>
           <div className="space-y-4">


### PR DESCRIPTION
## Summary
- Add FollowButton to UserProfilePage enabling users to follow others from their profile
- Create comprehensive E2E test suite for follow functionality and activity feed

## Changes
- **frontend/src/pages/Profile/UserProfilePage.tsx**: Added FollowButton component to the profile header, allowing users to follow/unfollow directly from the profile page
- **frontend/e2e/follow-user-activity-feed.spec.ts**: New E2E test suite covering:
  - Activity feed page navigation and UI
  - Empty state display when not following anyone
  - Follow button visibility and accessibility on user profiles
  - Follow/unfollow toggle functionality (backend-dependent)
  - Activity feed displaying followed users' activities
  - Navigation from activity cards to topics and user profiles
  - Load more pagination
  - Accessibility attributes (aria-label, aria-pressed)

## Test plan
- [ ] E2E tests pass in CI (Docker mode)
- [ ] FollowButton renders on user profile pages (not on own profile)
- [ ] Follow/unfollow toggles state correctly
- [ ] Activity feed shows activities from followed users
- [ ] Links in activity cards navigate correctly

## Related Issue
Closes #248

---
Generated with [Claude Code](https://claude.com/claude-code)