### PR TITLE
[T254] Implement POST /fact-check/check endpoint

### DIFF
--- a/services/fact-check-service/src/app.module.ts
+++ b/services/fact-check-service/src/app.module.ts
@@ -7,9 +7,10 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from './prisma/prisma.module.js';
 import { HealthModule } from './health/health.module.js';
 import { ClientsModule } from './clients/clients.module.js';
+import { FactCheckModule } from './controllers/fact-check.module.js';
 
 @Module({
-  imports: [PrismaModule, HealthModule, ClientsModule],
+  imports: [PrismaModule, HealthModule, ClientsModule, FactCheckModule],
   controllers: [],
   providers: [],
 })

--- a/services/fact-check-service/src/controllers/__tests__/fact-check.controller.test.ts
+++ b/services/fact-check-service/src/controllers/__tests__/fact-check.controller.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BadRequestException } from '@nestjs/common';
+import { FactCheckController } from '../fact-check.controller.js';
+import { FactCheckService } from '../../services/fact-check.service.js';
+import type { CheckClaimsRequestDto, CheckClaimsResponseDto } from '../../dto/check-claims.dto.js';
+
+describe('FactCheckController', () => {
+  let controller: FactCheckController;
+  let mockFactCheckService: {
+    checkClaims: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    mockFactCheckService = {
+      checkClaims: vi.fn(),
+    };
+    controller = new FactCheckController(mockFactCheckService as unknown as FactCheckService);
+  });
+
+  describe('checkClaims', () => {
+    const validRequest: CheckClaimsRequestDto = {
+      responseId: '123e4567-e89b-12d3-a456-426614174000',
+      claims: [
+        {
+          text: 'The Earth is flat',
+          startOffset: 0,
+          endOffset: 17,
+        },
+      ],
+    };
+
+    it('should check claims successfully', async () => {
+      const mockResponse: CheckClaimsResponseDto = {
+        results: [
+          {
+            id: 'result-1',
+            claimText: 'The Earth is flat',
+            claimStartOffset: 0,
+            claimEndOffset: 17,
+            displayedAs: 'Related Context',
+            sources: [
+              {
+                provider: 'Snopes',
+                url: 'https://snopes.com/earth-flat',
+                title: 'Is the Earth Flat?',
+                publishedAt: '2023-01-01T00:00:00.000Z',
+                rating: 'False',
+                ratingDescription: 'False',
+                credibilityScore: 0.95,
+                retrievedAt: '2024-01-01T00:00:00.000Z',
+              },
+            ],
+            hasConflictingSources: false,
+            expiresAt: '2024-01-02T00:00:00.000Z',
+          },
+        ],
+        processingTimeMs: 100,
+      };
+
+      mockFactCheckService.checkClaims.mockResolvedValue(mockResponse);
+
+      const result = await controller.checkClaims(validRequest);
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFactCheckService.checkClaims).toHaveBeenCalledWith(validRequest);
+    });
+
+    it('should throw BadRequestException when responseId is missing', async () => {
+      const request = { claims: validRequest.claims } as CheckClaimsRequestDto;
+
+      await expect(controller.checkClaims(request)).rejects.toThrow(BadRequestException);
+      await expect(controller.checkClaims(request)).rejects.toThrow('responseId is required');
+    });
+
+    it('should throw BadRequestException when claims is not an array', async () => {
+      const request = {
+        responseId: '123',
+        claims: 'not an array',
+      } as unknown as CheckClaimsRequestDto;
+
+      await expect(controller.checkClaims(request)).rejects.toThrow(BadRequestException);
+      await expect(controller.checkClaims(request)).rejects.toThrow('claims array is required');
+    });
+
+    it('should throw BadRequestException when claims is empty', async () => {
+      const request: CheckClaimsRequestDto = {
+        responseId: '123',
+        claims: [],
+      };
+
+      await expect(controller.checkClaims(request)).rejects.toThrow(BadRequestException);
+      await expect(controller.checkClaims(request)).rejects.toThrow('claims array cannot be empty');
+    });
+
+    it('should throw BadRequestException when claim text is missing', async () => {
+      const request: CheckClaimsRequestDto = {
+        responseId: '123',
+        claims: [{ startOffset: 0, endOffset: 10 }] as CheckClaimsRequestDto['claims'],
+      };
+
+      await expect(controller.checkClaims(request)).rejects.toThrow(BadRequestException);
+      await expect(controller.checkClaims(request)).rejects.toThrow(
+        'claims[0].text is required and must be a string',
+      );
+    });
+
+    it('should throw BadRequestException when claim text is empty', async () => {
+      const request: CheckClaimsRequestDto = {
+        responseId: '123',
+        claims: [{ text: '   ', startOffset: 0, endOffset: 10 }],
+      };
+
+      await expect(controller.checkClaims(request)).rejects.toThrow(BadRequestException);
+      await expect(controller.checkClaims(request)).rejects.toThrow(
+        'claims[0].text cannot be empty',
+      );
+    });
+
+    it('should throw BadRequestException when claim text exceeds 1000 characters', async () => {
+      const request: CheckClaimsRequestDto = {
+        responseId: '123',
+        claims: [{ text: 'a'.repeat(1001), startOffset: 0, endOffset: 1001 }],
+      };
+
+      await expect(controller.checkClaims(request)).rejects.toThrow(BadRequestException);
+      await expect(controller.checkClaims(request)).rejects.toThrow(
+        'claims[0].text exceeds maximum length of 1000 characters',
+      );
+    });
+
+    it('should throw BadRequestException when startOffset is negative', async () => {
+      const request: CheckClaimsRequestDto = {
+        responseId: '123',
+        claims: [{ text: 'test claim', startOffset: -1, endOffset: 10 }],
+      };
+
+      await expect(controller.checkClaims(request)).rejects.toThrow(BadRequestException);
+      await expect(controller.checkClaims(request)).rejects.toThrow(
+        'claims[0].startOffset is required and must be a non-negative number',
+      );
+    });
+
+    it('should throw BadRequestException when endOffset is not greater than startOffset', async () => {
+      const request: CheckClaimsRequestDto = {
+        responseId: '123',
+        claims: [{ text: 'test claim', startOffset: 10, endOffset: 5 }],
+      };
+
+      await expect(controller.checkClaims(request)).rejects.toThrow(BadRequestException);
+      await expect(controller.checkClaims(request)).rejects.toThrow(
+        'claims[0].endOffset must be greater than startOffset',
+      );
+    });
+
+    it('should throw BadRequestException when more than 10 claims are provided', async () => {
+      const claims = Array.from({ length: 11 }, (_, i) => ({
+        text: `Claim ${i}`,
+        startOffset: i * 10,
+        endOffset: i * 10 + 9,
+      }));
+
+      const request: CheckClaimsRequestDto = {
+        responseId: '123',
+        claims,
+      };
+
+      await expect(controller.checkClaims(request)).rejects.toThrow(BadRequestException);
+      await expect(controller.checkClaims(request)).rejects.toThrow(
+        'Maximum 10 claims allowed per request',
+      );
+    });
+
+    it('should validate multiple claims and report the first error', async () => {
+      const request: CheckClaimsRequestDto = {
+        responseId: '123',
+        claims: [
+          { text: 'Valid claim', startOffset: 0, endOffset: 11 },
+          { text: '   ', startOffset: 12, endOffset: 20 }, // whitespace-only is not empty but trims to empty
+        ],
+      };
+
+      await expect(controller.checkClaims(request)).rejects.toThrow(BadRequestException);
+      await expect(controller.checkClaims(request)).rejects.toThrow(
+        'claims[1].text cannot be empty',
+      );
+    });
+  });
+});

--- a/services/fact-check-service/src/controllers/fact-check.controller.ts
+++ b/services/fact-check-service/src/controllers/fact-check.controller.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Body, Controller, Post, BadRequestException, Logger } from '@nestjs/common';
+import { FactCheckService } from '../services/fact-check.service.js';
+import type { CheckClaimsRequestDto, CheckClaimsResponseDto } from '../dto/check-claims.dto.js';
+
+/**
+ * Controller for fact-check operations
+ *
+ * T254: POST /fact-check/check endpoint
+ *
+ * Exposes endpoints for checking factual claims against external
+ * fact-checking databases. Results are presented as "Related Context"
+ * without rendering verdicts (per FR-012b).
+ */
+@Controller('fact-check')
+export class FactCheckController {
+  private readonly logger = new Logger(FactCheckController.name);
+
+  constructor(private readonly factCheckService: FactCheckService) {}
+
+  /**
+   * Check claims for fact-check information
+   *
+   * POST /fact-check/check
+   *
+   * @param request - Claims to check
+   * @returns Fact-check results from external providers
+   */
+  @Post('check')
+  async checkClaims(@Body() request: CheckClaimsRequestDto): Promise<CheckClaimsResponseDto> {
+    // Validate required fields
+    if (!request.responseId) {
+      throw new BadRequestException('responseId is required');
+    }
+
+    if (!request.claims || !Array.isArray(request.claims)) {
+      throw new BadRequestException('claims array is required');
+    }
+
+    if (request.claims.length === 0) {
+      throw new BadRequestException('claims array cannot be empty');
+    }
+
+    // Validate each claim
+    request.claims.forEach((claim, i) => {
+      if (!claim || !claim.text || typeof claim.text !== 'string') {
+        throw new BadRequestException(`claims[${i}].text is required and must be a string`);
+      }
+
+      if (claim.text.trim().length === 0) {
+        throw new BadRequestException(`claims[${i}].text cannot be empty`);
+      }
+
+      if (claim.text.length > 1000) {
+        throw new BadRequestException(
+          `claims[${i}].text exceeds maximum length of 1000 characters`,
+        );
+      }
+
+      if (typeof claim.startOffset !== 'number' || claim.startOffset < 0) {
+        throw new BadRequestException(
+          `claims[${i}].startOffset is required and must be a non-negative number`,
+        );
+      }
+
+      if (typeof claim.endOffset !== 'number' || claim.endOffset < 0) {
+        throw new BadRequestException(
+          `claims[${i}].endOffset is required and must be a non-negative number`,
+        );
+      }
+
+      if (claim.endOffset <= claim.startOffset) {
+        throw new BadRequestException(`claims[${i}].endOffset must be greater than startOffset`);
+      }
+    });
+
+    // Limit number of claims per request
+    const maxClaims = 10;
+    if (request.claims.length > maxClaims) {
+      throw new BadRequestException(`Maximum ${maxClaims} claims allowed per request`);
+    }
+
+    this.logger.log(`Checking ${request.claims.length} claims for response ${request.responseId}`);
+
+    return this.factCheckService.checkClaims(request);
+  }
+}

--- a/services/fact-check-service/src/controllers/fact-check.module.ts
+++ b/services/fact-check-service/src/controllers/fact-check.module.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Module } from '@nestjs/common';
+import { FactCheckController } from './fact-check.controller.js';
+import { FactCheckService } from '../services/fact-check.service.js';
+
+/**
+ * Module for fact-check endpoints
+ *
+ * T254: POST /fact-check/check endpoint
+ */
+@Module({
+  controllers: [FactCheckController],
+  providers: [FactCheckService],
+  exports: [FactCheckService],
+})
+export class FactCheckModule {}

--- a/services/fact-check-service/src/dto/check-claims.dto.ts
+++ b/services/fact-check-service/src/dto/check-claims.dto.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Request to check claims for fact-check information
+ * T254: POST /fact-check/check endpoint
+ */
+export interface CheckClaimsRequestDto {
+  /** Response ID containing the claims */
+  responseId: string;
+  /** Claims to check */
+  claims: ClaimDto[];
+}
+
+/**
+ * Individual claim to check
+ */
+export interface ClaimDto {
+  /** The factual claim text to check */
+  text: string;
+  /** Start position in original response */
+  startOffset: number;
+  /** End position in original response */
+  endOffset: number;
+}
+
+/**
+ * Response from checking claims
+ */
+export interface CheckClaimsResponseDto {
+  /** Fact-check results for each claim */
+  results: FactCheckResultDto[];
+  /** Processing time in milliseconds */
+  processingTimeMs: number;
+}
+
+/**
+ * Fact-check result for a single claim
+ */
+export interface FactCheckResultDto {
+  /** Unique identifier for this result */
+  id: string;
+  /** The original claim text that was checked */
+  claimText: string;
+  /** Start position in original response */
+  claimStartOffset?: number;
+  /** End position in original response */
+  claimEndOffset?: number;
+  /** UI label - always "Related Context" per FR-012b */
+  displayedAs: string;
+  /** Array of fact-check sources */
+  sources: FactCheckSourceDto[];
+  /** Whether sources have conflicting assessments */
+  hasConflictingSources: boolean;
+  /** Explanation of conflict if sources disagree */
+  conflictSummary?: string;
+  /** When this result expires (24h default) */
+  expiresAt: string;
+}
+
+/**
+ * Source of fact-check information
+ */
+export interface FactCheckSourceDto {
+  /** Fact-check provider name */
+  provider: string;
+  /** URL to the fact-check article */
+  url: string;
+  /** Title of the fact-check article */
+  title: string;
+  /** When the fact-check was published */
+  publishedAt?: string;
+  /** Rating from the provider (passed through, not interpreted) */
+  rating?: string;
+  /** Full description of the rating */
+  ratingDescription?: string;
+  /** Credibility score of the source (0-1) */
+  credibilityScore: number;
+  /** When this result was retrieved */
+  retrievedAt: string;
+}

--- a/services/fact-check-service/src/dto/index.ts
+++ b/services/fact-check-service/src/dto/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './check-claims.dto.js';

--- a/services/fact-check-service/src/services/__tests__/fact-check.service.test.ts
+++ b/services/fact-check-service/src/services/__tests__/fact-check.service.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FactCheckService } from '../fact-check.service.js';
+import type { IFactCheckClient } from '../../clients/abstract-fact-check.client.js';
+import type { FactCheckResult, FactCheckClientHealth } from '../../clients/types.js';
+import type { CheckClaimsRequestDto } from '../../dto/check-claims.dto.js';
+
+describe('FactCheckService', () => {
+  let service: FactCheckService;
+  let mockClient: {
+    name: string;
+    checkClaim: ReturnType<typeof vi.fn>;
+    getHealth: ReturnType<typeof vi.fn>;
+    isConfigured: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    mockClient = {
+      name: 'mock-client',
+      checkClaim: vi.fn(),
+      getHealth: vi.fn(),
+      isConfigured: vi.fn().mockReturnValue(true),
+    };
+    service = new FactCheckService([mockClient as unknown as IFactCheckClient]);
+  });
+
+  describe('checkClaims', () => {
+    const validRequest: CheckClaimsRequestDto = {
+      responseId: '123e4567-e89b-12d3-a456-426614174000',
+      claims: [
+        {
+          text: 'The Earth is flat',
+          startOffset: 0,
+          endOffset: 17,
+        },
+      ],
+    };
+
+    it('should return empty results when no clients are configured', async () => {
+      const emptyService = new FactCheckService([]);
+
+      const result = await emptyService.checkClaims(validRequest);
+
+      expect(result.results).toHaveLength(0);
+      expect(result.processingTimeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should process claims and return results', async () => {
+      const mockResult: FactCheckResult = {
+        claimText: 'The Earth is flat',
+        sources: [
+          {
+            source: 'Snopes',
+            title: 'Is the Earth Flat?',
+            url: 'https://snopes.com/earth-flat',
+            publishedAt: new Date('2023-01-01'),
+            rating: 'False',
+            excerpt: 'The Earth is not flat',
+            sourceCredibility: 95,
+          },
+        ],
+        hasConflictingSources: false,
+        checkedAt: new Date(),
+        expiresAt: new Date(Date.now() + 86400000),
+      };
+
+      mockClient.checkClaim.mockResolvedValue(mockResult);
+
+      const result = await service.checkClaims(validRequest);
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].claimText).toBe('The Earth is flat');
+      expect(result.results[0].displayedAs).toBe('Related Context');
+      expect(result.results[0].sources).toHaveLength(1);
+      expect(result.results[0].sources[0].provider).toBe('Snopes');
+      expect(result.results[0].sources[0].credibilityScore).toBe(0.95);
+      expect(result.processingTimeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should return empty results when no fact-checks found', async () => {
+      mockClient.checkClaim.mockResolvedValue(null);
+
+      const result = await service.checkClaims(validRequest);
+
+      expect(result.results).toHaveLength(0);
+    });
+
+    it('should process multiple claims in parallel', async () => {
+      const request: CheckClaimsRequestDto = {
+        responseId: '123',
+        claims: [
+          { text: 'Claim 1', startOffset: 0, endOffset: 7 },
+          { text: 'Claim 2', startOffset: 10, endOffset: 17 },
+        ],
+      };
+
+      mockClient.checkClaim
+        .mockResolvedValueOnce({
+          claimText: 'Claim 1',
+          sources: [
+            {
+              source: 'Source 1',
+              title: 'Title 1',
+              url: 'https://example.com/1',
+              publishedAt: new Date(),
+              sourceCredibility: 80,
+            },
+          ],
+          hasConflictingSources: false,
+          checkedAt: new Date(),
+          expiresAt: new Date(Date.now() + 86400000),
+        })
+        .mockResolvedValueOnce({
+          claimText: 'Claim 2',
+          sources: [
+            {
+              source: 'Source 2',
+              title: 'Title 2',
+              url: 'https://example.com/2',
+              publishedAt: new Date(),
+              sourceCredibility: 90,
+            },
+          ],
+          hasConflictingSources: false,
+          checkedAt: new Date(),
+          expiresAt: new Date(Date.now() + 86400000),
+        });
+
+      const result = await service.checkClaims(request);
+
+      expect(result.results).toHaveLength(2);
+      expect(mockClient.checkClaim).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle client errors gracefully', async () => {
+      mockClient.checkClaim.mockRejectedValue(new Error('API error'));
+
+      const result = await service.checkClaims(validRequest);
+
+      expect(result.results).toHaveLength(0);
+    });
+
+    it('should detect conflicting sources', async () => {
+      const mockResult: FactCheckResult = {
+        claimText: 'Test claim',
+        sources: [
+          {
+            source: 'Source A',
+            title: 'Title A',
+            url: 'https://a.com',
+            publishedAt: new Date(),
+            rating: 'True',
+            sourceCredibility: 90,
+          },
+          {
+            source: 'Source B',
+            title: 'Title B',
+            url: 'https://b.com',
+            publishedAt: new Date(),
+            rating: 'False',
+            sourceCredibility: 85,
+          },
+        ],
+        hasConflictingSources: true,
+        checkedAt: new Date(),
+        expiresAt: new Date(Date.now() + 86400000),
+      };
+
+      mockClient.checkClaim.mockResolvedValue(mockResult);
+
+      const result = await service.checkClaims(validRequest);
+
+      expect(result.results[0].hasConflictingSources).toBe(true);
+      expect(result.results[0].conflictSummary).toBe(
+        'Multiple fact-checking sources have different assessments for this claim.',
+      );
+    });
+
+    it('should include claim offsets in results', async () => {
+      const mockResult: FactCheckResult = {
+        claimText: 'The Earth is flat',
+        sources: [
+          {
+            source: 'Snopes',
+            title: 'Is the Earth Flat?',
+            url: 'https://snopes.com/earth-flat',
+            publishedAt: new Date(),
+            sourceCredibility: 95,
+          },
+        ],
+        hasConflictingSources: false,
+        checkedAt: new Date(),
+        expiresAt: new Date(Date.now() + 86400000),
+      };
+
+      mockClient.checkClaim.mockResolvedValue(mockResult);
+
+      const result = await service.checkClaims(validRequest);
+
+      expect(result.results[0].claimStartOffset).toBe(0);
+      expect(result.results[0].claimEndOffset).toBe(17);
+    });
+
+    it('should sort sources by credibility (highest first)', async () => {
+      const mockResult: FactCheckResult = {
+        claimText: 'Test claim',
+        sources: [
+          {
+            source: 'Low credibility',
+            title: 'Title',
+            url: 'https://low.com',
+            publishedAt: new Date(),
+            sourceCredibility: 50,
+          },
+          {
+            source: 'High credibility',
+            title: 'Title',
+            url: 'https://high.com',
+            publishedAt: new Date(),
+            sourceCredibility: 95,
+          },
+          {
+            source: 'Medium credibility',
+            title: 'Title',
+            url: 'https://medium.com',
+            publishedAt: new Date(),
+            sourceCredibility: 75,
+          },
+        ],
+        hasConflictingSources: false,
+        checkedAt: new Date(),
+        expiresAt: new Date(Date.now() + 86400000),
+      };
+
+      mockClient.checkClaim.mockResolvedValue(mockResult);
+
+      const result = await service.checkClaims(validRequest);
+
+      expect(result.results[0].sources[0].credibilityScore).toBe(0.95);
+      expect(result.results[0].sources[1].credibilityScore).toBe(0.75);
+      expect(result.results[0].sources[2].credibilityScore).toBe(0.5);
+    });
+  });
+
+  describe('getProvidersHealth', () => {
+    it('should return health status of all providers', async () => {
+      const mockHealth: FactCheckClientHealth = {
+        isHealthy: true,
+        message: 'Operational',
+        recentErrorCount: 0,
+      };
+
+      mockClient.getHealth.mockResolvedValue(mockHealth);
+
+      const result = await service.getProvidersHealth();
+
+      expect(result.providers).toHaveLength(1);
+      expect(result.providers[0].name).toBe('mock-client');
+      expect(result.providers[0].isHealthy).toBe(true);
+      expect(result.providers[0].message).toBe('Operational');
+    });
+
+    it('should handle multiple providers', async () => {
+      const secondClient = {
+        name: 'second-client',
+        checkClaim: vi.fn(),
+        getHealth: vi.fn().mockResolvedValue({
+          isHealthy: false,
+          message: 'API key not configured',
+          recentErrorCount: 0,
+        }),
+        isConfigured: vi.fn().mockReturnValue(false),
+      };
+
+      mockClient.getHealth.mockResolvedValue({
+        isHealthy: true,
+        message: 'Operational',
+        recentErrorCount: 0,
+      });
+
+      const multiService = new FactCheckService([
+        mockClient as unknown as IFactCheckClient,
+        secondClient as unknown as IFactCheckClient,
+      ]);
+
+      const result = await multiService.getProvidersHealth();
+
+      expect(result.providers).toHaveLength(2);
+      expect(result.providers[0].isHealthy).toBe(true);
+      expect(result.providers[1].isHealthy).toBe(false);
+    });
+  });
+});

--- a/services/fact-check-service/src/services/fact-check.service.ts
+++ b/services/fact-check-service/src/services/fact-check.service.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import type { IFactCheckClient } from '../clients/abstract-fact-check.client.js';
+import { FACT_CHECK_CLIENTS } from '../clients/abstract-fact-check.client.js';
+import type {
+  CheckClaimsRequestDto,
+  CheckClaimsResponseDto,
+  FactCheckResultDto,
+  FactCheckSourceDto,
+  ClaimDto,
+} from '../dto/check-claims.dto.js';
+
+/**
+ * Service for coordinating fact-checks across multiple providers
+ *
+ * T254: POST /fact-check/check endpoint implementation
+ *
+ * This service aggregates results from all configured fact-check clients
+ * and transforms them into the API response format.
+ */
+@Injectable()
+export class FactCheckService {
+  private readonly logger = new Logger(FactCheckService.name);
+
+  constructor(
+    @Inject(FACT_CHECK_CLIENTS)
+    private readonly factCheckClients: IFactCheckClient[],
+  ) {
+    this.logger.log(
+      `FactCheckService initialized with ${this.factCheckClients.length} configured client(s)`,
+    );
+  }
+
+  /**
+   * Check multiple claims for fact-check information
+   *
+   * @param request - The claims to check
+   * @returns Aggregated fact-check results from all providers
+   */
+  async checkClaims(request: CheckClaimsRequestDto): Promise<CheckClaimsResponseDto> {
+    const startTime = Date.now();
+
+    if (this.factCheckClients.length === 0) {
+      this.logger.warn('No fact-check clients configured');
+      return {
+        results: [],
+        processingTimeMs: Date.now() - startTime,
+      };
+    }
+
+    // Process all claims in parallel
+    const resultsPromises = request.claims.map((claim) => this.checkSingleClaim(claim));
+    const results = await Promise.all(resultsPromises);
+
+    // Filter out null results (claims with no fact-checks found)
+    const validResults = results.filter((r): r is FactCheckResultDto => r !== null);
+
+    return {
+      results: validResults,
+      processingTimeMs: Date.now() - startTime,
+    };
+  }
+
+  /**
+   * Check a single claim against all configured providers
+   */
+  private async checkSingleClaim(claim: ClaimDto): Promise<FactCheckResultDto | null> {
+    // Query all clients in parallel
+    const clientPromises = this.factCheckClients.map((client) =>
+      client.checkClaim({ claim: claim.text }).catch((error) => {
+        this.logger.warn(`Error from client ${client.name}: ${error.message}`);
+        return null;
+      }),
+    );
+
+    const clientResults = await Promise.all(clientPromises);
+
+    // Filter out null results and aggregate sources
+    const allSources: FactCheckSourceDto[] = [];
+    let latestExpiresAt = new Date();
+    let hasConflictingSources = false;
+
+    for (const result of clientResults) {
+      if (!result) continue;
+
+      // Track if any client detected conflicts
+      if (result.hasConflictingSources) {
+        hasConflictingSources = true;
+      }
+
+      // Track the latest expiration time
+      if (result.expiresAt > latestExpiresAt) {
+        latestExpiresAt = result.expiresAt;
+      }
+
+      // Transform and add sources
+      for (const source of result.sources) {
+        allSources.push({
+          provider: source.source,
+          url: source.url,
+          title: source.title,
+          publishedAt: source.publishedAt.toISOString(),
+          rating: source.rating,
+          ratingDescription: source.rating,
+          // Convert from 0-100 to 0-1 scale
+          credibilityScore: source.sourceCredibility / 100,
+          retrievedAt: new Date().toISOString(),
+        });
+      }
+    }
+
+    // No sources found from any provider
+    if (allSources.length === 0) {
+      return null;
+    }
+
+    // Sort by credibility (highest first)
+    allSources.sort((a, b) => b.credibilityScore - a.credibilityScore);
+
+    // Generate conflict summary if needed
+    const conflictSummary = hasConflictingSources
+      ? 'Multiple fact-checking sources have different assessments for this claim.'
+      : undefined;
+
+    return {
+      id: randomUUID(),
+      claimText: claim.text,
+      claimStartOffset: claim.startOffset,
+      claimEndOffset: claim.endOffset,
+      displayedAs: 'Related Context',
+      sources: allSources,
+      hasConflictingSources,
+      conflictSummary,
+      expiresAt: latestExpiresAt.toISOString(),
+    };
+  }
+
+  /**
+   * Get health status of all fact-check providers
+   */
+  async getProvidersHealth(): Promise<{
+    providers: Array<{
+      name: string;
+      isHealthy: boolean;
+      message: string;
+    }>;
+  }> {
+    const healthPromises = this.factCheckClients.map(async (client) => {
+      const health = await client.getHealth();
+      return {
+        name: client.name,
+        isHealthy: health.isHealthy,
+        message: health.message,
+      };
+    });
+
+    const providers = await Promise.all(healthPromises);
+    return { providers };
+  }
+}


### PR DESCRIPTION
## Summary
- Implement POST /fact-check/check endpoint for checking factual claims
- Add FactCheckController and FactCheckService
- Create DTOs matching OpenAPI spec
- Results presented as "Related Context" per FR-012b

## Implementation Details
- **FactCheckController**: POST /fact-check/check endpoint with validation
  - Validates responseId, claims array structure, text length (max 1000 chars)
  - Validates offsets (startOffset < endOffset)
  - Limits max 10 claims per request
- **FactCheckService**: Coordinates fact-checking across all providers
  - Queries all configured clients in parallel
  - Aggregates sources sorted by credibility
  - Detects conflicting assessments between sources
- **DTOs**: CheckClaimsRequestDto, CheckClaimsResponseDto, FactCheckResultDto

## Test plan
- [x] 11 controller tests covering validation and successful checks
- [x] 10 service tests covering aggregation, parallel processing, error handling
- [x] All 47 fact-check-service tests pass

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)