### PR TITLE
feat(common): Implement graceful shutdown for all services (T275)

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -41,7 +41,16 @@
     "@aws-sdk/client-sqs": "^3.985.0",
     "@reason-bridge/event-schemas": "workspace:*"
   },
+  "peerDependencies": {
+    "@nestjs/common": "^10.0.0 || ^11.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@nestjs/common": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@nestjs/common": "^11.0.0",
     "typescript": "5.9.3"
   },
   "engines": {

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -10,3 +10,4 @@
 export * from './assert.js';
 export * from './environment.js';
 export * from './id.js';
+export * from './shutdown.js';

--- a/packages/common/src/utils/shutdown.ts
+++ b/packages/common/src/utils/shutdown.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { INestApplication } from '@nestjs/common';
+
+/**
+ * Configuration for graceful shutdown
+ */
+export interface GracefulShutdownConfig {
+  /** Service name for logging */
+  serviceName: string;
+  /** Timeout in milliseconds before forcing shutdown (default: 10000) */
+  timeoutMs?: number;
+  /** Custom logger (default: console) */
+  logger?: {
+    log: (message: string) => void;
+    warn: (message: string) => void;
+    error: (message: string) => void;
+  };
+}
+
+/**
+ * Default shutdown timeout: 10 seconds
+ */
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10000;
+
+/**
+ * Setup graceful shutdown handlers for a NestJS application.
+ *
+ * This enables proper cleanup when the application receives shutdown signals:
+ * - SIGTERM: Sent by container orchestrators (Docker, Kubernetes) for graceful shutdown
+ * - SIGINT: Sent when pressing Ctrl+C in terminal
+ *
+ * The shutdown process:
+ * 1. Stops accepting new connections
+ * 2. Waits for in-flight requests to complete
+ * 3. Calls OnModuleDestroy hooks on all modules
+ * 4. Closes database connections, queues, etc.
+ * 5. Exits the process
+ *
+ * @param app - The NestJS application instance
+ * @param config - Shutdown configuration
+ *
+ * @example
+ * ```typescript
+ * const app = await NestFactory.create(AppModule);
+ * setupGracefulShutdown(app, { serviceName: 'api-gateway' });
+ * await app.listen(3000);
+ * ```
+ */
+export function setupGracefulShutdown(app: INestApplication, config: GracefulShutdownConfig): void {
+  const { serviceName, timeoutMs = DEFAULT_SHUTDOWN_TIMEOUT_MS, logger = console } = config;
+
+  // Enable NestJS shutdown hooks (calls OnModuleDestroy, beforeApplicationShutdown, etc.)
+  app.enableShutdownHooks();
+
+  let isShuttingDown = false;
+
+  const shutdown = async (signal: string) => {
+    // Prevent multiple shutdown attempts
+    if (isShuttingDown) {
+      logger.warn(`[${serviceName}] Shutdown already in progress, ignoring ${signal}`);
+      return;
+    }
+
+    isShuttingDown = true;
+    logger.log(`[${serviceName}] Received ${signal}, starting graceful shutdown...`);
+
+    // Set a timeout to force exit if graceful shutdown takes too long
+    const forceExitTimeout = setTimeout(() => {
+      logger.error(
+        `[${serviceName}] Graceful shutdown timed out after ${timeoutMs}ms, forcing exit`,
+      );
+      process.exit(1);
+    }, timeoutMs);
+
+    try {
+      // Close the NestJS application (triggers all cleanup hooks)
+      await app.close();
+      clearTimeout(forceExitTimeout);
+      logger.log(`[${serviceName}] Graceful shutdown completed successfully`);
+      process.exit(0);
+    } catch (error) {
+      clearTimeout(forceExitTimeout);
+      logger.error(`[${serviceName}] Error during shutdown: ${error}`);
+      process.exit(1);
+    }
+  };
+
+  // Handle termination signals
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+
+  // Handle uncaught exceptions
+  process.on('uncaughtException', (error) => {
+    logger.error(`[${serviceName}] Uncaught exception: ${error}`);
+    shutdown('uncaughtException');
+  });
+
+  // Handle unhandled promise rejections
+  process.on('unhandledRejection', (reason) => {
+    logger.error(`[${serviceName}] Unhandled rejection: ${reason}`);
+    shutdown('unhandledRejection');
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
         specifier: workspace:*
         version: link:../event-schemas
     devDependencies:
+      '@nestjs/common':
+        specifier: ^11.0.0
+        version: 11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -2426,7 +2429,6 @@ packages:
   '@pact-foundation/pact-core@18.0.0':
     resolution: {integrity: sha512-21sOzu+28HLivTdsnwOmLAPjHLDaPfUbv/aTxlWqCVmBTXVsxekrbQJkO0ga6COXEXQg0BGKmqLxh22orm//9A==}
     engines: {node: '>=20'}
-    cpu: [x64, ia32, arm64]
     os: [darwin, linux, win32]
 
   '@pact-foundation/pact@16.1.0':

--- a/services/activity-service/src/main.ts
+++ b/services/activity-service/src/main.ts
@@ -5,7 +5,7 @@
 
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
-import { SERVICE_PORTS } from '@reason-bridge/common';
+import { SERVICE_PORTS, setupGracefulShutdown } from '@reason-bridge/common';
 import { AppModule } from './app.module.js';
 
 async function bootstrap() {
@@ -13,6 +13,9 @@ async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(AppModule, new FastifyAdapter(), {
     logger: process.env['NODE_ENV'] === 'test' ? ['error'] : undefined,
   });
+
+  // Setup graceful shutdown handlers
+  setupGracefulShutdown(app, { serviceName: 'activity-service' });
 
   const port = process.env['PORT'] || SERVICE_PORTS.ACTIVITY_SERVICE;
   await app.listen(port, '0.0.0.0');

--- a/services/ai-service/src/main.ts
+++ b/services/ai-service/src/main.ts
@@ -5,7 +5,7 @@
 
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
-import { SERVICE_PORTS } from '@reason-bridge/common';
+import { SERVICE_PORTS, setupGracefulShutdown } from '@reason-bridge/common';
 import { AppModule } from './app.module.js';
 
 async function bootstrap() {
@@ -14,6 +14,9 @@ async function bootstrap() {
     // Only log errors in test mode to prevent memory leaks from verbose logging
     logger: process.env['NODE_ENV'] === 'test' ? ['error'] : undefined,
   });
+
+  // Setup graceful shutdown handlers
+  setupGracefulShutdown(app, { serviceName: 'ai-service' });
 
   const port = process.env['PORT'] || SERVICE_PORTS.AI_SERVICE;
   await app.listen(port, '0.0.0.0');

--- a/services/api-gateway/src/main.ts
+++ b/services/api-gateway/src/main.ts
@@ -7,7 +7,7 @@ import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import helmet from '@fastify/helmet';
-import { SERVICE_PORTS } from '@reason-bridge/common';
+import { SERVICE_PORTS, setupGracefulShutdown } from '@reason-bridge/common';
 import { AppModule } from './app.module.js';
 import { getCorsConfig, getHelmetConfig } from './config/security.config.js';
 
@@ -72,6 +72,9 @@ async function bootstrap() {
       },
     });
   }
+
+  // Setup graceful shutdown handlers
+  setupGracefulShutdown(app, { serviceName: 'api-gateway' });
 
   const port = process.env['PORT'] || SERVICE_PORTS.API_GATEWAY;
   await app.listen(port, '0.0.0.0');

--- a/services/discussion-service/src/main.ts
+++ b/services/discussion-service/src/main.ts
@@ -6,7 +6,7 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
-import { SERVICE_PORTS } from '@reason-bridge/common';
+import { SERVICE_PORTS, setupGracefulShutdown } from '@reason-bridge/common';
 import { AppModule } from './app.module.js';
 
 async function bootstrap() {
@@ -24,6 +24,9 @@ async function bootstrap() {
       forbidNonWhitelisted: false,
     }),
   );
+
+  // Setup graceful shutdown handlers
+  setupGracefulShutdown(app, { serviceName: 'discussion-service' });
 
   // Port from single source of truth - see packages/common/src/config/ports.ts
   const port = process.env['PORT'] || SERVICE_PORTS.DISCUSSION_SERVICE;

--- a/services/fact-check-service/src/main.ts
+++ b/services/fact-check-service/src/main.ts
@@ -5,7 +5,7 @@
 
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
-import { SERVICE_PORTS } from '@reason-bridge/common';
+import { SERVICE_PORTS, setupGracefulShutdown } from '@reason-bridge/common';
 import { AppModule } from './app.module.js';
 
 async function bootstrap() {
@@ -14,6 +14,9 @@ async function bootstrap() {
     // Only log errors in test mode to prevent memory leaks from verbose logging
     logger: process.env['NODE_ENV'] === 'test' ? ['error'] : undefined,
   });
+
+  // Setup graceful shutdown handlers
+  setupGracefulShutdown(app, { serviceName: 'fact-check-service' });
 
   const port = process.env['PORT'] || SERVICE_PORTS.FACT_CHECK_SERVICE;
   await app.listen(port, '0.0.0.0');

--- a/services/moderation-service/src/main.ts
+++ b/services/moderation-service/src/main.ts
@@ -5,7 +5,7 @@
 
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
-import { SERVICE_PORTS } from '@reason-bridge/common';
+import { SERVICE_PORTS, setupGracefulShutdown } from '@reason-bridge/common';
 import { AppModule } from './app.module.js';
 
 async function bootstrap() {
@@ -14,6 +14,9 @@ async function bootstrap() {
     // Only log errors in test mode to prevent memory leaks from verbose logging
     logger: process.env['NODE_ENV'] === 'test' ? ['error'] : undefined,
   });
+
+  // Setup graceful shutdown handlers
+  setupGracefulShutdown(app, { serviceName: 'moderation-service' });
 
   const port = process.env['PORT'] || SERVICE_PORTS.MODERATION_SERVICE;
   await app.listen(port, '0.0.0.0');

--- a/services/notification-service/src/main.ts
+++ b/services/notification-service/src/main.ts
@@ -5,7 +5,7 @@
 
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
-import { SERVICE_PORTS } from '@reason-bridge/common';
+import { SERVICE_PORTS, setupGracefulShutdown } from '@reason-bridge/common';
 import { AppModule } from './app.module.js';
 
 async function bootstrap() {
@@ -14,6 +14,9 @@ async function bootstrap() {
     // Only log errors in test mode to prevent memory leaks from verbose logging
     logger: process.env['NODE_ENV'] === 'test' ? ['error'] : undefined,
   });
+
+  // Setup graceful shutdown handlers
+  setupGracefulShutdown(app, { serviceName: 'notification-service' });
 
   const port = process.env['PORT'] || SERVICE_PORTS.NOTIFICATION_SERVICE;
   await app.listen(port, '0.0.0.0');

--- a/services/recommendation-service/src/main.ts
+++ b/services/recommendation-service/src/main.ts
@@ -5,7 +5,7 @@
 
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
-import { SERVICE_PORTS } from '@reason-bridge/common';
+import { SERVICE_PORTS, setupGracefulShutdown } from '@reason-bridge/common';
 import { AppModule } from './app.module.js';
 
 async function bootstrap() {
@@ -14,6 +14,9 @@ async function bootstrap() {
     // Only log errors in test mode to prevent memory leaks from verbose logging
     logger: process.env['NODE_ENV'] === 'test' ? ['error'] : undefined,
   });
+
+  // Setup graceful shutdown handlers
+  setupGracefulShutdown(app, { serviceName: 'recommendation-service' });
 
   const port = process.env['PORT'] || SERVICE_PORTS.RECOMMENDATION_SERVICE;
   await app.listen(port, '0.0.0.0');

--- a/services/user-service/src/main.ts
+++ b/services/user-service/src/main.ts
@@ -6,6 +6,7 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
+import { setupGracefulShutdown } from '@reason-bridge/common';
 import { AppModule } from './app.module.js';
 
 async function bootstrap() {
@@ -23,6 +24,9 @@ async function bootstrap() {
       transform: true, // Automatically transform payloads to DTO instances
     }),
   );
+
+  // Setup graceful shutdown handlers
+  setupGracefulShutdown(app, { serviceName: 'user-service' });
 
   const port = process.env['PORT'] || 3001;
   await app.listen(port, '0.0.0.0');


### PR DESCRIPTION
## Summary
- Add `setupGracefulShutdown` utility to packages/common for proper NestJS application shutdown
- Integrate graceful shutdown across all 9 backend services
- Handle SIGTERM/SIGINT signals for container orchestration (Docker, Kubernetes)
- Handle uncaught exceptions and unhandled promise rejections
- Provide configurable timeout with 10-second default before forced exit

## Changes
- **packages/common/src/utils/shutdown.ts** - New utility with shutdown handlers
- **packages/common/package.json** - Add @nestjs/common as peer dependency
- **services/*/src/main.ts** - Add setupGracefulShutdown call to all 9 services

## Test plan
- [x] Typecheck passes across all packages
- [x] Pre-commit hooks pass
- [ ] CI pipeline passes
- [ ] Verify services start correctly with new shutdown handlers
- [ ] Verify SIGTERM triggers graceful shutdown (docker stop)

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)