### PR TITLE
feat(error-handling): Add error code taxonomy and response validator

### DIFF
--- a/packages/shared/src/errors/error-codes.test.ts
+++ b/packages/shared/src/errors/error-codes.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ErrorCodes,
+  ERROR_CODE_METADATA,
+  ERROR_CODE_PATTERN,
+  HttpStatus,
+  AUTH_ERRORS,
+  VALIDATION_ERRORS,
+  RESOURCE_ERRORS,
+  RATE_LIMIT_ERRORS,
+  BUSINESS_ERRORS,
+  EXTERNAL_ERRORS,
+  INTERNAL_ERRORS,
+  getErrorMeta,
+  getErrorMessage,
+  getHttpStatus,
+  shouldLogAsError,
+  getErrorCategory,
+  getErrorCodesByCategory,
+  isValidErrorCodeFormat,
+  isKnownErrorCode,
+  type ErrorCode,
+  type ErrorCategory,
+} from './error-codes';
+
+/**
+ * T310: Create error code contract tests
+ *
+ * These tests ensure:
+ * - All error codes are properly defined
+ * - Error code format consistency (CATEGORY_NNN)
+ * - Error message quality (human-readable, helpful)
+ * - HTTP status code correctness
+ * - Category consistency
+ */
+
+describe('Error Code Taxonomy', () => {
+  describe('Error Code Format', () => {
+    it('should have a valid regex pattern for error codes', () => {
+      expect(ERROR_CODE_PATTERN.test('AUTH_001')).toBe(true);
+      expect(ERROR_CODE_PATTERN.test('VALIDATION_012')).toBe(true);
+      expect(ERROR_CODE_PATTERN.test('RESOURCE_100')).toBe(true);
+      expect(ERROR_CODE_PATTERN.test('RATE_LIMIT_005')).toBe(true);
+      expect(ERROR_CODE_PATTERN.test('invalid')).toBe(false);
+      expect(ERROR_CODE_PATTERN.test('auth_001')).toBe(false);
+      expect(ERROR_CODE_PATTERN.test('AUTH_01')).toBe(false);
+      expect(ERROR_CODE_PATTERN.test('AUTH001')).toBe(false);
+    });
+
+    it('should have all error codes match the format pattern', () => {
+      const allCodes = Object.values(ErrorCodes);
+      allCodes.forEach((code) => {
+        expect(isValidErrorCodeFormat(code)).toBe(true);
+      });
+    });
+
+    it('should have unique error codes', () => {
+      const allCodes = Object.values(ErrorCodes);
+      const uniqueCodes = new Set(allCodes);
+      expect(uniqueCodes.size).toBe(allCodes.length);
+    });
+
+    it('should have matching keys and values in ErrorCodes', () => {
+      Object.entries(ErrorCodes).forEach(([key, value]) => {
+        expect(key).toBe(value);
+      });
+    });
+  });
+
+  describe('Error Categories', () => {
+    const categoryPrefixMap: Record<string, string> = {
+      AUTH: 'AUTH_',
+      VALIDATION: 'VALIDATION_',
+      RESOURCE: 'RESOURCE_',
+      RATE_LIMIT: 'RATE_LIMIT_',
+      BUSINESS: 'BUSINESS_',
+      EXTERNAL: 'EXTERNAL_',
+      INTERNAL: 'INTERNAL_',
+    };
+
+    it('should have AUTH errors starting with AUTH_', () => {
+      Object.values(AUTH_ERRORS).forEach((code) => {
+        expect(code.startsWith('AUTH_')).toBe(true);
+      });
+    });
+
+    it('should have VALIDATION errors starting with VALIDATION_', () => {
+      Object.values(VALIDATION_ERRORS).forEach((code) => {
+        expect(code.startsWith('VALIDATION_')).toBe(true);
+      });
+    });
+
+    it('should have RESOURCE errors starting with RESOURCE_', () => {
+      Object.values(RESOURCE_ERRORS).forEach((code) => {
+        expect(code.startsWith('RESOURCE_')).toBe(true);
+      });
+    });
+
+    it('should have RATE_LIMIT errors starting with RATE_LIMIT_', () => {
+      Object.values(RATE_LIMIT_ERRORS).forEach((code) => {
+        expect(code.startsWith('RATE_LIMIT_')).toBe(true);
+      });
+    });
+
+    it('should have BUSINESS errors starting with BUSINESS_', () => {
+      Object.values(BUSINESS_ERRORS).forEach((code) => {
+        expect(code.startsWith('BUSINESS_')).toBe(true);
+      });
+    });
+
+    it('should have EXTERNAL errors starting with EXTERNAL_', () => {
+      Object.values(EXTERNAL_ERRORS).forEach((code) => {
+        expect(code.startsWith('EXTERNAL_')).toBe(true);
+      });
+    });
+
+    it('should have INTERNAL errors starting with INTERNAL_', () => {
+      Object.values(INTERNAL_ERRORS).forEach((code) => {
+        expect(code.startsWith('INTERNAL_')).toBe(true);
+      });
+    });
+
+    it('should have correct category metadata for each error code', () => {
+      Object.entries(ERROR_CODE_METADATA).forEach(([code, meta]) => {
+        const expectedPrefix = categoryPrefixMap[meta.category];
+        expect(code.startsWith(expectedPrefix)).toBe(true);
+      });
+    });
+  });
+
+  describe('Error Metadata Completeness', () => {
+    it('should have metadata for every error code', () => {
+      const allCodes = Object.values(ErrorCodes);
+      allCodes.forEach((code) => {
+        expect(ERROR_CODE_METADATA[code]).toBeDefined();
+        expect(ERROR_CODE_METADATA[code].message).toBeDefined();
+        expect(ERROR_CODE_METADATA[code].httpStatus).toBeDefined();
+        expect(ERROR_CODE_METADATA[code].logAsError).toBeDefined();
+        expect(ERROR_CODE_METADATA[code].category).toBeDefined();
+      });
+    });
+
+    it('should have the same number of codes and metadata entries', () => {
+      const codeCount = Object.values(ErrorCodes).length;
+      const metadataCount = Object.keys(ERROR_CODE_METADATA).length;
+      expect(codeCount).toBe(metadataCount);
+    });
+  });
+
+  describe('Error Message Quality', () => {
+    it('should have non-empty messages', () => {
+      Object.values(ERROR_CODE_METADATA).forEach((meta) => {
+        expect(meta.message.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('should have messages that start with a capital letter', () => {
+      Object.values(ERROR_CODE_METADATA).forEach((meta) => {
+        expect(meta.message[0]).toBe(meta.message[0].toUpperCase());
+      });
+    });
+
+    it('should have messages that end with a period', () => {
+      Object.values(ERROR_CODE_METADATA).forEach((meta) => {
+        expect(meta.message.endsWith('.')).toBe(true);
+      });
+    });
+
+    it('should not have messages containing error codes', () => {
+      Object.entries(ERROR_CODE_METADATA).forEach(([code, meta]) => {
+        expect(meta.message).not.toContain(code);
+      });
+    });
+
+    it('should have human-readable messages (no technical jargon for user-facing errors)', () => {
+      const userFacingCategories: ErrorCategory[] = ['AUTH', 'VALIDATION', 'RESOURCE', 'BUSINESS'];
+
+      Object.entries(ERROR_CODE_METADATA)
+        .filter(([, meta]) => userFacingCategories.includes(meta.category))
+        .forEach(([, meta]) => {
+          // Should not contain common technical terms
+          expect(meta.message.toLowerCase()).not.toContain('exception');
+          expect(meta.message.toLowerCase()).not.toContain('null pointer');
+          expect(meta.message.toLowerCase()).not.toContain('stack trace');
+        });
+    });
+  });
+
+  describe('HTTP Status Codes', () => {
+    it('should have valid HTTP status codes', () => {
+      const validStatusCodes = Object.values(HttpStatus);
+      Object.values(ERROR_CODE_METADATA).forEach((meta) => {
+        expect(validStatusCodes).toContain(meta.httpStatus);
+      });
+    });
+
+    it('should use 401 or 403 for AUTH errors', () => {
+      Object.entries(ERROR_CODE_METADATA)
+        .filter(([code]) => code.startsWith('AUTH_'))
+        .forEach(([, meta]) => {
+          expect([HttpStatus.UNAUTHORIZED, HttpStatus.FORBIDDEN, HttpStatus.BAD_REQUEST]).toContain(
+            meta.httpStatus,
+          );
+        });
+    });
+
+    it('should use 400 for VALIDATION errors', () => {
+      Object.entries(ERROR_CODE_METADATA)
+        .filter(([code]) => code.startsWith('VALIDATION_'))
+        .forEach(([, meta]) => {
+          expect(meta.httpStatus).toBe(HttpStatus.BAD_REQUEST);
+        });
+    });
+
+    it('should use 404, 409, or 410 for RESOURCE errors', () => {
+      Object.entries(ERROR_CODE_METADATA)
+        .filter(([code]) => code.startsWith('RESOURCE_'))
+        .forEach(([, meta]) => {
+          expect([HttpStatus.NOT_FOUND, HttpStatus.CONFLICT, HttpStatus.GONE]).toContain(
+            meta.httpStatus,
+          );
+        });
+    });
+
+    it('should use 429 for RATE_LIMIT errors', () => {
+      Object.entries(ERROR_CODE_METADATA)
+        .filter(([code]) => code.startsWith('RATE_LIMIT_'))
+        .forEach(([, meta]) => {
+          expect(meta.httpStatus).toBe(HttpStatus.TOO_MANY_REQUESTS);
+        });
+    });
+
+    it('should use 500, 502, or 503 for EXTERNAL errors', () => {
+      Object.entries(ERROR_CODE_METADATA)
+        .filter(([code]) => code.startsWith('EXTERNAL_'))
+        .forEach(([, meta]) => {
+          expect([
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            HttpStatus.BAD_GATEWAY,
+            HttpStatus.SERVICE_UNAVAILABLE,
+          ]).toContain(meta.httpStatus);
+        });
+    });
+
+    it('should use 500 or 409 for INTERNAL errors', () => {
+      Object.entries(ERROR_CODE_METADATA)
+        .filter(([code]) => code.startsWith('INTERNAL_'))
+        .forEach(([, meta]) => {
+          expect([HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.CONFLICT]).toContain(
+            meta.httpStatus,
+          );
+        });
+    });
+  });
+
+  describe('Logging Configuration', () => {
+    it('should log EXTERNAL and INTERNAL errors as errors', () => {
+      Object.entries(ERROR_CODE_METADATA)
+        .filter(([code]) => code.startsWith('EXTERNAL_') || code.startsWith('INTERNAL_'))
+        .forEach(([, meta]) => {
+          expect(meta.logAsError).toBe(true);
+        });
+    });
+
+    it('should not log most AUTH validation errors as errors', () => {
+      // Most authentication failures (wrong password, expired token) are expected
+      // and should not trigger error-level logging
+      const expectedNotLoggedAsError = [
+        'AUTH_001',
+        'AUTH_002',
+        'AUTH_003',
+        'AUTH_004',
+        'AUTH_005',
+        'AUTH_006',
+        'AUTH_007',
+        'AUTH_010',
+        'AUTH_011',
+        'AUTH_012',
+        'AUTH_013',
+      ] as ErrorCode[];
+
+      expectedNotLoggedAsError.forEach((code) => {
+        expect(ERROR_CODE_METADATA[code].logAsError).toBe(false);
+      });
+    });
+
+    it('should log suspicious auth activities as errors', () => {
+      // OAuth failures and suspicious activities should be logged
+      expect(ERROR_CODE_METADATA['AUTH_008'].logAsError).toBe(true);
+      expect(ERROR_CODE_METADATA['AUTH_009'].logAsError).toBe(true);
+      expect(ERROR_CODE_METADATA['RATE_LIMIT_002'].logAsError).toBe(true);
+    });
+  });
+
+  describe('Helper Functions', () => {
+    describe('getErrorMeta', () => {
+      it('should return correct metadata for a code', () => {
+        const meta = getErrorMeta('AUTH_001');
+        expect(meta.message).toBe('Authentication required. Please provide a valid access token.');
+        expect(meta.httpStatus).toBe(HttpStatus.UNAUTHORIZED);
+        expect(meta.category).toBe('AUTH');
+      });
+    });
+
+    describe('getErrorMessage', () => {
+      it('should return the message for a code', () => {
+        const message = getErrorMessage('VALIDATION_004');
+        expect(message).toContain('Password does not meet requirements');
+      });
+    });
+
+    describe('getHttpStatus', () => {
+      it('should return the HTTP status for a code', () => {
+        expect(getHttpStatus('RESOURCE_001')).toBe(HttpStatus.NOT_FOUND);
+        expect(getHttpStatus('AUTH_001')).toBe(HttpStatus.UNAUTHORIZED);
+        expect(getHttpStatus('VALIDATION_001')).toBe(HttpStatus.BAD_REQUEST);
+      });
+    });
+
+    describe('shouldLogAsError', () => {
+      it('should return correct logging configuration', () => {
+        expect(shouldLogAsError('INTERNAL_001')).toBe(true);
+        expect(shouldLogAsError('AUTH_003')).toBe(false);
+      });
+    });
+
+    describe('getErrorCategory', () => {
+      it('should return the correct category', () => {
+        expect(getErrorCategory('AUTH_001')).toBe('AUTH');
+        expect(getErrorCategory('VALIDATION_001')).toBe('VALIDATION');
+        expect(getErrorCategory('RESOURCE_001')).toBe('RESOURCE');
+      });
+    });
+
+    describe('getErrorCodesByCategory', () => {
+      it('should return all codes for a category', () => {
+        const authCodes = getErrorCodesByCategory('AUTH');
+        expect(authCodes.length).toBeGreaterThan(0);
+        authCodes.forEach((code) => {
+          expect(code.startsWith('AUTH_')).toBe(true);
+        });
+      });
+
+      it('should return codes matching the expected count', () => {
+        const validationCodes = getErrorCodesByCategory('VALIDATION');
+        expect(validationCodes.length).toBe(Object.keys(VALIDATION_ERRORS).length);
+      });
+    });
+
+    describe('isValidErrorCodeFormat', () => {
+      it('should validate correct formats', () => {
+        expect(isValidErrorCodeFormat('AUTH_001')).toBe(true);
+        expect(isValidErrorCodeFormat('BUSINESS_123')).toBe(true);
+        expect(isValidErrorCodeFormat('RATE_LIMIT_005')).toBe(true);
+      });
+
+      it('should reject invalid formats', () => {
+        expect(isValidErrorCodeFormat('auth_001')).toBe(false);
+        expect(isValidErrorCodeFormat('AUTH-001')).toBe(false);
+        expect(isValidErrorCodeFormat('AUTH_01')).toBe(false);
+        expect(isValidErrorCodeFormat('AUTH001')).toBe(false);
+        expect(isValidErrorCodeFormat('')).toBe(false);
+      });
+    });
+
+    describe('isKnownErrorCode', () => {
+      it('should identify known codes', () => {
+        expect(isKnownErrorCode('AUTH_001')).toBe(true);
+        expect(isKnownErrorCode('VALIDATION_001')).toBe(true);
+      });
+
+      it('should reject unknown codes', () => {
+        expect(isKnownErrorCode('AUTH_999')).toBe(false);
+        expect(isKnownErrorCode('UNKNOWN_001')).toBe(false);
+      });
+    });
+  });
+
+  describe('Error Code Coverage', () => {
+    it('should have at least 10 AUTH error codes', () => {
+      expect(Object.keys(AUTH_ERRORS).length).toBeGreaterThanOrEqual(10);
+    });
+
+    it('should have at least 10 VALIDATION error codes', () => {
+      expect(Object.keys(VALIDATION_ERRORS).length).toBeGreaterThanOrEqual(10);
+    });
+
+    it('should have at least 5 RESOURCE error codes', () => {
+      expect(Object.keys(RESOURCE_ERRORS).length).toBeGreaterThanOrEqual(5);
+    });
+
+    it('should have at least 3 RATE_LIMIT error codes', () => {
+      expect(Object.keys(RATE_LIMIT_ERRORS).length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should have at least 5 BUSINESS error codes', () => {
+      expect(Object.keys(BUSINESS_ERRORS).length).toBeGreaterThanOrEqual(5);
+    });
+
+    it('should have at least 5 EXTERNAL error codes', () => {
+      expect(Object.keys(EXTERNAL_ERRORS).length).toBeGreaterThanOrEqual(5);
+    });
+
+    it('should have at least 3 INTERNAL error codes', () => {
+      expect(Object.keys(INTERNAL_ERRORS).length).toBeGreaterThanOrEqual(3);
+    });
+  });
+});

--- a/packages/shared/src/errors/error-codes.ts
+++ b/packages/shared/src/errors/error-codes.ts
@@ -1,0 +1,763 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Error Code Taxonomy for ReasonBridge Platform
+ *
+ * T309: Create error code taxonomy
+ *
+ * This module defines a standardized error code system used across all services.
+ * Error codes follow a hierarchical naming convention: CATEGORY_NNN
+ *
+ * Categories:
+ * - AUTH: Authentication and authorization errors (401, 403)
+ * - VALIDATION: Input validation errors (400)
+ * - RESOURCE: Resource-related errors (404, 409, 410)
+ * - RATE_LIMIT: Rate limiting errors (429)
+ * - BUSINESS: Business logic errors (400, 422)
+ * - EXTERNAL: External service errors (502, 503)
+ * - INTERNAL: Internal server errors (500)
+ */
+
+/**
+ * Error code format regex pattern
+ * Matches: CATEGORY_NNN (e.g., AUTH_001, VALIDATION_002, RATE_LIMIT_005)
+ * Supports multi-word categories with underscores
+ */
+export const ERROR_CODE_PATTERN = /^[A-Z]+(?:_[A-Z]+)*_\d{3}$/;
+
+/**
+ * HTTP status codes used in error responses
+ */
+export enum HttpStatus {
+  BAD_REQUEST = 400,
+  UNAUTHORIZED = 401,
+  FORBIDDEN = 403,
+  NOT_FOUND = 404,
+  CONFLICT = 409,
+  GONE = 410,
+  UNPROCESSABLE_ENTITY = 422,
+  TOO_MANY_REQUESTS = 429,
+  INTERNAL_SERVER_ERROR = 500,
+  BAD_GATEWAY = 502,
+  SERVICE_UNAVAILABLE = 503,
+}
+
+/**
+ * Error code metadata
+ */
+export interface ErrorCodeMeta {
+  /** Human-readable error message */
+  message: string;
+  /** HTTP status code to return */
+  httpStatus: HttpStatus;
+  /** Whether this error should be logged at error level */
+  logAsError: boolean;
+  /** Category for grouping */
+  category: ErrorCategory;
+}
+
+/**
+ * Error categories for grouping and filtering
+ */
+export type ErrorCategory =
+  | 'AUTH'
+  | 'VALIDATION'
+  | 'RESOURCE'
+  | 'RATE_LIMIT'
+  | 'BUSINESS'
+  | 'EXTERNAL'
+  | 'INTERNAL';
+
+/**
+ * Authentication and Authorization Errors (AUTH_XXX)
+ */
+export const AUTH_ERRORS = {
+  /** Missing or invalid authentication token */
+  AUTH_001: 'AUTH_001',
+  /** Token has expired */
+  AUTH_002: 'AUTH_002',
+  /** Invalid credentials provided */
+  AUTH_003: 'AUTH_003',
+  /** Email address not verified */
+  AUTH_004: 'AUTH_004',
+  /** Account is suspended */
+  AUTH_005: 'AUTH_005',
+  /** Account is deactivated */
+  AUTH_006: 'AUTH_006',
+  /** Insufficient permissions for this action */
+  AUTH_007: 'AUTH_007',
+  /** OAuth authentication failed */
+  AUTH_008: 'AUTH_008',
+  /** Invalid OAuth state parameter */
+  AUTH_009: 'AUTH_009',
+  /** Refresh token is invalid or expired */
+  AUTH_010: 'AUTH_010',
+  /** Multi-factor authentication required */
+  AUTH_011: 'AUTH_011',
+  /** Invalid MFA code */
+  AUTH_012: 'AUTH_012',
+  /** Session has been invalidated */
+  AUTH_013: 'AUTH_013',
+} as const;
+
+/**
+ * Validation Errors (VALIDATION_XXX)
+ */
+export const VALIDATION_ERRORS = {
+  /** Request body validation failed */
+  VALIDATION_001: 'VALIDATION_001',
+  /** Required field is missing */
+  VALIDATION_002: 'VALIDATION_002',
+  /** Field value is invalid */
+  VALIDATION_003: 'VALIDATION_003',
+  /** Password does not meet requirements */
+  VALIDATION_004: 'VALIDATION_004',
+  /** Email format is invalid */
+  VALIDATION_005: 'VALIDATION_005',
+  /** Phone number format is invalid */
+  VALIDATION_006: 'VALIDATION_006',
+  /** Username does not meet requirements */
+  VALIDATION_007: 'VALIDATION_007',
+  /** File type not allowed */
+  VALIDATION_008: 'VALIDATION_008',
+  /** File size exceeds limit */
+  VALIDATION_009: 'VALIDATION_009',
+  /** Invalid date or date range */
+  VALIDATION_010: 'VALIDATION_010',
+  /** Content length exceeds limit */
+  VALIDATION_011: 'VALIDATION_011',
+  /** Invalid JSON format */
+  VALIDATION_012: 'VALIDATION_012',
+} as const;
+
+/**
+ * Resource Errors (RESOURCE_XXX)
+ */
+export const RESOURCE_ERRORS = {
+  /** Requested resource not found */
+  RESOURCE_001: 'RESOURCE_001',
+  /** Resource already exists (conflict) */
+  RESOURCE_002: 'RESOURCE_002',
+  /** Resource is no longer available (gone) */
+  RESOURCE_003: 'RESOURCE_003',
+  /** Resource is locked */
+  RESOURCE_004: 'RESOURCE_004',
+  /** Resource state conflict */
+  RESOURCE_005: 'RESOURCE_005',
+  /** User not found */
+  RESOURCE_006: 'RESOURCE_006',
+  /** Topic not found */
+  RESOURCE_007: 'RESOURCE_007',
+  /** Discussion not found */
+  RESOURCE_008: 'RESOURCE_008',
+  /** Response not found */
+  RESOURCE_009: 'RESOURCE_009',
+  /** Proposition not found */
+  RESOURCE_010: 'RESOURCE_010',
+} as const;
+
+/**
+ * Rate Limit Errors (RATE_LIMIT_XXX)
+ */
+export const RATE_LIMIT_ERRORS = {
+  /** Request rate limit exceeded */
+  RATE_LIMIT_001: 'RATE_LIMIT_001',
+  /** Login attempts limit exceeded */
+  RATE_LIMIT_002: 'RATE_LIMIT_002',
+  /** API quota exceeded */
+  RATE_LIMIT_003: 'RATE_LIMIT_003',
+  /** Verification code request limit exceeded */
+  RATE_LIMIT_004: 'RATE_LIMIT_004',
+  /** Password reset request limit exceeded */
+  RATE_LIMIT_005: 'RATE_LIMIT_005',
+} as const;
+
+/**
+ * Business Logic Errors (BUSINESS_XXX)
+ */
+export const BUSINESS_ERRORS = {
+  /** Operation not permitted in current state */
+  BUSINESS_001: 'BUSINESS_001',
+  /** Verification code has expired */
+  BUSINESS_002: 'BUSINESS_002',
+  /** Invalid verification code */
+  BUSINESS_003: 'BUSINESS_003',
+  /** Email already verified */
+  BUSINESS_004: 'BUSINESS_004',
+  /** Phone already verified */
+  BUSINESS_005: 'BUSINESS_005',
+  /** Onboarding already completed */
+  BUSINESS_006: 'BUSINESS_006',
+  /** Invalid topic selection */
+  BUSINESS_007: 'BUSINESS_007',
+  /** Discussion is closed */
+  BUSINESS_008: 'BUSINESS_008',
+  /** Cannot respond to own content */
+  BUSINESS_009: 'BUSINESS_009',
+  /** Maximum responses reached */
+  BUSINESS_010: 'BUSINESS_010',
+  /** Insufficient reputation */
+  BUSINESS_011: 'BUSINESS_011',
+  /** Feature not available for this account */
+  BUSINESS_012: 'BUSINESS_012',
+} as const;
+
+/**
+ * External Service Errors (EXTERNAL_XXX)
+ */
+export const EXTERNAL_ERRORS = {
+  /** External service temporarily unavailable */
+  EXTERNAL_001: 'EXTERNAL_001',
+  /** External service returned an error */
+  EXTERNAL_002: 'EXTERNAL_002',
+  /** External service timeout */
+  EXTERNAL_003: 'EXTERNAL_003',
+  /** Database connection failed */
+  EXTERNAL_004: 'EXTERNAL_004',
+  /** Cache service unavailable */
+  EXTERNAL_005: 'EXTERNAL_005',
+  /** Message queue unavailable */
+  EXTERNAL_006: 'EXTERNAL_006',
+  /** AI service unavailable */
+  EXTERNAL_007: 'EXTERNAL_007',
+  /** Email service failed */
+  EXTERNAL_008: 'EXTERNAL_008',
+  /** SMS service failed */
+  EXTERNAL_009: 'EXTERNAL_009',
+  /** Storage service failed */
+  EXTERNAL_010: 'EXTERNAL_010',
+} as const;
+
+/**
+ * Internal Server Errors (INTERNAL_XXX)
+ */
+export const INTERNAL_ERRORS = {
+  /** Unexpected server error */
+  INTERNAL_001: 'INTERNAL_001',
+  /** Configuration error */
+  INTERNAL_002: 'INTERNAL_002',
+  /** Data integrity error */
+  INTERNAL_003: 'INTERNAL_003',
+  /** Serialization error */
+  INTERNAL_004: 'INTERNAL_004',
+  /** Concurrent modification error */
+  INTERNAL_005: 'INTERNAL_005',
+} as const;
+
+/**
+ * Combined error codes object
+ */
+export const ErrorCodes = {
+  ...AUTH_ERRORS,
+  ...VALIDATION_ERRORS,
+  ...RESOURCE_ERRORS,
+  ...RATE_LIMIT_ERRORS,
+  ...BUSINESS_ERRORS,
+  ...EXTERNAL_ERRORS,
+  ...INTERNAL_ERRORS,
+} as const;
+
+/**
+ * Error code type
+ */
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];
+
+/**
+ * Error code metadata registry
+ * Maps error codes to their human-readable messages and HTTP status codes
+ */
+export const ERROR_CODE_METADATA: Record<ErrorCode, ErrorCodeMeta> = {
+  // Authentication Errors
+  AUTH_001: {
+    message: 'Authentication required. Please provide a valid access token.',
+    httpStatus: HttpStatus.UNAUTHORIZED,
+    logAsError: false,
+    category: 'AUTH',
+  },
+  AUTH_002: {
+    message: 'Your session has expired. Please log in again.',
+    httpStatus: HttpStatus.UNAUTHORIZED,
+    logAsError: false,
+    category: 'AUTH',
+  },
+  AUTH_003: {
+    message: 'Invalid email or password.',
+    httpStatus: HttpStatus.UNAUTHORIZED,
+    logAsError: false,
+    category: 'AUTH',
+  },
+  AUTH_004: {
+    message: 'Please verify your email address before continuing.',
+    httpStatus: HttpStatus.FORBIDDEN,
+    logAsError: false,
+    category: 'AUTH',
+  },
+  AUTH_005: {
+    message: 'Your account has been suspended. Contact support for assistance.',
+    httpStatus: HttpStatus.FORBIDDEN,
+    logAsError: false,
+    category: 'AUTH',
+  },
+  AUTH_006: {
+    message: 'This account has been deactivated.',
+    httpStatus: HttpStatus.FORBIDDEN,
+    logAsError: false,
+    category: 'AUTH',
+  },
+  AUTH_007: {
+    message: 'You do not have permission to perform this action.',
+    httpStatus: HttpStatus.FORBIDDEN,
+    logAsError: false,
+    category: 'AUTH',
+  },
+  AUTH_008: {
+    message: 'OAuth authentication failed. Please try again.',
+    httpStatus: HttpStatus.UNAUTHORIZED,
+    logAsError: true,
+    category: 'AUTH',
+  },
+  AUTH_009: {
+    message: 'Invalid OAuth state. Please restart the authentication process.',
+    httpStatus: HttpStatus.BAD_REQUEST,
+    logAsError: true,
+    category: 'AUTH',
+  },
+  AUTH_010: {
+    message: 'Your refresh token is invalid or expired. Please log in again.',
+    httpStatus: HttpStatus.UNAUTHORIZED,
+    logAsError: false,
+    category: 'AUTH',
+  },
+  AUTH_011: {
+    message: 'Multi-factor authentication is required.',
+    httpStatus: HttpStatus.UNAUTHORIZED,
+    logAsError: false,
+    category: 'AUTH',
+  },
+  AUTH_012: {
+    message: 'Invalid verification code. Please try again.',
+    httpStatus: HttpStatus.UNAUTHORIZED,
+    logAsError: false,
+    category: 'AUTH',
+  },
+  AUTH_013: {
+    message: 'Your session has been invalidated. Please log in again.',
+    httpStatus: HttpStatus.UNAUTHORIZED,
+    logAsError: false,
+    category: 'AUTH',
+  },
+
+  // Validation Errors
+  VALIDATION_001: {
+    message: 'Request validation failed. Please check your input.',
+    httpStatus: HttpStatus.BAD_REQUEST,
+    logAsError: false,
+    category: 'VALIDATION',
+  },
+  VALIDATION_002: {
+    message: 'A required field is missing.',
+    httpStatus: HttpStatus.BAD_REQUEST,
+    logAsError: false,
+    category: 'VALIDATION',
+  },
+  VALIDATION_003: {
+    message: 'Invalid field value provided.',
+    httpStatus: HttpStatus.BAD_REQUEST,
+    logAsError: false,
+    category: 'VALIDATION',
+  },
+  VALIDATION_004: {
+    message:
+      'Password does not meet requirements. Use at least 8 characters with uppercase, lowercase, number, and special character.',
+    httpStatus: HttpStatus.BAD_REQUEST,
+    logAsError: false,
+    category: 'VALIDATION',
+  },
+  VALIDATION_005: {
+    message: 'Please provide a valid email address.',
+    httpStatus: HttpStatus.BAD_REQUEST,
+    logAsError: false,
+    category: 'VALIDATION',
+  },
+  VALIDATION_006: {
+    message: 'Please provide a valid phone number.',
+    httpStatus: HttpStatus.BAD_REQUEST,
+    logAsError: false,
+    category: 'VALIDATION',
+  },
+  VALIDATION_007: {
+    message: 'Username must be 3-30 characters and contain only letters, numbers, and underscores.',
+    httpStatus: HttpStatus.BAD_REQUEST,
+    logAsError: false,
+    category: 'VALIDATION',
+  },
+  VALIDATION_008: {
+    message: 'This file type is not allowed.',
+    httpStatus: HttpStatus.BAD_REQUEST,
+    logAsError: false,
+    category: 'VALIDATION',
+  },
+  VALIDATION_009: {
+    message: 'File size exceeds the maximum allowed limit.',
+    httpStatus: HttpStatus.BAD_REQUEST,
+    logAsError: false,
+    category: 'VALIDATION',
+  },
+  VALIDATION_010: {
+    message: 'Invalid date or date range provided.',
+    httpStatus: HttpStatus.BAD_REQUEST,
+    logAsError: false,
+    category: 'VALIDATION',
+  },
+  VALIDATION_011: {
+    message: 'Content length exceeds the maximum allowed limit.',
+    httpStatus: HttpStatus.BAD_REQUEST,
+    logAsError: false,
+    category: 'VALIDATION',
+  },
+  VALIDATION_012: {
+    message: 'Invalid JSON format in request body.',
+    httpStatus: HttpStatus.BAD_REQUEST,
+    logAsError: false,
+    category: 'VALIDATION',
+  },
+
+  // Resource Errors
+  RESOURCE_001: {
+    message: 'The requested resource was not found.',
+    httpStatus: HttpStatus.NOT_FOUND,
+    logAsError: false,
+    category: 'RESOURCE',
+  },
+  RESOURCE_002: {
+    message: 'A resource with this identifier already exists.',
+    httpStatus: HttpStatus.CONFLICT,
+    logAsError: false,
+    category: 'RESOURCE',
+  },
+  RESOURCE_003: {
+    message: 'This resource is no longer available.',
+    httpStatus: HttpStatus.GONE,
+    logAsError: false,
+    category: 'RESOURCE',
+  },
+  RESOURCE_004: {
+    message: 'This resource is currently locked and cannot be modified.',
+    httpStatus: HttpStatus.CONFLICT,
+    logAsError: false,
+    category: 'RESOURCE',
+  },
+  RESOURCE_005: {
+    message: 'The resource is in a conflicting state.',
+    httpStatus: HttpStatus.CONFLICT,
+    logAsError: false,
+    category: 'RESOURCE',
+  },
+  RESOURCE_006: {
+    message: 'User not found.',
+    httpStatus: HttpStatus.NOT_FOUND,
+    logAsError: false,
+    category: 'RESOURCE',
+  },
+  RESOURCE_007: {
+    message: 'Topic not found.',
+    httpStatus: HttpStatus.NOT_FOUND,
+    logAsError: false,
+    category: 'RESOURCE',
+  },
+  RESOURCE_008: {
+    message: 'Discussion not found.',
+    httpStatus: HttpStatus.NOT_FOUND,
+    logAsError: false,
+    category: 'RESOURCE',
+  },
+  RESOURCE_009: {
+    message: 'Response not found.',
+    httpStatus: HttpStatus.NOT_FOUND,
+    logAsError: false,
+    category: 'RESOURCE',
+  },
+  RESOURCE_010: {
+    message: 'Proposition not found.',
+    httpStatus: HttpStatus.NOT_FOUND,
+    logAsError: false,
+    category: 'RESOURCE',
+  },
+
+  // Rate Limit Errors
+  RATE_LIMIT_001: {
+    message: 'Too many requests. Please try again later.',
+    httpStatus: HttpStatus.TOO_MANY_REQUESTS,
+    logAsError: false,
+    category: 'RATE_LIMIT',
+  },
+  RATE_LIMIT_002: {
+    message: 'Too many login attempts. Please try again later.',
+    httpStatus: HttpStatus.TOO_MANY_REQUESTS,
+    logAsError: true,
+    category: 'RATE_LIMIT',
+  },
+  RATE_LIMIT_003: {
+    message: 'API quota exceeded. Please upgrade your plan or try again later.',
+    httpStatus: HttpStatus.TOO_MANY_REQUESTS,
+    logAsError: false,
+    category: 'RATE_LIMIT',
+  },
+  RATE_LIMIT_004: {
+    message: 'Too many verification code requests. Please wait before requesting again.',
+    httpStatus: HttpStatus.TOO_MANY_REQUESTS,
+    logAsError: false,
+    category: 'RATE_LIMIT',
+  },
+  RATE_LIMIT_005: {
+    message: 'Too many password reset requests. Please wait before requesting again.',
+    httpStatus: HttpStatus.TOO_MANY_REQUESTS,
+    logAsError: false,
+    category: 'RATE_LIMIT',
+  },
+
+  // Business Logic Errors
+  BUSINESS_001: {
+    message: 'This operation is not permitted in the current state.',
+    httpStatus: HttpStatus.UNPROCESSABLE_ENTITY,
+    logAsError: false,
+    category: 'BUSINESS',
+  },
+  BUSINESS_002: {
+    message: 'Verification code has expired. Please request a new one.',
+    httpStatus: HttpStatus.UNPROCESSABLE_ENTITY,
+    logAsError: false,
+    category: 'BUSINESS',
+  },
+  BUSINESS_003: {
+    message: 'Invalid verification code.',
+    httpStatus: HttpStatus.UNPROCESSABLE_ENTITY,
+    logAsError: false,
+    category: 'BUSINESS',
+  },
+  BUSINESS_004: {
+    message: 'Email is already verified.',
+    httpStatus: HttpStatus.CONFLICT,
+    logAsError: false,
+    category: 'BUSINESS',
+  },
+  BUSINESS_005: {
+    message: 'Phone number is already verified.',
+    httpStatus: HttpStatus.CONFLICT,
+    logAsError: false,
+    category: 'BUSINESS',
+  },
+  BUSINESS_006: {
+    message: 'Onboarding has already been completed.',
+    httpStatus: HttpStatus.CONFLICT,
+    logAsError: false,
+    category: 'BUSINESS',
+  },
+  BUSINESS_007: {
+    message: 'Invalid topic selection.',
+    httpStatus: HttpStatus.BAD_REQUEST,
+    logAsError: false,
+    category: 'BUSINESS',
+  },
+  BUSINESS_008: {
+    message: 'This discussion is closed and no longer accepting responses.',
+    httpStatus: HttpStatus.UNPROCESSABLE_ENTITY,
+    logAsError: false,
+    category: 'BUSINESS',
+  },
+  BUSINESS_009: {
+    message: 'You cannot respond to your own content.',
+    httpStatus: HttpStatus.UNPROCESSABLE_ENTITY,
+    logAsError: false,
+    category: 'BUSINESS',
+  },
+  BUSINESS_010: {
+    message: 'Maximum number of responses reached.',
+    httpStatus: HttpStatus.UNPROCESSABLE_ENTITY,
+    logAsError: false,
+    category: 'BUSINESS',
+  },
+  BUSINESS_011: {
+    message: 'Insufficient reputation to perform this action.',
+    httpStatus: HttpStatus.FORBIDDEN,
+    logAsError: false,
+    category: 'BUSINESS',
+  },
+  BUSINESS_012: {
+    message: 'This feature is not available for your account.',
+    httpStatus: HttpStatus.FORBIDDEN,
+    logAsError: false,
+    category: 'BUSINESS',
+  },
+
+  // External Service Errors
+  EXTERNAL_001: {
+    message: 'A required service is temporarily unavailable. Please try again later.',
+    httpStatus: HttpStatus.SERVICE_UNAVAILABLE,
+    logAsError: true,
+    category: 'EXTERNAL',
+  },
+  EXTERNAL_002: {
+    message: 'An external service returned an error. Please try again later.',
+    httpStatus: HttpStatus.BAD_GATEWAY,
+    logAsError: true,
+    category: 'EXTERNAL',
+  },
+  EXTERNAL_003: {
+    message: 'Request to external service timed out. Please try again.',
+    httpStatus: HttpStatus.BAD_GATEWAY,
+    logAsError: true,
+    category: 'EXTERNAL',
+  },
+  EXTERNAL_004: {
+    message: 'Database connection failed. Please try again later.',
+    httpStatus: HttpStatus.SERVICE_UNAVAILABLE,
+    logAsError: true,
+    category: 'EXTERNAL',
+  },
+  EXTERNAL_005: {
+    message: 'Cache service is unavailable. Please try again later.',
+    httpStatus: HttpStatus.SERVICE_UNAVAILABLE,
+    logAsError: true,
+    category: 'EXTERNAL',
+  },
+  EXTERNAL_006: {
+    message: 'Message queue is unavailable. Please try again later.',
+    httpStatus: HttpStatus.SERVICE_UNAVAILABLE,
+    logAsError: true,
+    category: 'EXTERNAL',
+  },
+  EXTERNAL_007: {
+    message: 'AI service is temporarily unavailable. Please try again later.',
+    httpStatus: HttpStatus.SERVICE_UNAVAILABLE,
+    logAsError: true,
+    category: 'EXTERNAL',
+  },
+  EXTERNAL_008: {
+    message: 'Failed to send email. Please try again later.',
+    httpStatus: HttpStatus.SERVICE_UNAVAILABLE,
+    logAsError: true,
+    category: 'EXTERNAL',
+  },
+  EXTERNAL_009: {
+    message: 'Failed to send SMS. Please try again later.',
+    httpStatus: HttpStatus.SERVICE_UNAVAILABLE,
+    logAsError: true,
+    category: 'EXTERNAL',
+  },
+  EXTERNAL_010: {
+    message: 'Storage service is unavailable. Please try again later.',
+    httpStatus: HttpStatus.SERVICE_UNAVAILABLE,
+    logAsError: true,
+    category: 'EXTERNAL',
+  },
+
+  // Internal Server Errors
+  INTERNAL_001: {
+    message: 'An unexpected error occurred. Please try again later.',
+    httpStatus: HttpStatus.INTERNAL_SERVER_ERROR,
+    logAsError: true,
+    category: 'INTERNAL',
+  },
+  INTERNAL_002: {
+    message: 'Server configuration error. Please contact support.',
+    httpStatus: HttpStatus.INTERNAL_SERVER_ERROR,
+    logAsError: true,
+    category: 'INTERNAL',
+  },
+  INTERNAL_003: {
+    message: 'Data integrity error. Please contact support.',
+    httpStatus: HttpStatus.INTERNAL_SERVER_ERROR,
+    logAsError: true,
+    category: 'INTERNAL',
+  },
+  INTERNAL_004: {
+    message: 'Data serialization error. Please contact support.',
+    httpStatus: HttpStatus.INTERNAL_SERVER_ERROR,
+    logAsError: true,
+    category: 'INTERNAL',
+  },
+  INTERNAL_005: {
+    message: 'Concurrent modification detected. Please try again.',
+    httpStatus: HttpStatus.CONFLICT,
+    logAsError: true,
+    category: 'INTERNAL',
+  },
+};
+
+/**
+ * Get the metadata for an error code
+ * @param code - The error code
+ * @returns The error code metadata
+ */
+export function getErrorMeta(code: ErrorCode): ErrorCodeMeta {
+  return ERROR_CODE_METADATA[code];
+}
+
+/**
+ * Get the human-readable message for an error code
+ * @param code - The error code
+ * @returns The error message
+ */
+export function getErrorMessage(code: ErrorCode): string {
+  return ERROR_CODE_METADATA[code].message;
+}
+
+/**
+ * Get the HTTP status code for an error code
+ * @param code - The error code
+ * @returns The HTTP status code
+ */
+export function getHttpStatus(code: ErrorCode): HttpStatus {
+  return ERROR_CODE_METADATA[code].httpStatus;
+}
+
+/**
+ * Check if an error code should be logged at error level
+ * @param code - The error code
+ * @returns Whether to log as error
+ */
+export function shouldLogAsError(code: ErrorCode): boolean {
+  return ERROR_CODE_METADATA[code].logAsError;
+}
+
+/**
+ * Get the category for an error code
+ * @param code - The error code
+ * @returns The error category
+ */
+export function getErrorCategory(code: ErrorCode): ErrorCategory {
+  return ERROR_CODE_METADATA[code].category;
+}
+
+/**
+ * Get all error codes for a specific category
+ * @param category - The error category
+ * @returns Array of error codes in the category
+ */
+export function getErrorCodesByCategory(category: ErrorCategory): ErrorCode[] {
+  return Object.entries(ERROR_CODE_METADATA)
+    .filter(([, meta]) => meta.category === category)
+    .map(([code]) => code as ErrorCode);
+}
+
+/**
+ * Validate that a string is a valid error code format
+ * @param code - The string to validate
+ * @returns Whether the string matches the error code pattern
+ */
+export function isValidErrorCodeFormat(code: string): boolean {
+  return ERROR_CODE_PATTERN.test(code);
+}
+
+/**
+ * Check if a string is a known error code
+ * @param code - The string to check
+ * @returns Whether the string is a known error code
+ */
+export function isKnownErrorCode(code: string): code is ErrorCode {
+  return code in ErrorCodes;
+}

--- a/packages/shared/src/errors/index.ts
+++ b/packages/shared/src/errors/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Error handling module
+ *
+ * Provides standardized error codes, messages, and utilities
+ * for consistent error handling across all services.
+ */
+
+export * from './error-codes.js';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,3 +19,6 @@ export function getVersionInfo(): string {
 
 // Export tracing module
 export * from './tracing/index.js';
+
+// Export error handling module
+export * from './errors/index.js';

--- a/packages/testing-utils/src/__tests__/error-response.spec.ts
+++ b/packages/testing-utils/src/__tests__/error-response.spec.ts
@@ -1,0 +1,378 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  validateErrorResponse,
+  assertErrorResponse,
+  assertErrorCode,
+  assertErrorCodePrefix,
+  assertHasCorrelationId,
+  extractErrorCode,
+  extractErrorMessage,
+  extractCorrelationId,
+  isErrorResponse,
+  createMockErrorResponse,
+  ERROR_CODE_PATTERN,
+  DEFAULT_CORRELATION_ID_PATTERN,
+  ISO_TIMESTAMP_PATTERN,
+} from '../validators/error-response';
+import { AssertionError } from '../assertions';
+
+describe('Error Response Validator', () => {
+  describe('Pattern Constants', () => {
+    it('ERROR_CODE_PATTERN should match valid error codes', () => {
+      expect(ERROR_CODE_PATTERN.test('AUTH_001')).toBe(true);
+      expect(ERROR_CODE_PATTERN.test('VALIDATION_012')).toBe(true);
+      expect(ERROR_CODE_PATTERN.test('RATE_LIMIT_005')).toBe(true);
+    });
+
+    it('ERROR_CODE_PATTERN should reject invalid codes', () => {
+      expect(ERROR_CODE_PATTERN.test('auth_001')).toBe(false);
+      expect(ERROR_CODE_PATTERN.test('AUTH001')).toBe(false);
+      expect(ERROR_CODE_PATTERN.test('AUTH_01')).toBe(false);
+    });
+
+    it('DEFAULT_CORRELATION_ID_PATTERN should match valid UUIDs', () => {
+      expect(DEFAULT_CORRELATION_ID_PATTERN.test('12345678-1234-1234-1234-123456789abc')).toBe(
+        true,
+      );
+      expect(DEFAULT_CORRELATION_ID_PATTERN.test('a1b2c3d4-e5f6-7890-abcd-ef1234567890')).toBe(
+        true,
+      );
+    });
+
+    it('DEFAULT_CORRELATION_ID_PATTERN should reject invalid UUIDs', () => {
+      expect(DEFAULT_CORRELATION_ID_PATTERN.test('not-a-uuid')).toBe(false);
+      expect(DEFAULT_CORRELATION_ID_PATTERN.test('12345678-1234-1234-1234')).toBe(false);
+    });
+
+    it('ISO_TIMESTAMP_PATTERN should match valid timestamps', () => {
+      expect(ISO_TIMESTAMP_PATTERN.test('2024-01-15T12:30:45Z')).toBe(true);
+      expect(ISO_TIMESTAMP_PATTERN.test('2024-01-15T12:30:45.123Z')).toBe(true);
+      expect(ISO_TIMESTAMP_PATTERN.test('2024-01-15T12:30:45')).toBe(true);
+    });
+
+    it('ISO_TIMESTAMP_PATTERN should reject invalid timestamps', () => {
+      expect(ISO_TIMESTAMP_PATTERN.test('2024-1-15T12:30:45Z')).toBe(false);
+      expect(ISO_TIMESTAMP_PATTERN.test('not-a-date')).toBe(false);
+    });
+  });
+
+  describe('validateErrorResponse', () => {
+    it('should validate a valid error response', () => {
+      const response = {
+        code: 'AUTH_001',
+        message: 'Authentication required.',
+      };
+
+      const result = validateErrorResponse(response);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should validate a complete error response', () => {
+      const response = createMockErrorResponse();
+
+      const result = validateErrorResponse(response);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should reject null response', () => {
+      const result = validateErrorResponse(null);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Response must be a non-null object');
+    });
+
+    it('should reject non-object response', () => {
+      const result = validateErrorResponse('string');
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Response must be a non-null object');
+    });
+
+    it('should reject missing code field', () => {
+      const response = { message: 'Error occurred.' };
+
+      const result = validateErrorResponse(response);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain("Missing required field: 'code'");
+    });
+
+    it('should reject non-string code field', () => {
+      const response = { code: 123, message: 'Error occurred.' };
+
+      const result = validateErrorResponse(response);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain("Field 'code' must be a string");
+    });
+
+    it('should reject invalid code format', () => {
+      const response = { code: 'invalid', message: 'Error occurred.' };
+
+      const result = validateErrorResponse(response);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain("Field 'code' must match pattern CATEGORY_NNN");
+    });
+
+    it('should reject missing message field', () => {
+      const response = { code: 'AUTH_001' };
+
+      const result = validateErrorResponse(response);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain("Missing required field: 'message'");
+    });
+
+    it('should reject empty message field', () => {
+      const response = { code: 'AUTH_001', message: '' };
+
+      const result = validateErrorResponse(response);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain("Field 'message' must not be empty");
+    });
+
+    describe('with options', () => {
+      it('should validate expectedCode', () => {
+        const response = { code: 'AUTH_001', message: 'Error.' };
+
+        const result = validateErrorResponse(response, { expectedCode: 'AUTH_002' });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Expected error code 'AUTH_002', got: AUTH_001");
+      });
+
+      it('should validate expectedCodePrefix', () => {
+        const response = { code: 'VALIDATION_001', message: 'Error.' };
+
+        const result = validateErrorResponse(response, { expectedCodePrefix: 'AUTH_' });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Expected error code prefix 'AUTH_', got: VALIDATION_001");
+      });
+
+      it('should require correlationId when specified', () => {
+        const response = { code: 'AUTH_001', message: 'Error.' };
+
+        const result = validateErrorResponse(response, { requireCorrelationId: true });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Missing required field: 'correlationId'");
+      });
+
+      it('should validate correlationId format', () => {
+        const response = {
+          code: 'AUTH_001',
+          message: 'Error.',
+          correlationId: 'invalid',
+        };
+
+        const result = validateErrorResponse(response, { requireCorrelationId: true });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain("Field 'correlationId' must match pattern");
+      });
+
+      it('should require timestamp when specified', () => {
+        const response = { code: 'AUTH_001', message: 'Error.' };
+
+        const result = validateErrorResponse(response, { requireTimestamp: true });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Missing required field: 'timestamp'");
+      });
+
+      it('should validate timestamp format', () => {
+        const response = {
+          code: 'AUTH_001',
+          message: 'Error.',
+          timestamp: 'invalid',
+        };
+
+        const result = validateErrorResponse(response);
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain("Field 'timestamp' must be ISO 8601 format");
+      });
+
+      it('should require path when specified', () => {
+        const response = { code: 'AUTH_001', message: 'Error.' };
+
+        const result = validateErrorResponse(response, { requirePath: true });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Missing required field: 'path'");
+      });
+
+      it('should validate path format', () => {
+        const response = {
+          code: 'AUTH_001',
+          message: 'Error.',
+          path: 'no-leading-slash',
+        };
+
+        const result = validateErrorResponse(response);
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("Field 'path' must start with '/', got: no-leading-slash");
+      });
+    });
+
+    it('should validate details field as object', () => {
+      const response = {
+        code: 'AUTH_001',
+        message: 'Error.',
+        details: 'not-an-object',
+      };
+
+      const result = validateErrorResponse(response);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain("Field 'details' must be a non-null object");
+    });
+
+    it('should reject array as details', () => {
+      const response = {
+        code: 'AUTH_001',
+        message: 'Error.',
+        details: ['not', 'valid'],
+      };
+
+      const result = validateErrorResponse(response);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain("Field 'details' must be a non-null object");
+    });
+  });
+
+  describe('assertErrorResponse', () => {
+    it('should pass for valid response', () => {
+      const response = createMockErrorResponse();
+      expect(() => assertErrorResponse(response)).not.toThrow();
+    });
+
+    it('should throw AssertionError for invalid response', () => {
+      expect(() => assertErrorResponse(null)).toThrow(AssertionError);
+    });
+
+    it('should include validation errors in message', () => {
+      try {
+        assertErrorResponse({});
+      } catch (error) {
+        expect(error).toBeInstanceOf(AssertionError);
+        expect((error as AssertionError).message).toContain("Missing required field: 'code'");
+      }
+    });
+  });
+
+  describe('assertErrorCode', () => {
+    it('should pass for matching code', () => {
+      const response = createMockErrorResponse({ code: 'AUTH_001' });
+      expect(() => assertErrorCode(response, 'AUTH_001')).not.toThrow();
+    });
+
+    it('should throw for non-matching code', () => {
+      const response = createMockErrorResponse({ code: 'AUTH_001' });
+      expect(() => assertErrorCode(response, 'AUTH_002')).toThrow(AssertionError);
+    });
+  });
+
+  describe('assertErrorCodePrefix', () => {
+    it('should pass for matching prefix', () => {
+      const response = createMockErrorResponse({ code: 'AUTH_001' });
+      expect(() => assertErrorCodePrefix(response, 'AUTH_')).not.toThrow();
+    });
+
+    it('should throw for non-matching prefix', () => {
+      const response = createMockErrorResponse({ code: 'AUTH_001' });
+      expect(() => assertErrorCodePrefix(response, 'VALIDATION_')).toThrow(AssertionError);
+    });
+  });
+
+  describe('assertHasCorrelationId', () => {
+    it('should pass when correlationId present', () => {
+      const response = createMockErrorResponse();
+      expect(() => assertHasCorrelationId(response)).not.toThrow();
+    });
+
+    it('should throw when correlationId missing', () => {
+      const response = { code: 'AUTH_001', message: 'Error.' };
+      expect(() => assertHasCorrelationId(response)).toThrow(AssertionError);
+    });
+  });
+
+  describe('extractErrorCode', () => {
+    it('should extract code from response', () => {
+      const response = { code: 'AUTH_001', message: 'Error.' };
+      expect(extractErrorCode(response)).toBe('AUTH_001');
+    });
+
+    it('should return undefined for missing code', () => {
+      expect(extractErrorCode({})).toBeUndefined();
+    });
+
+    it('should return undefined for non-string code', () => {
+      expect(extractErrorCode({ code: 123 })).toBeUndefined();
+    });
+
+    it('should return undefined for null', () => {
+      expect(extractErrorCode(null)).toBeUndefined();
+    });
+  });
+
+  describe('extractErrorMessage', () => {
+    it('should extract message from response', () => {
+      const response = { code: 'AUTH_001', message: 'Error occurred.' };
+      expect(extractErrorMessage(response)).toBe('Error occurred.');
+    });
+
+    it('should return undefined for missing message', () => {
+      expect(extractErrorMessage({})).toBeUndefined();
+    });
+  });
+
+  describe('extractCorrelationId', () => {
+    it('should extract correlationId from response', () => {
+      const response = createMockErrorResponse();
+      expect(extractCorrelationId(response)).toBe('12345678-1234-1234-1234-123456789abc');
+    });
+
+    it('should return undefined for missing correlationId', () => {
+      expect(extractCorrelationId({})).toBeUndefined();
+    });
+  });
+
+  describe('isErrorResponse', () => {
+    it('should return true for valid error response', () => {
+      const response = createMockErrorResponse();
+      expect(isErrorResponse(response)).toBe(true);
+    });
+
+    it('should return false for invalid response', () => {
+      expect(isErrorResponse(null)).toBe(false);
+      expect(isErrorResponse({})).toBe(false);
+      expect(isErrorResponse({ code: 'invalid' })).toBe(false);
+    });
+  });
+
+  describe('createMockErrorResponse', () => {
+    it('should create a valid error response', () => {
+      const response = createMockErrorResponse();
+
+      expect(response.code).toBe('VALIDATION_001');
+      expect(response.message).toBe('Request validation failed.');
+      expect(response.correlationId).toBeDefined();
+      expect(response.timestamp).toBeDefined();
+      expect(response.path).toBe('/api/test');
+    });
+
+    it('should allow overriding fields', () => {
+      const response = createMockErrorResponse({
+        code: 'AUTH_001',
+        message: 'Custom message.',
+        path: '/custom/path',
+      });
+
+      expect(response.code).toBe('AUTH_001');
+      expect(response.message).toBe('Custom message.');
+      expect(response.path).toBe('/custom/path');
+    });
+
+    it('should create a valid response according to validator', () => {
+      const response = createMockErrorResponse();
+      const result = validateErrorResponse(response);
+      expect(result.valid).toBe(true);
+    });
+  });
+});

--- a/packages/testing-utils/src/index.ts
+++ b/packages/testing-utils/src/index.ts
@@ -28,6 +28,7 @@
 export * from './mocks/index.js';
 export * from './fixtures/index.js';
 export * from './assertions/index.js';
+export * from './validators/index.js';
 export * from './db-cleanup.js';
 
 // Re-export commonly used MSW types for convenience

--- a/packages/testing-utils/src/validators/error-response.ts
+++ b/packages/testing-utils/src/validators/error-response.ts
@@ -1,0 +1,343 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Error Response Schema Validator
+ *
+ * T311: Create error response schema validator
+ *
+ * Validates API error responses to ensure they conform to the
+ * standard error response schema. Reusable across integration tests.
+ */
+
+import { AssertionError } from '../assertions/index.js';
+
+/**
+ * Standard error response structure
+ */
+export interface ErrorResponse {
+  /** Error code (e.g., AUTH_001, VALIDATION_002) */
+  code: string;
+  /** Human-readable error message */
+  message: string;
+  /** Correlation ID for request tracing */
+  correlationId?: string;
+  /** Additional error details */
+  details?: Record<string, unknown>;
+  /** Timestamp of the error */
+  timestamp?: string;
+  /** Request path that caused the error */
+  path?: string;
+}
+
+/**
+ * Validation result
+ */
+export interface ValidationResult {
+  /** Whether the response is valid */
+  valid: boolean;
+  /** Validation errors if invalid */
+  errors: string[];
+}
+
+/**
+ * Validation options
+ */
+export interface ValidationOptions {
+  /** Require correlationId to be present */
+  requireCorrelationId?: boolean;
+  /** Require timestamp to be present */
+  requireTimestamp?: boolean;
+  /** Require path to be present */
+  requirePath?: boolean;
+  /** Expected HTTP status code */
+  expectedStatus?: number;
+  /** Expected error code */
+  expectedCode?: string;
+  /** Expected error code prefix (e.g., 'AUTH_', 'VALIDATION_') */
+  expectedCodePrefix?: string;
+  /** Pattern for correlation ID validation */
+  correlationIdPattern?: RegExp;
+}
+
+/**
+ * Default correlation ID pattern (UUID format)
+ */
+export const DEFAULT_CORRELATION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Error code pattern (CATEGORY_NNN)
+ * Supports multi-word categories with underscores (e.g., RATE_LIMIT_005)
+ */
+export const ERROR_CODE_PATTERN = /^[A-Z]+(?:_[A-Z]+)*_\d{3}$/;
+
+/**
+ * ISO 8601 timestamp pattern
+ */
+export const ISO_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z?$/;
+
+/**
+ * Validate an error response against the schema
+ *
+ * @param response - The response body to validate
+ * @param options - Validation options
+ * @returns Validation result with errors if invalid
+ *
+ * @example
+ * ```typescript
+ * const result = validateErrorResponse(response.body, {
+ *   requireCorrelationId: true,
+ *   expectedCodePrefix: 'AUTH_',
+ * });
+ *
+ * if (!result.valid) {
+ *   console.error('Validation errors:', result.errors);
+ * }
+ * ```
+ */
+export function validateErrorResponse(
+  response: unknown,
+  options: ValidationOptions = {},
+): ValidationResult {
+  const errors: string[] = [];
+
+  // Check if response is an object
+  if (!response || typeof response !== 'object') {
+    return {
+      valid: false,
+      errors: ['Response must be a non-null object'],
+    };
+  }
+
+  const errorResponse = response as Record<string, unknown>;
+
+  // Validate required 'code' field
+  if (!('code' in errorResponse)) {
+    errors.push("Missing required field: 'code'");
+  } else if (typeof errorResponse['code'] !== 'string') {
+    errors.push("Field 'code' must be a string");
+  } else if (!ERROR_CODE_PATTERN.test(errorResponse['code'])) {
+    errors.push(`Field 'code' must match pattern CATEGORY_NNN, got: ${errorResponse['code']}`);
+  } else {
+    // Check expected code
+    if (options.expectedCode && errorResponse['code'] !== options.expectedCode) {
+      errors.push(`Expected error code '${options.expectedCode}', got: ${errorResponse['code']}`);
+    }
+
+    // Check expected code prefix
+    if (
+      options.expectedCodePrefix &&
+      !String(errorResponse['code']).startsWith(options.expectedCodePrefix)
+    ) {
+      errors.push(
+        `Expected error code prefix '${options.expectedCodePrefix}', got: ${errorResponse['code']}`,
+      );
+    }
+  }
+
+  // Validate required 'message' field
+  if (!('message' in errorResponse)) {
+    errors.push("Missing required field: 'message'");
+  } else if (typeof errorResponse['message'] !== 'string') {
+    errors.push("Field 'message' must be a string");
+  } else if (errorResponse['message'].length === 0) {
+    errors.push("Field 'message' must not be empty");
+  }
+
+  // Validate optional 'correlationId' field
+  if (options.requireCorrelationId && !('correlationId' in errorResponse)) {
+    errors.push("Missing required field: 'correlationId'");
+  }
+
+  if ('correlationId' in errorResponse && errorResponse['correlationId'] !== undefined) {
+    if (typeof errorResponse['correlationId'] !== 'string') {
+      errors.push("Field 'correlationId' must be a string");
+    } else {
+      const pattern = options.correlationIdPattern ?? DEFAULT_CORRELATION_ID_PATTERN;
+      if (!pattern.test(errorResponse['correlationId'])) {
+        errors.push(
+          `Field 'correlationId' must match pattern ${pattern}, got: ${errorResponse['correlationId']}`,
+        );
+      }
+    }
+  }
+
+  // Validate optional 'timestamp' field
+  if (options.requireTimestamp && !('timestamp' in errorResponse)) {
+    errors.push("Missing required field: 'timestamp'");
+  }
+
+  if ('timestamp' in errorResponse && errorResponse['timestamp'] !== undefined) {
+    if (typeof errorResponse['timestamp'] !== 'string') {
+      errors.push("Field 'timestamp' must be a string");
+    } else if (!ISO_TIMESTAMP_PATTERN.test(errorResponse['timestamp'])) {
+      errors.push(`Field 'timestamp' must be ISO 8601 format, got: ${errorResponse['timestamp']}`);
+    }
+  }
+
+  // Validate optional 'path' field
+  if (options.requirePath && !('path' in errorResponse)) {
+    errors.push("Missing required field: 'path'");
+  }
+
+  if ('path' in errorResponse && errorResponse['path'] !== undefined) {
+    if (typeof errorResponse['path'] !== 'string') {
+      errors.push("Field 'path' must be a string");
+    } else if (!errorResponse['path'].startsWith('/')) {
+      errors.push(`Field 'path' must start with '/', got: ${errorResponse['path']}`);
+    }
+  }
+
+  // Validate optional 'details' field
+  if ('details' in errorResponse && errorResponse['details'] !== undefined) {
+    if (
+      typeof errorResponse['details'] !== 'object' ||
+      errorResponse['details'] === null ||
+      Array.isArray(errorResponse['details'])
+    ) {
+      errors.push("Field 'details' must be a non-null object");
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Assert that an error response is valid
+ *
+ * @param response - The response body to validate
+ * @param options - Validation options
+ * @throws AssertionError if validation fails
+ *
+ * @example
+ * ```typescript
+ * // In an integration test
+ * const response = await api.post('/login').send({ email: 'bad' });
+ * assertErrorResponse(response.body, {
+ *   expectedCodePrefix: 'VALIDATION_',
+ *   requireCorrelationId: true,
+ * });
+ * ```
+ */
+export function assertErrorResponse(
+  response: unknown,
+  options: ValidationOptions = {},
+): asserts response is ErrorResponse {
+  const result = validateErrorResponse(response, options);
+
+  if (!result.valid) {
+    throw new AssertionError(
+      `Invalid error response:\n${result.errors.map((e) => `  - ${e}`).join('\n')}`,
+      'valid error response',
+      response,
+    );
+  }
+}
+
+/**
+ * Assert that a response has a specific error code
+ *
+ * @param response - The response body to check
+ * @param expectedCode - The expected error code
+ * @throws AssertionError if the code doesn't match
+ */
+export function assertErrorCode(response: unknown, expectedCode: string): void {
+  assertErrorResponse(response, { expectedCode });
+}
+
+/**
+ * Assert that a response has an error code starting with a prefix
+ *
+ * @param response - The response body to check
+ * @param prefix - The expected error code prefix
+ * @throws AssertionError if the prefix doesn't match
+ */
+export function assertErrorCodePrefix(response: unknown, prefix: string): void {
+  assertErrorResponse(response, { expectedCodePrefix: prefix });
+}
+
+/**
+ * Assert that a response has a correlation ID
+ *
+ * @param response - The response body to check
+ * @throws AssertionError if correlationId is missing
+ */
+export function assertHasCorrelationId(response: unknown): void {
+  assertErrorResponse(response, { requireCorrelationId: true });
+}
+
+/**
+ * Extract error code from a response
+ *
+ * @param response - The response body
+ * @returns The error code or undefined if not found
+ */
+export function extractErrorCode(response: unknown): string | undefined {
+  if (response && typeof response === 'object' && 'code' in response) {
+    const code = (response as { code: unknown })['code'];
+    return typeof code === 'string' ? code : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Extract error message from a response
+ *
+ * @param response - The response body
+ * @returns The error message or undefined if not found
+ */
+export function extractErrorMessage(response: unknown): string | undefined {
+  if (response && typeof response === 'object' && 'message' in response) {
+    const message = (response as { message: unknown })['message'];
+    return typeof message === 'string' ? message : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Extract correlation ID from a response
+ *
+ * @param response - The response body
+ * @returns The correlation ID or undefined if not found
+ */
+export function extractCorrelationId(response: unknown): string | undefined {
+  if (response && typeof response === 'object' && 'correlationId' in response) {
+    const correlationId = (response as { correlationId: unknown })['correlationId'];
+    return typeof correlationId === 'string' ? correlationId : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Check if a response is an error response
+ *
+ * @param response - The response body to check
+ * @returns true if the response has the structure of an error response
+ */
+export function isErrorResponse(response: unknown): response is ErrorResponse {
+  const result = validateErrorResponse(response);
+  return result.valid;
+}
+
+/**
+ * Create a mock error response for testing
+ *
+ * @param overrides - Fields to override in the mock
+ * @returns A valid error response object
+ */
+export function createMockErrorResponse(overrides: Partial<ErrorResponse> = {}): ErrorResponse {
+  return {
+    code: 'VALIDATION_001',
+    message: 'Request validation failed.',
+    correlationId: '12345678-1234-1234-1234-123456789abc',
+    timestamp: new Date().toISOString(),
+    path: '/api/test',
+    ...overrides,
+  };
+}

--- a/packages/testing-utils/src/validators/index.ts
+++ b/packages/testing-utils/src/validators/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Validators module
+ *
+ * Provides schema validators for testing API responses.
+ */
+
+export * from './error-response.js';


### PR DESCRIPTION
## Summary
- Implements Issues #368, #369, #370 - Error Handling Standards bundle
- Creates standardized error code taxonomy in packages/shared with 60+ error codes
- Creates error response schema validator in packages/testing-utils for integration tests

## Changes

### packages/shared - Error Code Taxonomy (T309)
- **Error Categories**: AUTH, VALIDATION, RESOURCE, RATE_LIMIT, BUSINESS, EXTERNAL, INTERNAL
- **Error Codes**: 60+ hierarchical codes following CATEGORY_NNN pattern
- **Metadata**: Human-readable messages, HTTP status codes, logging configuration
- **Helper Functions**: getErrorMeta, getErrorMessage, getHttpStatus, getErrorCategory, getErrorCodesByCategory
- **Validation**: isValidErrorCodeFormat, isKnownErrorCode

### packages/shared - Contract Tests (T310)
- 47 tests validating error code format consistency
- Tests for message quality (capitalization, punctuation, no jargon)
- HTTP status code correctness per category
- Logging configuration validation

### packages/testing-utils - Error Response Validator (T311)
- Schema validator for API error responses (code, message, correlationId, timestamp, path, details)
- Assertion helpers: assertErrorResponse, assertErrorCode, assertErrorCodePrefix, assertHasCorrelationId
- Extraction utilities: extractErrorCode, extractErrorMessage, extractCorrelationId
- Type guards: isErrorResponse
- Factory: createMockErrorResponse for test fixtures
- 47 comprehensive tests

## Test Plan
- [x] packages/shared tests pass (52 tests)
- [x] packages/testing-utils tests pass (175 tests)
- [x] TypeScript builds successfully
- [x] Lint checks pass

Closes #368, Closes #369, Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)