### PR TITLE
feat(testing): Add k6 performance testing and perf assertions (#371, #372, #373, #374, #375)

### DIFF
--- a/.husky/pre-commit-no-console
+++ b/.husky/pre-commit-no-console
@@ -89,11 +89,18 @@ while IFS= read -r file; do
     continue
   fi
 
+  # Skip e2e/tests/performance/ folder - k6 performance tests need console output
+  if [[ "$file" =~ ^e2e/tests/performance/ ]]; then
+    debug "Skipping performance test file: $file"
+    continue
+  fi
+
   # Get staged content and check for problematic console statements
   STAGED_CONTENT=$(git show ":$file" 2>/dev/null || echo "")
 
   # Check for console.log
-  if echo "$STAGED_CONTENT" | grep -E "console\.(log|debug)" | grep -v "^\s*\/\/" > /dev/null 2>&1; then
+  # Exclude lines starting with // or * (JSDoc/TSDoc comments)
+  if echo "$STAGED_CONTENT" | grep -E "console\.(log|debug)" | grep -v "^\s*\/\/" | grep -v "^\s*\*" > /dev/null 2>&1; then
     VIOLATIONS+=("$file: contains console.log/debug")
   fi
 done <<< "$STAGED_FILES"

--- a/e2e/tests/performance/api-load.js
+++ b/e2e/tests/performance/api-load.js
@@ -1,0 +1,223 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * k6 Load Test Script for reasonBridge API
+ *
+ * Stages: ramp up -> sustained -> peak (10k users) -> ramp down
+ * Thresholds: p95 < 200ms, error rate < 1%
+ *
+ * Usage:
+ *   k6 run e2e/tests/performance/api-load.js
+ *   k6 run --env BASE_URL=http://localhost:3000 e2e/tests/performance/api-load.js
+ */
+
+import http from 'k6/http';
+import { check, sleep, group } from 'k6';
+import { Rate, Trend, Counter } from 'k6/metrics';
+
+// Custom metrics
+const errorRate = new Rate('errors');
+const topicsLatency = new Trend('topics_latency', true);
+const usersLatency = new Trend('users_latency', true);
+const healthLatency = new Trend('health_latency', true);
+const requestCount = new Counter('requests');
+
+// Test configuration
+export const options = {
+  // Load test stages: ramp up, sustained, peak, ramp down
+  stages: [
+    // Ramp up: 0 to 1000 users over 2 minutes
+    { duration: '2m', target: 1000 },
+    // Sustained load: 1000 users for 5 minutes
+    { duration: '5m', target: 1000 },
+    // Peak load: ramp to 10000 users over 3 minutes
+    { duration: '3m', target: 10000 },
+    // Hold peak: 10000 users for 5 minutes
+    { duration: '5m', target: 10000 },
+    // Ramp down: 10000 to 0 users over 2 minutes
+    { duration: '2m', target: 0 },
+  ],
+
+  // Thresholds for pass/fail criteria
+  thresholds: {
+    // 95th percentile response time must be under 200ms
+    http_req_duration: ['p(95)<200'],
+    // Error rate must be under 1%
+    errors: ['rate<0.01'],
+    // Custom latency thresholds per endpoint
+    topics_latency: ['p(95)<200', 'p(99)<500'],
+    users_latency: ['p(95)<200', 'p(99)<500'],
+    health_latency: ['p(95)<50', 'p(99)<100'],
+  },
+
+  // Tags for result grouping
+  tags: {
+    testType: 'load',
+  },
+
+  // Graceful stop configuration
+  gracefulStop: '30s',
+  gracefulRampDown: '30s',
+};
+
+// Base URL from environment or default
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+
+// Common headers
+const headers = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+};
+
+/**
+ * Setup function - runs once before the test
+ */
+export function setup() {
+  // Verify the API is reachable
+  const healthRes = http.get(`${BASE_URL}/health`, { headers });
+
+  if (healthRes.status !== 200) {
+    console.error(`Health check failed: ${healthRes.status}`);
+    throw new Error('API health check failed - aborting test');
+  }
+
+  console.log(`Load test starting against ${BASE_URL}`);
+
+  return {
+    baseUrl: BASE_URL,
+    startTime: new Date().toISOString(),
+  };
+}
+
+/**
+ * Main test function - runs for each virtual user
+ */
+export default function (data) {
+  const baseUrl = data.baseUrl;
+
+  // Health endpoint (lightweight)
+  group('Health Check', () => {
+    const start = Date.now();
+    const res = http.get(`${baseUrl}/health`, { headers, tags: { endpoint: 'health' } });
+
+    healthLatency.add(Date.now() - start);
+    requestCount.add(1);
+
+    const success = check(res, {
+      'health status is 200': (r) => r.status === 200,
+      'health response time < 100ms': (r) => r.timings.duration < 100,
+    });
+
+    errorRate.add(!success);
+  });
+
+  sleep(0.1); // Small pause between groups
+
+  // Topics endpoint
+  group('List Topics', () => {
+    const start = Date.now();
+    const res = http.get(`${baseUrl}/api/topics?page=1&limit=20`, {
+      headers,
+      tags: { endpoint: 'topics' },
+    });
+
+    topicsLatency.add(Date.now() - start);
+    requestCount.add(1);
+
+    const success = check(res, {
+      'topics status is 200 or 401': (r) => r.status === 200 || r.status === 401,
+      'topics response time < 300ms': (r) => r.timings.duration < 300,
+      'topics has valid JSON': (r) => {
+        try {
+          if (r.status === 200) {
+            const body = JSON.parse(r.body);
+            return Array.isArray(body.topics) || Array.isArray(body.data) || Array.isArray(body);
+          }
+          return true; // 401 responses don't need JSON validation
+        } catch {
+          return false;
+        }
+      },
+    });
+
+    errorRate.add(!success);
+  });
+
+  sleep(0.2);
+
+  // Users endpoint (if authenticated)
+  group('User Profile', () => {
+    const start = Date.now();
+    const res = http.get(`${baseUrl}/api/users/me`, {
+      headers,
+      tags: { endpoint: 'users' },
+    });
+
+    usersLatency.add(Date.now() - start);
+    requestCount.add(1);
+
+    // 401 is expected without auth token
+    const success = check(res, {
+      'users status is 200 or 401': (r) => r.status === 200 || r.status === 401,
+      'users response time < 300ms': (r) => r.timings.duration < 300,
+    });
+
+    errorRate.add(!success);
+  });
+
+  // Simulate user think time
+  sleep(Math.random() * 2 + 1); // 1-3 seconds
+}
+
+/**
+ * Teardown function - runs once after the test
+ */
+export function teardown(data) {
+  console.log(`Load test completed. Started at: ${data.startTime}`);
+  console.log(`Tested against: ${data.baseUrl}`);
+}
+
+/**
+ * Handle summary - customize output format
+ */
+export function handleSummary(data) {
+  const summary = {
+    timestamp: new Date().toISOString(),
+    testType: 'load',
+    baseUrl: BASE_URL,
+    metrics: {
+      http_req_duration: {
+        avg: data.metrics.http_req_duration?.values?.avg,
+        p95: data.metrics.http_req_duration?.values?.['p(95)'],
+        p99: data.metrics.http_req_duration?.values?.['p(99)'],
+        max: data.metrics.http_req_duration?.values?.max,
+      },
+      errors: {
+        rate: data.metrics.errors?.values?.rate,
+        passes: data.metrics.errors?.values?.passes,
+        fails: data.metrics.errors?.values?.fails,
+      },
+      requests: {
+        total: data.metrics.requests?.values?.count,
+        rate: data.metrics.http_reqs?.values?.rate,
+      },
+      vus: {
+        max: data.metrics.vus_max?.values?.max,
+      },
+    },
+    thresholds: {
+      passed: Object.values(data.root_group?.checks || {}).every((c) => c.passes > 0),
+    },
+  };
+
+  return {
+    'stdout': textSummary(data, { indent: ' ', enableColors: true }),
+    'e2e/tests/performance/results/load-test-summary.json': JSON.stringify(summary, null, 2),
+  };
+}
+
+/**
+ * Generate text summary (imported from k6)
+ */
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';

--- a/e2e/tests/performance/api-soak.js
+++ b/e2e/tests/performance/api-soak.js
@@ -1,0 +1,269 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * k6 Soak Test Script for reasonBridge API
+ *
+ * Extended duration test to detect:
+ * - Memory leaks
+ * - Resource exhaustion
+ * - Performance degradation over time
+ * - Connection pool issues
+ *
+ * Usage:
+ *   k6 run e2e/tests/performance/api-soak.js
+ *   k6 run --env BASE_URL=http://localhost:3000 --env DURATION=4h e2e/tests/performance/api-soak.js
+ */
+
+import http from 'k6/http';
+import { check, sleep, group } from 'k6';
+import { Rate, Trend, Counter, Gauge } from 'k6/metrics';
+
+// Custom metrics for soak test analysis
+const errorRate = new Rate('errors');
+const latencyTrend = new Trend('latency_over_time', true);
+const memoryIndicator = new Gauge('memory_pressure_indicator');
+const requestCount = new Counter('requests');
+const degradationCounter = new Counter('degradation_events');
+
+// Configurable duration via environment variable
+const SOAK_DURATION = __ENV.DURATION || '1h';
+
+// Test configuration - Sustained load over extended period
+export const options = {
+  stages: [
+    // Ramp up to target load over 5 minutes
+    { duration: '5m', target: 500 },
+    // Sustained load for configured duration (default 1 hour)
+    { duration: SOAK_DURATION, target: 500 },
+    // Ramp down over 5 minutes
+    { duration: '5m', target: 0 },
+  ],
+
+  // Soak test thresholds - focus on consistency over time
+  thresholds: {
+    // Response times should remain consistent
+    http_req_duration: ['p(95)<200', 'p(99)<400', 'avg<100'],
+    // Very low error rate for soak tests
+    errors: ['rate<0.001'], // Less than 0.1%
+    // No significant degradation events
+    degradation_events: ['count<10'],
+    // Latency should not increase significantly over time
+    latency_over_time: ['p(95)<250'],
+  },
+
+  tags: {
+    testType: 'soak',
+  },
+
+  // Longer graceful periods for soak tests
+  gracefulStop: '60s',
+  gracefulRampDown: '60s',
+
+  // Batch requests to reduce overhead
+  batch: 10,
+  batchPerHost: 5,
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+
+const headers = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+};
+
+// Track baseline latency for degradation detection
+let baselineLatency = null;
+let sampleCount = 0;
+const BASELINE_SAMPLES = 100;
+const DEGRADATION_THRESHOLD = 1.5; // 50% increase triggers degradation event
+
+export function setup() {
+  const healthRes = http.get(`${BASE_URL}/health`, { headers });
+
+  if (healthRes.status !== 200) {
+    throw new Error('API health check failed - aborting soak test');
+  }
+
+  console.log(`Soak test starting against ${BASE_URL}`);
+  console.log(`Duration: ${SOAK_DURATION}`);
+
+  return {
+    baseUrl: BASE_URL,
+    startTime: new Date().toISOString(),
+    duration: SOAK_DURATION,
+  };
+}
+
+export default function (data) {
+  const baseUrl = data.baseUrl;
+  const iteration = __ITER;
+
+  // Primary endpoint: Topics listing
+  group('Topics Soak', () => {
+    const start = Date.now();
+    const res = http.get(`${baseUrl}/api/topics?page=1&limit=20`, {
+      headers,
+      tags: { endpoint: 'topics' },
+    });
+
+    const latency = Date.now() - start;
+    latencyTrend.add(latency);
+    requestCount.add(1);
+
+    // Establish baseline from first N samples
+    if (sampleCount < BASELINE_SAMPLES) {
+      if (baselineLatency === null) {
+        baselineLatency = latency;
+      } else {
+        baselineLatency = (baselineLatency * sampleCount + latency) / (sampleCount + 1);
+      }
+      sampleCount++;
+    } else if (baselineLatency !== null) {
+      // Check for degradation after baseline is established
+      if (latency > baselineLatency * DEGRADATION_THRESHOLD) {
+        degradationCounter.add(1);
+      }
+    }
+
+    const success = check(res, {
+      'status is 200 or 401': (r) => r.status === 200 || r.status === 401,
+      'response time acceptable': (r) => r.timings.duration < 400,
+      'no timeout': (r) => r.timings.duration < 10000,
+    });
+
+    errorRate.add(!success);
+  });
+
+  sleep(0.5);
+
+  // Secondary endpoint: User profile
+  group('Users Soak', () => {
+    const start = Date.now();
+    const res = http.get(`${baseUrl}/api/users/me`, {
+      headers,
+      tags: { endpoint: 'users' },
+    });
+
+    const latency = Date.now() - start;
+    latencyTrend.add(latency);
+    requestCount.add(1);
+
+    const success = check(res, {
+      'status is 200 or 401': (r) => r.status === 200 || r.status === 401,
+      'response time acceptable': (r) => r.timings.duration < 400,
+    });
+
+    errorRate.add(!success);
+  });
+
+  sleep(0.5);
+
+  // Health check - monitor system health during soak
+  if (iteration % 10 === 0) {
+    // Every 10th iteration
+    group('Health Monitoring', () => {
+      const res = http.get(`${baseUrl}/health`, {
+        headers,
+        tags: { endpoint: 'health' },
+      });
+
+      requestCount.add(1);
+
+      // Use response time as a proxy for system health
+      // Higher health check times may indicate memory pressure
+      const healthLatency = res.timings.duration;
+      if (healthLatency > 100) {
+        memoryIndicator.add(healthLatency / 100); // Normalized indicator
+      } else {
+        memoryIndicator.add(1); // Healthy baseline
+      }
+
+      const success = check(res, {
+        'health endpoint healthy': (r) => r.status === 200,
+        'health response fast': (r) => r.timings.duration < 100,
+      });
+
+      errorRate.add(!success);
+    });
+  }
+
+  // Simulate realistic user behavior with think time
+  sleep(Math.random() * 3 + 2); // 2-5 seconds
+}
+
+export function teardown(data) {
+  console.log(`Soak test completed. Started at: ${data.startTime}`);
+  console.log(`Duration: ${data.duration}`);
+  console.log(`Baseline latency established: ${baselineLatency?.toFixed(2)}ms`);
+}
+
+export function handleSummary(data) {
+  // Calculate latency trend over time
+  const latencyStart = data.metrics.latency_over_time?.values?.min || 0;
+  const latencyEnd = data.metrics.latency_over_time?.values?.max || 0;
+  const latencyIncrease = latencyEnd > 0 ? ((latencyEnd - latencyStart) / latencyStart) * 100 : 0;
+
+  const summary = {
+    timestamp: new Date().toISOString(),
+    testType: 'soak',
+    baseUrl: BASE_URL,
+    duration: SOAK_DURATION,
+    metrics: {
+      http_req_duration: {
+        avg: data.metrics.http_req_duration?.values?.avg,
+        p95: data.metrics.http_req_duration?.values?.['p(95)'],
+        p99: data.metrics.http_req_duration?.values?.['p(99)'],
+        max: data.metrics.http_req_duration?.values?.max,
+        min: data.metrics.http_req_duration?.values?.min,
+      },
+      errors: {
+        rate: data.metrics.errors?.values?.rate,
+        total: data.metrics.errors?.values?.fails,
+      },
+      requests: {
+        total: data.metrics.requests?.values?.count,
+        rate: data.metrics.http_reqs?.values?.rate,
+      },
+      degradation: {
+        events: data.metrics.degradation_events?.values?.count || 0,
+        latencyIncreasePercent: latencyIncrease.toFixed(2),
+      },
+    },
+    analysis: {
+      memoryLeakIndicator: latencyIncrease > 50, // >50% increase suggests leak
+      performanceDegraded: (data.metrics.degradation_events?.values?.count || 0) > 10,
+      stablePerformance:
+        (data.metrics.http_req_duration?.values?.['p(95)'] || 0) < 200 &&
+        (data.metrics.errors?.values?.rate || 0) < 0.001,
+    },
+    recommendations: [],
+  };
+
+  // Add recommendations based on results
+  if (summary.analysis.memoryLeakIndicator) {
+    summary.recommendations.push(
+      'Potential memory leak detected: latency increased significantly over time'
+    );
+  }
+  if (summary.analysis.performanceDegraded) {
+    summary.recommendations.push(
+      'Performance degradation detected: multiple degradation events recorded'
+    );
+  }
+  if (!summary.analysis.stablePerformance) {
+    summary.recommendations.push(
+      'System did not maintain stable performance during soak test'
+    );
+  }
+  if (summary.recommendations.length === 0) {
+    summary.recommendations.push('System performed well during extended load test');
+  }
+
+  return {
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+    'e2e/tests/performance/results/soak-test-summary.json': JSON.stringify(summary, null, 2),
+  };
+}
+
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';

--- a/e2e/tests/performance/api-spike.js
+++ b/e2e/tests/performance/api-spike.js
@@ -1,0 +1,223 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * k6 Spike Test Script for reasonBridge API
+ *
+ * Tests system behavior under sudden extreme load spikes
+ * Validates recovery after spike subsides
+ *
+ * Usage:
+ *   k6 run e2e/tests/performance/api-spike.js
+ *   k6 run --env BASE_URL=http://localhost:3000 e2e/tests/performance/api-spike.js
+ */
+
+import http from 'k6/http';
+import { check, sleep, group } from 'k6';
+import { Rate, Trend, Counter } from 'k6/metrics';
+
+// Custom metrics
+const errorRate = new Rate('errors');
+const spikeLatency = new Trend('spike_latency', true);
+const recoveryLatency = new Trend('recovery_latency', true);
+const requestCount = new Counter('requests');
+
+// Test configuration - Spike pattern
+export const options = {
+  stages: [
+    // Baseline: normal load (100 users) for 1 minute
+    { duration: '1m', target: 100 },
+
+    // Spike 1: sudden jump to 2000 users in 10 seconds
+    { duration: '10s', target: 2000 },
+    // Hold spike for 30 seconds
+    { duration: '30s', target: 2000 },
+    // Quick drop back to baseline
+    { duration: '10s', target: 100 },
+
+    // Recovery period: hold baseline for 1 minute
+    { duration: '1m', target: 100 },
+
+    // Spike 2: extreme spike to 5000 users in 10 seconds
+    { duration: '10s', target: 5000 },
+    // Hold extreme spike for 30 seconds
+    { duration: '30s', target: 5000 },
+    // Drop back to baseline
+    { duration: '10s', target: 100 },
+
+    // Final recovery period
+    { duration: '1m', target: 100 },
+
+    // Ramp down
+    { duration: '30s', target: 0 },
+  ],
+
+  // Spike test thresholds - more lenient during spikes
+  thresholds: {
+    // 95th percentile can be higher during spikes
+    http_req_duration: ['p(95)<500', 'p(99)<1000'],
+    // Allow slightly higher error rate during spikes (2%)
+    errors: ['rate<0.02'],
+    // Recovery latency should return to normal
+    recovery_latency: ['p(95)<200'],
+  },
+
+  tags: {
+    testType: 'spike',
+  },
+
+  // Shorter graceful periods for spike tests
+  gracefulStop: '10s',
+  gracefulRampDown: '10s',
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+
+const headers = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+};
+
+// Track which phase we're in
+let currentPhase = 'baseline';
+
+export function setup() {
+  const healthRes = http.get(`${BASE_URL}/health`, { headers });
+
+  if (healthRes.status !== 200) {
+    throw new Error('API health check failed - aborting spike test');
+  }
+
+  console.log(`Spike test starting against ${BASE_URL}`);
+
+  return {
+    baseUrl: BASE_URL,
+    startTime: new Date().toISOString(),
+  };
+}
+
+export default function (data) {
+  const baseUrl = data.baseUrl;
+
+  // Determine current phase based on VU count
+  const vuCount = __VU;
+  if (vuCount > 2000) {
+    currentPhase = 'extreme_spike';
+  } else if (vuCount > 500) {
+    currentPhase = 'spike';
+  } else {
+    currentPhase = 'baseline';
+  }
+
+  // Critical path: Topics listing
+  group('Topics Under Spike', () => {
+    const start = Date.now();
+    const res = http.get(`${baseUrl}/api/topics?page=1&limit=10`, {
+      headers,
+      tags: { endpoint: 'topics', phase: currentPhase },
+    });
+
+    const latency = Date.now() - start;
+
+    // Track latency based on phase
+    if (currentPhase === 'baseline') {
+      recoveryLatency.add(latency);
+    } else {
+      spikeLatency.add(latency);
+    }
+
+    requestCount.add(1);
+
+    const success = check(
+      res,
+      {
+        'status is 200 or 401 or 429': (r) => [200, 401, 429].includes(r.status),
+        'response received': (r) => r.body !== null,
+      },
+      { phase: currentPhase }
+    );
+
+    // 429 (rate limited) during spike is acceptable
+    if (res.status === 429) {
+      errorRate.add(false); // Not counted as error
+    } else {
+      errorRate.add(!success);
+    }
+  });
+
+  sleep(0.1);
+
+  // Health check - should remain responsive even during spike
+  group('Health Under Spike', () => {
+    const res = http.get(`${baseUrl}/health`, {
+      headers,
+      tags: { endpoint: 'health', phase: currentPhase },
+      timeout: '5s', // Short timeout for health checks
+    });
+
+    requestCount.add(1);
+
+    const success = check(
+      res,
+      {
+        'health endpoint responsive': (r) => r.status === 200,
+        'health response time < 500ms': (r) => r.timings.duration < 500,
+      },
+      { phase: currentPhase }
+    );
+
+    errorRate.add(!success);
+  });
+
+  // Minimal think time during spike tests
+  sleep(Math.random() * 0.5 + 0.1); // 0.1-0.6 seconds
+}
+
+export function teardown(data) {
+  console.log(`Spike test completed. Started at: ${data.startTime}`);
+  console.log(`Tested against: ${data.baseUrl}`);
+}
+
+export function handleSummary(data) {
+  const summary = {
+    timestamp: new Date().toISOString(),
+    testType: 'spike',
+    baseUrl: BASE_URL,
+    metrics: {
+      http_req_duration: {
+        avg: data.metrics.http_req_duration?.values?.avg,
+        p95: data.metrics.http_req_duration?.values?.['p(95)'],
+        p99: data.metrics.http_req_duration?.values?.['p(99)'],
+        max: data.metrics.http_req_duration?.values?.max,
+      },
+      spike_latency: {
+        avg: data.metrics.spike_latency?.values?.avg,
+        p95: data.metrics.spike_latency?.values?.['p(95)'],
+        max: data.metrics.spike_latency?.values?.max,
+      },
+      recovery_latency: {
+        avg: data.metrics.recovery_latency?.values?.avg,
+        p95: data.metrics.recovery_latency?.values?.['p(95)'],
+        max: data.metrics.recovery_latency?.values?.max,
+      },
+      errors: {
+        rate: data.metrics.errors?.values?.rate,
+      },
+      requests: {
+        total: data.metrics.requests?.values?.count,
+      },
+    },
+    analysis: {
+      recoveredFromSpike:
+        (data.metrics.recovery_latency?.values?.['p(95)'] || 0) < 200,
+      maxLatencyDuringSpike: data.metrics.spike_latency?.values?.max,
+    },
+  };
+
+  return {
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+    'e2e/tests/performance/results/spike-test-summary.json': JSON.stringify(summary, null, 2),
+  };
+}
+
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';

--- a/packages/testing-utils/package.json
+++ b/packages/testing-utils/package.json
@@ -41,6 +41,10 @@
     "./openapi": {
       "types": "./dist/openapi/index.d.ts",
       "import": "./dist/openapi/index.js"
+    },
+    "./perf": {
+      "types": "./dist/perf/index.d.ts",
+      "import": "./dist/perf/index.js"
     }
   },
   "files": [

--- a/packages/testing-utils/src/__tests__/latency-assertions.spec.ts
+++ b/packages/testing-utils/src/__tests__/latency-assertions.spec.ts
@@ -1,0 +1,291 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  analyzeLatency,
+  validateLatency,
+  assertLatency,
+  measureDuration,
+  collectLatencies,
+  createLatencyCollector,
+  formatLatencyStats,
+} from '../perf/latency-assertions.js';
+
+describe('latency-assertions', () => {
+  describe('analyzeLatency', () => {
+    it('should return zero stats for empty array', () => {
+      const stats = analyzeLatency([]);
+
+      expect(stats.count).toBe(0);
+      expect(stats.min).toBe(0);
+      expect(stats.max).toBe(0);
+      expect(stats.mean).toBe(0);
+      expect(stats.median).toBe(0);
+      expect(stats.p95).toBe(0);
+      expect(stats.p99).toBe(0);
+    });
+
+    it('should calculate correct stats for single value', () => {
+      const stats = analyzeLatency([42]);
+
+      expect(stats.count).toBe(1);
+      expect(stats.min).toBe(42);
+      expect(stats.max).toBe(42);
+      expect(stats.mean).toBe(42);
+      expect(stats.median).toBe(42);
+      expect(stats.p95).toBe(42);
+      expect(stats.p99).toBe(42);
+      expect(stats.stdDev).toBe(0);
+    });
+
+    it('should calculate correct stats for multiple values', () => {
+      const latencies = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+      const stats = analyzeLatency(latencies);
+
+      expect(stats.count).toBe(10);
+      expect(stats.min).toBe(10);
+      expect(stats.max).toBe(100);
+      expect(stats.mean).toBe(55);
+      expect(stats.median).toBe(55); // Middle between 50 and 60
+      expect(stats.p90).toBeCloseTo(91, 0);
+      expect(stats.p95).toBeCloseTo(95.5, 0);
+      expect(stats.p99).toBeCloseTo(99.1, 0);
+    });
+
+    it('should handle unsorted input', () => {
+      const latencies = [50, 10, 30, 90, 20, 80, 40, 70, 60, 100];
+      const stats = analyzeLatency(latencies);
+
+      expect(stats.min).toBe(10);
+      expect(stats.max).toBe(100);
+      expect(stats.mean).toBe(55);
+    });
+
+    it('should calculate standard deviation correctly', () => {
+      const latencies = [2, 4, 4, 4, 5, 5, 7, 9];
+      const stats = analyzeLatency(latencies);
+
+      expect(stats.mean).toBe(5);
+      // stdDev should be 2
+      expect(stats.stdDev).toBeCloseTo(2, 1);
+    });
+  });
+
+  describe('validateLatency', () => {
+    const latencies = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+
+    it('should pass when all thresholds are met', () => {
+      const result = validateLatency(latencies, {
+        p95Max: 200,
+        p99Max: 300,
+        meanMax: 100,
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.results).toHaveLength(3);
+      expect(result.results.every((r) => r.passed)).toBe(true);
+    });
+
+    it('should fail when p95 threshold exceeded', () => {
+      const result = validateLatency(latencies, {
+        p95Max: 50, // Will fail
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.results.at(0)?.passed).toBe(false);
+      expect(result.results.at(0)?.name).toBe('p95');
+    });
+
+    it('should fail when mean threshold exceeded', () => {
+      const result = validateLatency(latencies, {
+        meanMax: 40, // Will fail (mean is 55)
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.results.at(0)?.name).toBe('mean');
+      expect(result.results.at(0)?.actual).toBe(55);
+    });
+
+    it('should check max threshold', () => {
+      const result = validateLatency(latencies, {
+        maxMax: 80, // Will fail (max is 100)
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.results.at(0)?.name).toBe('max');
+      expect(result.results.at(0)?.actual).toBe(100);
+    });
+
+    it('should include stats in result', () => {
+      const result = validateLatency(latencies, {});
+
+      expect(result.stats.count).toBe(10);
+      expect(result.stats.min).toBe(10);
+      expect(result.stats.max).toBe(100);
+    });
+  });
+
+  describe('assertLatency', () => {
+    it('should not throw when thresholds are met', () => {
+      const latencies = [10, 20, 30, 40, 50];
+
+      expect(() => assertLatency(latencies, { p95Max: 100 })).not.toThrow();
+    });
+
+    it('should throw when thresholds are exceeded', () => {
+      const latencies = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+
+      expect(() => assertLatency(latencies, { p95Max: 50 })).toThrow(
+        /Latency thresholds exceeded.*p95/,
+      );
+    });
+
+    it('should include all failures in error message', () => {
+      const latencies = [100, 200, 300, 400, 500];
+
+      expect(() =>
+        assertLatency(latencies, {
+          p95Max: 100,
+          meanMax: 100,
+        }),
+      ).toThrow(/p95.*mean/);
+    });
+  });
+
+  describe('measureDuration', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should measure sync function duration', async () => {
+      // Can't reliably test timing with fake timers for sync functions
+      vi.useRealTimers();
+
+      const duration = await measureDuration(() => {
+        // Simulate work
+        let sum = 0;
+        for (let i = 0; i < 1000; i++) {
+          sum += i;
+        }
+        return sum;
+      });
+
+      expect(duration).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should measure async function duration', async () => {
+      vi.useRealTimers();
+
+      const duration = await measureDuration(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      expect(duration).toBeGreaterThanOrEqual(9);
+    });
+  });
+
+  describe('collectLatencies', () => {
+    it('should collect specified number of samples', async () => {
+      let callCount = 0;
+      const fn = () => {
+        callCount++;
+        return callCount;
+      };
+
+      const latencies = await collectLatencies(fn, 10);
+
+      expect(latencies).toHaveLength(10);
+      expect(callCount).toBe(10);
+    });
+
+    it('should exclude warmup iterations', async () => {
+      let callCount = 0;
+      const fn = () => {
+        callCount++;
+        return callCount;
+      };
+
+      const latencies = await collectLatencies(fn, 5, { warmup: 3 });
+
+      expect(latencies).toHaveLength(5);
+      expect(callCount).toBe(8); // 3 warmup + 5 measured
+    });
+  });
+
+  describe('createLatencyCollector', () => {
+    it('should record and return latencies', () => {
+      const collector = createLatencyCollector();
+
+      collector.record(10);
+      collector.record(20);
+      collector.record(30);
+
+      expect(collector.getLatencies()).toEqual([10, 20, 30]);
+    });
+
+    it('should calculate stats', () => {
+      const collector = createLatencyCollector();
+
+      collector.record(10);
+      collector.record(20);
+      collector.record(30);
+
+      const stats = collector.getStats();
+
+      expect(stats.count).toBe(3);
+      expect(stats.mean).toBe(20);
+      expect(stats.min).toBe(10);
+      expect(stats.max).toBe(30);
+    });
+
+    it('should clear recorded latencies', () => {
+      const collector = createLatencyCollector();
+
+      collector.record(10);
+      collector.record(20);
+      collector.clear();
+
+      expect(collector.getLatencies()).toEqual([]);
+      expect(collector.getStats().count).toBe(0);
+    });
+
+    it('should return copy of latencies array', () => {
+      const collector = createLatencyCollector();
+
+      collector.record(10);
+      const latencies = collector.getLatencies();
+      latencies.push(999);
+
+      expect(collector.getLatencies()).toEqual([10]);
+    });
+  });
+
+  describe('formatLatencyStats', () => {
+    it('should format stats as human-readable string', () => {
+      const stats = analyzeLatency([10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
+      const formatted = formatLatencyStats(stats);
+
+      expect(formatted).toContain('n=10');
+      expect(formatted).toContain('min=10.0ms');
+      expect(formatted).toContain('max=100.0ms');
+      expect(formatted).toContain('p50=');
+      expect(formatted).toContain('p95=');
+      expect(formatted).toContain('p99=');
+    });
+
+    it('should handle empty stats', () => {
+      const stats = analyzeLatency([]);
+      const formatted = formatLatencyStats(stats);
+
+      expect(formatted).toContain('n=0');
+      expect(formatted).toContain('min=0.0ms');
+    });
+  });
+});

--- a/packages/testing-utils/src/__tests__/query-timing.spec.ts
+++ b/packages/testing-utils/src/__tests__/query-timing.spec.ts
@@ -1,0 +1,391 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Pool, QueryResult } from 'pg';
+import {
+  explainAnalyze,
+  validateQueryTiming,
+  assertQueryTiming,
+  measureQueryTime,
+  collectQueryTimings,
+  formatExplainSummary,
+} from '../perf/query-timing.js';
+
+// Mock pool factory
+function createMockPool(explainOutput: string[]): Pool {
+  return {
+    query: vi.fn().mockResolvedValue({
+      rows: explainOutput.map((line) => ({ 'QUERY PLAN': line })),
+    } as QueryResult),
+  } as unknown as Pool;
+}
+
+describe('query-timing', () => {
+  describe('explainAnalyze', () => {
+    it('should parse execution and planning times', async () => {
+      const pool = createMockPool([
+        'Seq Scan on users  (cost=0.00..10.00 rows=100 width=100) (actual time=0.010..0.050 rows=100 loops=1)',
+        'Planning Time: 0.045 ms',
+        'Execution Time: 0.123 ms',
+      ]);
+
+      const result = await explainAnalyze(pool, 'SELECT * FROM users');
+
+      expect(result.planningTime).toBe(0.045);
+      expect(result.executionTime).toBe(0.123);
+      expect(result.totalTime).toBeCloseTo(0.168, 3);
+    });
+
+    it('should detect index scan', async () => {
+      const pool = createMockPool([
+        'Index Scan using idx_users_email on users  (cost=0.00..8.27 rows=1 width=100)',
+        'Planning Time: 0.030 ms',
+        'Execution Time: 0.010 ms',
+      ]);
+
+      const result = await explainAnalyze(
+        pool,
+        "SELECT * FROM users WHERE email = 'test@example.com'",
+      );
+
+      expect(result.usedIndexScan).toBe(true);
+      expect(result.usedSequentialScan).toBe(false);
+      expect(result.indexesUsed).toContain('idx_users_email');
+    });
+
+    it('should detect sequential scan', async () => {
+      const pool = createMockPool([
+        'Seq Scan on users  (cost=0.00..10.00 rows=100 width=100)',
+        'Planning Time: 0.045 ms',
+        'Execution Time: 0.123 ms',
+      ]);
+
+      const result = await explainAnalyze(pool, 'SELECT * FROM users');
+
+      expect(result.usedSequentialScan).toBe(true);
+      expect(result.usedIndexScan).toBe(false);
+      expect(result.indexesUsed).toEqual([]);
+    });
+
+    it('should detect Index Only Scan', async () => {
+      const pool = createMockPool([
+        'Index Only Scan using idx_topics_covering on topics  (cost=0.00..5.00 rows=10 width=50)',
+        'Planning Time: 0.020 ms',
+        'Execution Time: 0.008 ms',
+      ]);
+
+      const result = await explainAnalyze(pool, 'SELECT id FROM topics WHERE status = $1', [
+        'ACTIVE',
+      ]);
+
+      expect(result.usedIndexScan).toBe(true);
+      expect(result.indexesUsed).toContain('idx_topics_covering');
+    });
+
+    it('should detect multiple indexes', async () => {
+      const pool = createMockPool([
+        'Nested Loop  (cost=0.00..20.00 rows=10 width=100)',
+        '  ->  Index Scan using idx_users_id on users  (cost=0.00..8.27 rows=1 width=50)',
+        '  ->  Index Scan using idx_topics_author on topics  (cost=0.00..8.27 rows=10 width=50)',
+        'Planning Time: 0.100 ms',
+        'Execution Time: 0.050 ms',
+      ]);
+
+      const result = await explainAnalyze(
+        pool,
+        'SELECT * FROM users u JOIN topics t ON u.id = t.author_id',
+      );
+
+      expect(result.indexesUsed).toContain('idx_users_id');
+      expect(result.indexesUsed).toContain('idx_topics_author');
+      expect(result.indexesUsed).toHaveLength(2);
+    });
+
+    it('should parse row estimates', async () => {
+      const pool = createMockPool([
+        'Seq Scan on users  (cost=0.00..10.00 rows=100 width=100) (actual time=0.010..0.050 rows=95 loops=1)',
+        'Planning Time: 0.045 ms',
+        'Execution Time: 0.123 ms',
+      ]);
+
+      const result = await explainAnalyze(pool, 'SELECT * FROM users');
+
+      expect(result.rowEstimates).toHaveLength(1);
+      expect(result.rowEstimates.at(0)?.estimated).toBe(100);
+      expect(result.rowEstimates.at(0)?.actual).toBe(95);
+      expect(result.rowEstimates.at(0)?.accuracy).toBe(0.95);
+    });
+
+    it('should pass query parameters', async () => {
+      const pool = createMockPool(['Planning Time: 0.010 ms', 'Execution Time: 0.010 ms']);
+
+      await explainAnalyze(pool, 'SELECT * FROM users WHERE id = $1', ['user-123']);
+
+      expect(pool.query).toHaveBeenCalledWith(
+        'EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) SELECT * FROM users WHERE id = $1',
+        ['user-123'],
+      );
+    });
+
+    it('should include raw output', async () => {
+      const lines = [
+        'Seq Scan on users  (cost=0.00..10.00 rows=100 width=100)',
+        'Planning Time: 0.045 ms',
+        'Execution Time: 0.123 ms',
+      ];
+      const pool = createMockPool(lines);
+
+      const result = await explainAnalyze(pool, 'SELECT * FROM users');
+
+      expect(result.rawOutput).toEqual(lines);
+    });
+  });
+
+  describe('validateQueryTiming', () => {
+    it('should pass when all thresholds are met', async () => {
+      const pool = createMockPool([
+        'Index Scan using idx_users_email on users  (cost=0.00..8.27 rows=1 width=100)',
+        'Planning Time: 0.030 ms',
+        'Execution Time: 0.010 ms',
+      ]);
+
+      const result = await validateQueryTiming(pool, 'SELECT * FROM users', [], {
+        maxExecutionTime: 1,
+        requireIndexScan: true,
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.results.every((r) => r.passed)).toBe(true);
+    });
+
+    it('should fail when execution time exceeded', async () => {
+      const pool = createMockPool([
+        'Seq Scan on users  (cost=0.00..10.00 rows=100 width=100)',
+        'Planning Time: 0.045 ms',
+        'Execution Time: 50.000 ms',
+      ]);
+
+      const result = await validateQueryTiming(pool, 'SELECT * FROM users', [], {
+        maxExecutionTime: 10,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.results.find((r) => r.name === 'maxExecutionTime')?.passed).toBe(false);
+    });
+
+    it('should fail when index scan required but seq scan used', async () => {
+      const pool = createMockPool([
+        'Seq Scan on users  (cost=0.00..10.00 rows=100 width=100)',
+        'Planning Time: 0.045 ms',
+        'Execution Time: 0.123 ms',
+      ]);
+
+      const result = await validateQueryTiming(pool, 'SELECT * FROM users', [], {
+        requireIndexScan: true,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.results.find((r) => r.name === 'requireIndexScan')?.passed).toBe(false);
+    });
+
+    it('should fail when specific index required but not used', async () => {
+      const pool = createMockPool([
+        'Index Scan using idx_users_id on users  (cost=0.00..8.27 rows=1 width=100)',
+        'Planning Time: 0.030 ms',
+        'Execution Time: 0.010 ms',
+      ]);
+
+      const result = await validateQueryTiming(pool, 'SELECT * FROM users', [], {
+        requireIndex: 'idx_users_email',
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.results.find((r) => r.name === 'requireIndex')?.passed).toBe(false);
+    });
+
+    it('should pass when specific index is used', async () => {
+      const pool = createMockPool([
+        'Index Scan using idx_users_email on users  (cost=0.00..8.27 rows=1 width=100)',
+        'Planning Time: 0.030 ms',
+        'Execution Time: 0.010 ms',
+      ]);
+
+      const result = await validateQueryTiming(pool, 'SELECT * FROM users', [], {
+        requireIndex: 'idx_users_email',
+      });
+
+      expect(result.passed).toBe(true);
+    });
+
+    it('should check total time threshold', async () => {
+      const pool = createMockPool([
+        'Seq Scan on users  (cost=0.00..10.00 rows=100 width=100)',
+        'Planning Time: 5.000 ms',
+        'Execution Time: 10.000 ms',
+      ]);
+
+      const result = await validateQueryTiming(pool, 'SELECT * FROM users', [], {
+        maxTotalTime: 10, // Total is 15ms
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.results.find((r) => r.name === 'maxTotalTime')?.passed).toBe(false);
+    });
+  });
+
+  describe('assertQueryTiming', () => {
+    it('should not throw when thresholds are met', async () => {
+      const pool = createMockPool([
+        'Index Scan using idx_users_email on users  (cost=0.00..8.27 rows=1 width=100)',
+        'Planning Time: 0.030 ms',
+        'Execution Time: 0.010 ms',
+      ]);
+
+      await expect(
+        assertQueryTiming(pool, 'SELECT * FROM users', [], { maxExecutionTime: 1 }),
+      ).resolves.not.toThrow();
+    });
+
+    it('should throw when thresholds are exceeded', async () => {
+      const pool = createMockPool([
+        'Seq Scan on users  (cost=0.00..10.00 rows=100 width=100)',
+        'Planning Time: 0.045 ms',
+        'Execution Time: 50.000 ms',
+      ]);
+
+      await expect(
+        assertQueryTiming(pool, 'SELECT * FROM users', [], { maxExecutionTime: 10 }),
+      ).rejects.toThrow(/Query timing thresholds exceeded/);
+    });
+
+    it('should include query in error message', async () => {
+      const pool = createMockPool([
+        'Seq Scan on users  (cost=0.00..10.00 rows=100 width=100)',
+        'Planning Time: 0.045 ms',
+        'Execution Time: 50.000 ms',
+      ]);
+
+      await expect(
+        assertQueryTiming(pool, 'SELECT * FROM users WHERE active = true', [], {
+          maxExecutionTime: 10,
+        }),
+      ).rejects.toThrow(/SELECT \* FROM users WHERE active = true/);
+    });
+  });
+
+  describe('measureQueryTime', () => {
+    it('should measure query execution time', async () => {
+      const pool = {
+        query: vi.fn().mockImplementation(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          return { rows: [] };
+        }),
+      } as unknown as Pool;
+
+      const duration = await measureQueryTime(pool, 'SELECT 1');
+
+      expect(duration).toBeGreaterThanOrEqual(9);
+      expect(pool.query).toHaveBeenCalledWith('SELECT 1', []);
+    });
+
+    it('should pass parameters to query', async () => {
+      const pool = {
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+      } as unknown as Pool;
+
+      await measureQueryTime(pool, 'SELECT * FROM users WHERE id = $1', ['user-123']);
+
+      expect(pool.query).toHaveBeenCalledWith('SELECT * FROM users WHERE id = $1', ['user-123']);
+    });
+  });
+
+  describe('collectQueryTimings', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    it('should collect specified number of samples', async () => {
+      const pool = {
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+      } as unknown as Pool;
+
+      vi.useRealTimers(); // Need real timers for timing measurement
+      const timings = await collectQueryTimings(pool, 'SELECT 1', [], 5);
+
+      expect(timings).toHaveLength(5);
+      expect(pool.query).toHaveBeenCalledTimes(5);
+    });
+
+    it('should exclude warmup iterations', async () => {
+      const pool = {
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+      } as unknown as Pool;
+
+      vi.useRealTimers();
+      const timings = await collectQueryTimings(pool, 'SELECT 1', [], 5, { warmup: 3 });
+
+      expect(timings).toHaveLength(5);
+      expect(pool.query).toHaveBeenCalledTimes(8); // 3 warmup + 5 measured
+    });
+  });
+
+  describe('formatExplainSummary', () => {
+    it('should format summary with indexes', () => {
+      const result = {
+        rawOutput: [],
+        executionTime: 0.123,
+        planningTime: 0.045,
+        totalTime: 0.168,
+        usedIndexScan: true,
+        usedSequentialScan: false,
+        indexesUsed: ['idx_users_email'],
+        rowEstimates: [],
+      };
+
+      const summary = formatExplainSummary(result);
+
+      expect(summary).toContain('exec=0.12ms');
+      // Note: 0.045.toFixed(2) = "0.04" due to floating-point representation
+      expect(summary).toContain('plan=0.04ms');
+      expect(summary).toContain('total=0.17ms');
+      expect(summary).toContain('indexes: idx_users_email');
+    });
+
+    it('should show warning for seq scan', () => {
+      const result = {
+        rawOutput: [],
+        executionTime: 50.0,
+        planningTime: 0.1,
+        totalTime: 50.1,
+        usedIndexScan: false,
+        usedSequentialScan: true,
+        indexesUsed: [],
+        rowEstimates: [],
+      };
+
+      const summary = formatExplainSummary(result);
+
+      expect(summary).toContain('WARN: seq scan');
+    });
+
+    it('should format multiple indexes', () => {
+      const result = {
+        rawOutput: [],
+        executionTime: 0.05,
+        planningTime: 0.02,
+        totalTime: 0.07,
+        usedIndexScan: true,
+        usedSequentialScan: false,
+        indexesUsed: ['idx_a', 'idx_b'],
+        rowEstimates: [],
+      };
+
+      const summary = formatExplainSummary(result);
+
+      expect(summary).toContain('indexes: idx_a, idx_b');
+    });
+  });
+});

--- a/packages/testing-utils/src/perf/index.ts
+++ b/packages/testing-utils/src/perf/index.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Performance testing utilities
+ *
+ * This module provides tools for measuring and asserting performance:
+ * - Latency analysis with percentile calculations (p50, p95, p99)
+ * - Database query timing with EXPLAIN ANALYZE support
+ * - Index usage verification
+ * - Vitest-compatible assertions
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   analyzeLatency,
+ *   assertLatency,
+ *   collectLatencies,
+ *   explainAnalyze,
+ *   assertQueryTiming,
+ * } from '@reason-bridge/testing-utils/perf';
+ *
+ * // Measure API endpoint latency
+ * const latencies = await collectLatencies(() => fetch('/api/users'), 100);
+ * assertLatency(latencies, { p95Max: 200, p99Max: 500 });
+ *
+ * // Verify database query performance
+ * await assertQueryTiming(pool, 'SELECT * FROM users WHERE id = $1', ['user-123'], {
+ *   maxExecutionTime: 10,
+ *   requireIndexScan: true,
+ * });
+ * ```
+ */
+
+// Latency assertions
+export {
+  analyzeLatency,
+  validateLatency,
+  assertLatency,
+  measureDuration,
+  collectLatencies,
+  createLatencyCollector,
+  formatLatencyStats,
+  type LatencyStats,
+  type LatencyThresholds,
+  type LatencyValidation,
+} from './latency-assertions.js';
+
+// Query timing
+export {
+  explainAnalyze,
+  validateQueryTiming,
+  assertQueryTiming,
+  measureQueryTime,
+  collectQueryTimings,
+  formatExplainSummary,
+  type ExplainAnalyzeResult,
+  type QueryTimingThresholds,
+  type QueryTimingValidation,
+} from './query-timing.js';

--- a/packages/testing-utils/src/perf/latency-assertions.ts
+++ b/packages/testing-utils/src/perf/latency-assertions.ts
@@ -1,0 +1,399 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Performance assertion helpers for latency testing
+ *
+ * Provides statistical analysis and assertions for latency measurements,
+ * including percentile calculations (p50, p95, p99), mean/median,
+ * and integration with Vitest expect matchers.
+ */
+
+import { AssertionError } from '../assertions/index.js';
+
+/**
+ * Result of latency analysis
+ */
+export interface LatencyStats {
+  /** Number of samples */
+  count: number;
+  /** Minimum latency in milliseconds */
+  min: number;
+  /** Maximum latency in milliseconds */
+  max: number;
+  /** Mean (average) latency in milliseconds */
+  mean: number;
+  /** Median (50th percentile) latency in milliseconds */
+  median: number;
+  /** 90th percentile latency */
+  p90: number;
+  /** 95th percentile latency */
+  p95: number;
+  /** 99th percentile latency */
+  p99: number;
+  /** Standard deviation */
+  stdDev: number;
+}
+
+/**
+ * Options for latency assertions
+ */
+export interface LatencyThresholds {
+  /** Maximum acceptable p95 latency in milliseconds */
+  p95Max?: number;
+  /** Maximum acceptable p99 latency in milliseconds */
+  p99Max?: number;
+  /** Maximum acceptable mean latency in milliseconds */
+  meanMax?: number;
+  /** Maximum acceptable median latency in milliseconds */
+  medianMax?: number;
+  /** Maximum acceptable max latency in milliseconds */
+  maxMax?: number;
+}
+
+/**
+ * Result of latency threshold validation
+ */
+export interface LatencyValidation {
+  /** Whether all thresholds passed */
+  passed: boolean;
+  /** Individual threshold results */
+  results: {
+    name: string;
+    threshold: number;
+    actual: number;
+    passed: boolean;
+  }[];
+  /** Computed statistics */
+  stats: LatencyStats;
+}
+
+/**
+ * Calculate percentile value from sorted array
+ *
+ * @param sorted - Array of numbers in ascending order
+ * @param percentile - Percentile to calculate (0-100)
+ * @returns The percentile value
+ */
+function calculatePercentile(sorted: number[], percentile: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0] ?? 0;
+
+  const index = (percentile / 100) * (sorted.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  const weight = index - lower;
+
+  if (upper >= sorted.length) return sorted[sorted.length - 1] ?? 0;
+
+  const lowerVal = sorted[lower] ?? 0;
+  const upperVal = sorted[upper] ?? 0;
+  return lowerVal * (1 - weight) + upperVal * weight;
+}
+
+/**
+ * Calculate standard deviation
+ *
+ * @param values - Array of numbers
+ * @param mean - Pre-calculated mean value
+ * @returns Standard deviation
+ */
+function calculateStdDev(values: number[], mean: number): number {
+  if (values.length < 2) return 0;
+  const squaredDiffs = values.map((v) => Math.pow(v - mean, 2));
+  const avgSquaredDiff = squaredDiffs.reduce((a, b) => a + b, 0) / values.length;
+  return Math.sqrt(avgSquaredDiff);
+}
+
+/**
+ * Analyze an array of latency measurements
+ *
+ * @param latencies - Array of latency measurements in milliseconds
+ * @returns Statistical analysis of the latencies
+ *
+ * @example
+ * ```typescript
+ * const latencies = [10, 15, 12, 18, 25, 11, 14, 16, 20, 22];
+ * const stats = analyzeLatency(latencies);
+ * console.log(`p95: ${stats.p95}ms, mean: ${stats.mean}ms`);
+ * ```
+ */
+export function analyzeLatency(latencies: number[]): LatencyStats {
+  if (latencies.length === 0) {
+    return {
+      count: 0,
+      min: 0,
+      max: 0,
+      mean: 0,
+      median: 0,
+      p90: 0,
+      p95: 0,
+      p99: 0,
+      stdDev: 0,
+    };
+  }
+
+  const sorted = [...latencies].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const mean = sum / sorted.length;
+
+  return {
+    count: sorted.length,
+    min: sorted[0] ?? 0,
+    max: sorted[sorted.length - 1] ?? 0,
+    mean,
+    median: calculatePercentile(sorted, 50),
+    p90: calculatePercentile(sorted, 90),
+    p95: calculatePercentile(sorted, 95),
+    p99: calculatePercentile(sorted, 99),
+    stdDev: calculateStdDev(sorted, mean),
+  };
+}
+
+/**
+ * Validate latencies against thresholds
+ *
+ * @param latencies - Array of latency measurements in milliseconds
+ * @param thresholds - Maximum acceptable values for various metrics
+ * @returns Validation result with pass/fail status and details
+ *
+ * @example
+ * ```typescript
+ * const result = validateLatency(latencies, {
+ *   p95Max: 200,
+ *   p99Max: 500,
+ *   meanMax: 100,
+ * });
+ * if (!result.passed) {
+ *   console.log('Failed thresholds:', result.results.filter(r => !r.passed));
+ * }
+ * ```
+ */
+export function validateLatency(
+  latencies: number[],
+  thresholds: LatencyThresholds,
+): LatencyValidation {
+  const stats = analyzeLatency(latencies);
+  const results: LatencyValidation['results'] = [];
+
+  if (thresholds.p95Max !== undefined) {
+    results.push({
+      name: 'p95',
+      threshold: thresholds.p95Max,
+      actual: stats.p95,
+      passed: stats.p95 <= thresholds.p95Max,
+    });
+  }
+
+  if (thresholds.p99Max !== undefined) {
+    results.push({
+      name: 'p99',
+      threshold: thresholds.p99Max,
+      actual: stats.p99,
+      passed: stats.p99 <= thresholds.p99Max,
+    });
+  }
+
+  if (thresholds.meanMax !== undefined) {
+    results.push({
+      name: 'mean',
+      threshold: thresholds.meanMax,
+      actual: stats.mean,
+      passed: stats.mean <= thresholds.meanMax,
+    });
+  }
+
+  if (thresholds.medianMax !== undefined) {
+    results.push({
+      name: 'median',
+      threshold: thresholds.medianMax,
+      actual: stats.median,
+      passed: stats.median <= thresholds.medianMax,
+    });
+  }
+
+  if (thresholds.maxMax !== undefined) {
+    results.push({
+      name: 'max',
+      threshold: thresholds.maxMax,
+      actual: stats.max,
+      passed: stats.max <= thresholds.maxMax,
+    });
+  }
+
+  return {
+    passed: results.every((r) => r.passed),
+    results,
+    stats,
+  };
+}
+
+/**
+ * Assert that latencies meet specified thresholds
+ *
+ * @param latencies - Array of latency measurements in milliseconds
+ * @param thresholds - Maximum acceptable values for various metrics
+ * @throws AssertionError if any threshold is exceeded
+ *
+ * @example
+ * ```typescript
+ * // In a Vitest test
+ * it('should respond within SLA', async () => {
+ *   const latencies = await measureEndpointLatency('/api/users', 100);
+ *   assertLatency(latencies, { p95Max: 200, p99Max: 500 });
+ * });
+ * ```
+ */
+export function assertLatency(latencies: number[], thresholds: LatencyThresholds): void {
+  const validation = validateLatency(latencies, thresholds);
+
+  if (!validation.passed) {
+    const failures = validation.results.filter((r) => !r.passed);
+    const failureMessages = failures
+      .map((f) => `${f.name}: ${f.actual.toFixed(2)}ms > ${f.threshold}ms`)
+      .join(', ');
+
+    throw new AssertionError(
+      `Latency thresholds exceeded: ${failureMessages}`,
+      thresholds,
+      validation.stats,
+    );
+  }
+}
+
+/**
+ * Measure execution time of a function
+ *
+ * @param fn - Function to measure (can be async)
+ * @returns Duration in milliseconds
+ *
+ * @example
+ * ```typescript
+ * const duration = await measureDuration(async () => {
+ *   await fetch('/api/data');
+ * });
+ * expect(duration).toBeLessThan(100);
+ * ```
+ */
+export async function measureDuration(fn: () => unknown | Promise<unknown>): Promise<number> {
+  const start = performance.now();
+  await fn();
+  return performance.now() - start;
+}
+
+/**
+ * Collect multiple latency samples by running a function repeatedly
+ *
+ * @param fn - Function to measure (can be async)
+ * @param iterations - Number of times to run the function
+ * @param options - Additional options
+ * @returns Array of duration measurements in milliseconds
+ *
+ * @example
+ * ```typescript
+ * const latencies = await collectLatencies(
+ *   () => fetch('/api/users'),
+ *   100,
+ *   { warmup: 5 }
+ * );
+ * assertLatency(latencies, { p95Max: 200 });
+ * ```
+ */
+export async function collectLatencies(
+  fn: () => unknown | Promise<unknown>,
+  iterations: number,
+  options: {
+    /** Number of warmup iterations to discard */
+    warmup?: number;
+    /** Delay between iterations in milliseconds */
+    delayMs?: number;
+  } = {},
+): Promise<number[]> {
+  const { warmup = 0, delayMs = 0 } = options;
+  const latencies: number[] = [];
+
+  // Warmup runs (discarded)
+  for (let i = 0; i < warmup; i++) {
+    await fn();
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  // Measured runs
+  for (let i = 0; i < iterations; i++) {
+    const duration = await measureDuration(fn);
+    latencies.push(duration);
+    if (delayMs > 0 && i < iterations - 1) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  return latencies;
+}
+
+/**
+ * Create a latency collector for incremental measurements
+ *
+ * @returns Collector object with record() and getStats() methods
+ *
+ * @example
+ * ```typescript
+ * const collector = createLatencyCollector();
+ *
+ * // Record measurements as they happen
+ * collector.record(await measureDuration(() => api.call()));
+ * collector.record(await measureDuration(() => api.call()));
+ *
+ * // Get final stats
+ * const stats = collector.getStats();
+ * assertLatency(collector.getLatencies(), { p95Max: 200 });
+ * ```
+ */
+export function createLatencyCollector(): {
+  record: (latency: number) => void;
+  getLatencies: () => number[];
+  getStats: () => LatencyStats;
+  clear: () => void;
+} {
+  let latencies: number[] = [];
+
+  return {
+    record(latency: number) {
+      latencies.push(latency);
+    },
+    getLatencies() {
+      return [...latencies];
+    },
+    getStats() {
+      return analyzeLatency(latencies);
+    },
+    clear() {
+      latencies = [];
+    },
+  };
+}
+
+/**
+ * Format latency stats as a human-readable string
+ *
+ * @param stats - Latency statistics to format
+ * @returns Formatted string
+ *
+ * @example
+ * ```typescript
+ * const stats = analyzeLatency(latencies);
+ * console.log(formatLatencyStats(stats));
+ * // Output: "n=100 | min=5.2ms | p50=12.4ms | p95=45.2ms | p99=89.1ms | max=102.3ms"
+ * ```
+ */
+export function formatLatencyStats(stats: LatencyStats): string {
+  return [
+    `n=${stats.count}`,
+    `min=${stats.min.toFixed(1)}ms`,
+    `p50=${stats.median.toFixed(1)}ms`,
+    `p95=${stats.p95.toFixed(1)}ms`,
+    `p99=${stats.p99.toFixed(1)}ms`,
+    `max=${stats.max.toFixed(1)}ms`,
+  ].join(' | ');
+}

--- a/packages/testing-utils/src/perf/query-timing.ts
+++ b/packages/testing-utils/src/perf/query-timing.ts
@@ -1,0 +1,406 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Database query timing assertions
+ *
+ * Provides utilities for measuring and asserting database query performance,
+ * including EXPLAIN ANALYZE wrappers, index usage verification, and
+ * execution time thresholds.
+ */
+
+import type { Pool } from 'pg';
+import { AssertionError } from '../assertions/index.js';
+
+/**
+ * Result of EXPLAIN ANALYZE query
+ */
+export interface ExplainAnalyzeResult {
+  /** Raw EXPLAIN ANALYZE output lines */
+  rawOutput: string[];
+  /** Parsed execution time in milliseconds */
+  executionTime: number;
+  /** Parsed planning time in milliseconds */
+  planningTime: number;
+  /** Total time (planning + execution) in milliseconds */
+  totalTime: number;
+  /** Whether the query used an index scan */
+  usedIndexScan: boolean;
+  /** Whether the query used a sequential scan */
+  usedSequentialScan: boolean;
+  /** Index names used in the query */
+  indexesUsed: string[];
+  /** Estimated vs actual row counts (for detecting estimate accuracy) */
+  rowEstimates: {
+    estimated: number;
+    actual: number;
+    accuracy: number; // ratio of actual/estimated
+  }[];
+}
+
+/**
+ * Options for query timing assertions
+ */
+export interface QueryTimingThresholds {
+  /** Maximum acceptable execution time in milliseconds */
+  maxExecutionTime?: number;
+  /** Maximum acceptable total time (planning + execution) in milliseconds */
+  maxTotalTime?: number;
+  /** Require index scan (fail if sequential scan used) */
+  requireIndexScan?: boolean;
+  /** Require specific index to be used */
+  requireIndex?: string;
+  /** Maximum acceptable row estimate inaccuracy (ratio) */
+  maxEstimateInaccuracy?: number;
+}
+
+/**
+ * Result of query timing validation
+ */
+export interface QueryTimingValidation {
+  /** Whether all thresholds passed */
+  passed: boolean;
+  /** Individual threshold results */
+  results: {
+    name: string;
+    threshold: unknown;
+    actual: unknown;
+    passed: boolean;
+  }[];
+  /** EXPLAIN ANALYZE results */
+  explain: ExplainAnalyzeResult;
+}
+
+/**
+ * Parse EXPLAIN ANALYZE output from PostgreSQL
+ *
+ * @param lines - Array of output lines from EXPLAIN ANALYZE
+ * @returns Parsed analysis results
+ */
+function parseExplainAnalyze(lines: string[]): ExplainAnalyzeResult {
+  let executionTime = 0;
+  let planningTime = 0;
+  const indexesUsed: string[] = [];
+  let usedIndexScan = false;
+  let usedSequentialScan = false;
+  const rowEstimates: ExplainAnalyzeResult['rowEstimates'] = [];
+
+  for (const line of lines) {
+    // Parse execution time: "Execution Time: 0.123 ms"
+    const execMatch = line.match(/Execution Time:\s*([\d.]+)\s*ms/i);
+    if (execMatch?.[1]) {
+      executionTime = parseFloat(execMatch[1]);
+    }
+
+    // Parse planning time: "Planning Time: 0.045 ms"
+    const planMatch = line.match(/Planning Time:\s*([\d.]+)\s*ms/i);
+    if (planMatch?.[1]) {
+      planningTime = parseFloat(planMatch[1]);
+    }
+
+    // Detect index scan: "Index Scan using idx_name on table"
+    const indexScanMatch = line.match(/Index (?:Scan|Only Scan) using (\S+)/i);
+    if (indexScanMatch?.[1]) {
+      usedIndexScan = true;
+      const indexName = indexScanMatch[1];
+      if (!indexesUsed.includes(indexName)) {
+        indexesUsed.push(indexName);
+      }
+    }
+
+    // Detect sequential scan: "Seq Scan on table"
+    if (/Seq Scan/i.test(line)) {
+      usedSequentialScan = true;
+    }
+
+    // Parse row estimates: "(cost=... rows=100 width=...) (actual ... rows=95 ...)"
+    const rowMatch = line.match(/rows=(\d+).*?\).*actual.*rows=(\d+)/i);
+    if (rowMatch?.[1] && rowMatch[2]) {
+      const estimated = parseInt(rowMatch[1], 10);
+      const actual = parseInt(rowMatch[2], 10);
+      rowEstimates.push({
+        estimated,
+        actual,
+        accuracy: estimated > 0 ? actual / estimated : actual === 0 ? 1 : Infinity,
+      });
+    }
+  }
+
+  return {
+    rawOutput: lines,
+    executionTime,
+    planningTime,
+    totalTime: planningTime + executionTime,
+    usedIndexScan,
+    usedSequentialScan,
+    indexesUsed,
+    rowEstimates,
+  };
+}
+
+/**
+ * Run EXPLAIN ANALYZE on a query and parse the results
+ *
+ * @param pool - PostgreSQL connection pool
+ * @param query - SQL query to analyze
+ * @param params - Query parameters
+ * @returns Parsed EXPLAIN ANALYZE results
+ *
+ * @example
+ * ```typescript
+ * const result = await explainAnalyze(pool, 'SELECT * FROM users WHERE id = $1', ['user-123']);
+ * console.log(`Execution time: ${result.executionTime}ms`);
+ * console.log(`Used indexes: ${result.indexesUsed.join(', ')}`);
+ * ```
+ */
+export async function explainAnalyze(
+  pool: Pool,
+  query: string,
+  params: unknown[] = [],
+): Promise<ExplainAnalyzeResult> {
+  const explainQuery = `EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) ${query}`;
+  const result = await pool.query(explainQuery, params);
+
+  const lines = result.rows.map((row: { 'QUERY PLAN': string }) => row['QUERY PLAN']);
+  return parseExplainAnalyze(lines);
+}
+
+/**
+ * Validate query timing against thresholds
+ *
+ * @param pool - PostgreSQL connection pool
+ * @param query - SQL query to analyze
+ * @param params - Query parameters
+ * @param thresholds - Timing and behavior thresholds
+ * @returns Validation result
+ *
+ * @example
+ * ```typescript
+ * const validation = await validateQueryTiming(
+ *   pool,
+ *   'SELECT * FROM topics WHERE status = $1 ORDER BY created_at DESC LIMIT 20',
+ *   ['ACTIVE'],
+ *   {
+ *     maxExecutionTime: 50,
+ *     requireIndexScan: true,
+ *   }
+ * );
+ * if (!validation.passed) {
+ *   console.log('Query needs optimization');
+ * }
+ * ```
+ */
+export async function validateQueryTiming(
+  pool: Pool,
+  query: string,
+  params: unknown[],
+  thresholds: QueryTimingThresholds,
+): Promise<QueryTimingValidation> {
+  const explain = await explainAnalyze(pool, query, params);
+  const results: QueryTimingValidation['results'] = [];
+
+  if (thresholds.maxExecutionTime !== undefined) {
+    results.push({
+      name: 'maxExecutionTime',
+      threshold: thresholds.maxExecutionTime,
+      actual: explain.executionTime,
+      passed: explain.executionTime <= thresholds.maxExecutionTime,
+    });
+  }
+
+  if (thresholds.maxTotalTime !== undefined) {
+    results.push({
+      name: 'maxTotalTime',
+      threshold: thresholds.maxTotalTime,
+      actual: explain.totalTime,
+      passed: explain.totalTime <= thresholds.maxTotalTime,
+    });
+  }
+
+  if (thresholds.requireIndexScan) {
+    results.push({
+      name: 'requireIndexScan',
+      threshold: true,
+      actual: explain.usedIndexScan,
+      passed: explain.usedIndexScan && !explain.usedSequentialScan,
+    });
+  }
+
+  if (thresholds.requireIndex) {
+    const indexUsed = explain.indexesUsed.includes(thresholds.requireIndex);
+    results.push({
+      name: 'requireIndex',
+      threshold: thresholds.requireIndex,
+      actual: explain.indexesUsed,
+      passed: indexUsed,
+    });
+  }
+
+  if (thresholds.maxEstimateInaccuracy !== undefined) {
+    const maxInaccuracy = Math.max(...explain.rowEstimates.map((r) => Math.abs(1 - r.accuracy)), 0);
+    results.push({
+      name: 'maxEstimateInaccuracy',
+      threshold: thresholds.maxEstimateInaccuracy,
+      actual: maxInaccuracy,
+      passed: maxInaccuracy <= thresholds.maxEstimateInaccuracy,
+    });
+  }
+
+  return {
+    passed: results.every((r) => r.passed),
+    results,
+    explain,
+  };
+}
+
+/**
+ * Assert that a query meets timing and behavior thresholds
+ *
+ * @param pool - PostgreSQL connection pool
+ * @param query - SQL query to analyze
+ * @param params - Query parameters
+ * @param thresholds - Timing and behavior thresholds
+ * @throws AssertionError if any threshold is exceeded
+ *
+ * @example
+ * ```typescript
+ * // In a Vitest test
+ * it('should use index for user lookup', async () => {
+ *   await assertQueryTiming(
+ *     pool,
+ *     'SELECT * FROM users WHERE email = $1',
+ *     ['test@example.com'],
+ *     {
+ *       maxExecutionTime: 10,
+ *       requireIndexScan: true,
+ *       requireIndex: 'idx_users_email',
+ *     }
+ *   );
+ * });
+ * ```
+ */
+export async function assertQueryTiming(
+  pool: Pool,
+  query: string,
+  params: unknown[],
+  thresholds: QueryTimingThresholds,
+): Promise<void> {
+  const validation = await validateQueryTiming(pool, query, params, thresholds);
+
+  if (!validation.passed) {
+    const failures = validation.results.filter((r) => !r.passed);
+    const failureMessages = failures
+      .map(
+        (f) =>
+          `${f.name}: expected ${JSON.stringify(f.threshold)}, got ${JSON.stringify(f.actual)}`,
+      )
+      .join('; ');
+
+    throw new AssertionError(
+      `Query timing thresholds exceeded: ${failureMessages}\n\nQuery: ${query}\n\nEXPLAIN output:\n${validation.explain.rawOutput.join('\n')}`,
+      thresholds,
+      validation.explain,
+    );
+  }
+}
+
+/**
+ * Measure query execution time (simple timing without EXPLAIN ANALYZE)
+ *
+ * @param pool - PostgreSQL connection pool
+ * @param query - SQL query to measure
+ * @param params - Query parameters
+ * @returns Execution time in milliseconds
+ *
+ * @example
+ * ```typescript
+ * const duration = await measureQueryTime(pool, 'SELECT COUNT(*) FROM topics');
+ * expect(duration).toBeLessThan(100);
+ * ```
+ */
+export async function measureQueryTime(
+  pool: Pool,
+  query: string,
+  params: unknown[] = [],
+): Promise<number> {
+  const start = performance.now();
+  await pool.query(query, params);
+  return performance.now() - start;
+}
+
+/**
+ * Collect multiple query timing samples
+ *
+ * @param pool - PostgreSQL connection pool
+ * @param query - SQL query to measure
+ * @param params - Query parameters
+ * @param iterations - Number of times to run the query
+ * @param options - Additional options
+ * @returns Array of execution times in milliseconds
+ *
+ * @example
+ * ```typescript
+ * const timings = await collectQueryTimings(
+ *   pool,
+ *   'SELECT * FROM topics WHERE id = $1',
+ *   ['topic-123'],
+ *   50,
+ *   { warmup: 5 }
+ * );
+ *
+ * const stats = analyzeLatency(timings);
+ * assertLatency(timings, { p95Max: 10 });
+ * ```
+ */
+export async function collectQueryTimings(
+  pool: Pool,
+  query: string,
+  params: unknown[],
+  iterations: number,
+  options: { warmup?: number } = {},
+): Promise<number[]> {
+  const { warmup = 0 } = options;
+  const timings: number[] = [];
+
+  // Warmup runs (discarded)
+  for (let i = 0; i < warmup; i++) {
+    await pool.query(query, params);
+  }
+
+  // Measured runs
+  for (let i = 0; i < iterations; i++) {
+    const duration = await measureQueryTime(pool, query, params);
+    timings.push(duration);
+  }
+
+  return timings;
+}
+
+/**
+ * Format EXPLAIN ANALYZE results as a human-readable summary
+ *
+ * @param result - EXPLAIN ANALYZE results
+ * @returns Formatted string
+ *
+ * @example
+ * ```typescript
+ * const result = await explainAnalyze(pool, query);
+ * console.log(formatExplainSummary(result));
+ * // Output: "exec=0.12ms | plan=0.05ms | total=0.17ms | indexes: idx_topics_status"
+ * ```
+ */
+export function formatExplainSummary(result: ExplainAnalyzeResult): string {
+  const parts = [
+    `exec=${result.executionTime.toFixed(2)}ms`,
+    `plan=${result.planningTime.toFixed(2)}ms`,
+    `total=${result.totalTime.toFixed(2)}ms`,
+  ];
+
+  if (result.indexesUsed.length > 0) {
+    parts.push(`indexes: ${result.indexesUsed.join(', ')}`);
+  } else if (result.usedSequentialScan) {
+    parts.push('WARN: seq scan');
+  }
+
+  return parts.join(' | ');
+}


### PR DESCRIPTION
## Summary
- Add k6 load, spike, and soak test scripts for API performance testing
- Add `@reason-bridge/testing-utils/perf` module with latency assertions and query timing helpers
- Update pre-commit hook to handle k6 performance tests and JSDoc examples

## Changes

### k6 Performance Tests (`e2e/tests/performance/`)
- **api-load.js**: Load test with stages (ramp up → 1000 VUs → peak 10k VUs → ramp down), p95 < 200ms threshold
- **api-spike.js**: Sudden extreme load simulation (baseline → 2000 VUs → 5000 VUs spike), tests recovery
- **api-soak.js**: Extended duration test (1 hour default), detects memory leaks and degradation

### Perf Assertions Module (`@reason-bridge/testing-utils/perf`)
- **latency-assertions.ts**: p50/p95/p99 percentile calculations, Vitest-compatible assertions, latency collector
- **query-timing.ts**: EXPLAIN ANALYZE wrapper, index usage verification, query timing thresholds

### Pre-commit Hook Updates
- Allow `console.log` in `e2e/tests/performance/` (k6 standard practice)
- Ignore console statements in JSDoc/TSDoc `*` comment lines

## Test plan
- [x] Build passes (`pnpm -r build`)
- [x] Unit tests pass for testing-utils package (47 new tests for latency/query modules)
- [ ] CI pipeline passes

## Issues Closed
Closes #371, #372, #373, #374, #375

🤖 Generated with [Claude Code](https://claude.ai/claude-code)