### PR TITLE
fix(frontend): Fix flaky TagSelector test with fake timers

### DIFF
--- a/frontend/src/components/topics/__tests__/TagSelector.test.tsx
+++ b/frontend/src/components/topics/__tests__/TagSelector.test.tsx
@@ -208,21 +208,17 @@ describe('TagSelector', () => {
 
       await user.click(screen.getByText(/create "newtag"/i));
 
-      // Advance timers to ensure React processes all state updates
-      await vi.advanceTimersByTimeAsync(100);
+      // Flush all pending timers to allow React state updates to complete
+      // Using runAllTimersAsync ensures all setTimeout/setInterval callbacks execute
+      await vi.runAllTimersAsync();
 
-      // Wait for React to process state updates from handleSelectTag and clear()
-      await waitFor(
-        () => {
-          expect(onChange).toHaveBeenCalledWith([
-            expect.objectContaining({
-              name: 'newtag',
-              slug: 'newtag',
-            }),
-          ]);
-        },
-        { timeout: 3000 },
-      );
+      // Assert directly after flushing timers - no waitFor needed
+      expect(onChange).toHaveBeenCalledWith([
+        expect.objectContaining({
+          name: 'newtag',
+          slug: 'newtag',
+        }),
+      ]);
     });
 
     it('should not show create option for existing tag', async () => {


### PR DESCRIPTION
## Summary
- Replace `waitFor` with `vi.runAllTimersAsync()` for the "should create new tag when no exact match" test
- `waitFor` polling intervals don't advance correctly with fake timers, causing intermittent timeouts in CI
- Using `runAllTimersAsync` ensures all pending timer callbacks execute, making the test deterministic

## Test plan
- [x] Ran test 5 times locally - all passes
- [x] Pre-commit hooks passed
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)