### PR TITLE
feat(event-schemas): Add AI output schema contracts (#405, #406, #407, #408)

### DIFF
--- a/packages/event-schemas/package.json
+++ b/packages/event-schemas/package.json
@@ -29,6 +29,10 @@
     "./base": {
       "types": "./dist/base.d.ts",
       "import": "./dist/base.js"
+    },
+    "./ai-schemas": {
+      "types": "./dist/ai-schemas/index.d.ts",
+      "import": "./dist/ai-schemas/index.js"
     }
   },
   "files": [
@@ -40,7 +44,9 @@
     "typecheck": "tsc --noEmit",
     "dev": "tsc --watch"
   },
-  "dependencies": {},
+  "dependencies": {
+    "zod": "^4.3.5"
+  },
   "devDependencies": {
     "typescript": "5.9.3"
   },

--- a/packages/event-schemas/src/ai-schemas/base.schema.ts
+++ b/packages/event-schemas/src/ai-schemas/base.schema.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Base schema components shared across AI analyzer output contracts
+ */
+
+import { z } from 'zod';
+
+/**
+ * Schema for educational resource links
+ */
+export const EducationalResourceSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  url: z.string().url('Must be a valid URL'),
+});
+
+export type EducationalResource = z.infer<typeof EducationalResourceSchema>;
+
+/**
+ * Schema for an array of educational resources
+ */
+export const EducationalResourcesSchema = z.array(EducationalResourceSchema);
+
+export type EducationalResources = z.infer<typeof EducationalResourcesSchema>;
+
+/**
+ * Feedback type enum matching the existing FeedbackType in the AI service
+ */
+export const FeedbackTypeSchema = z.enum([
+  'fallacy',
+  'inflammatory',
+  'unsourced',
+  'bias',
+  'affirmation',
+]);
+
+export type FeedbackType = z.infer<typeof FeedbackTypeSchema>;
+
+/**
+ * Confidence score schema (0.00 to 1.00)
+ */
+export const ConfidenceScoreSchema = z
+  .number()
+  .min(0, 'Confidence score must be at least 0')
+  .max(1, 'Confidence score must be at most 1');
+
+/**
+ * Base analysis result schema with common fields
+ * Extended by specific analyzer schemas
+ */
+export const BaseAnalysisResultSchema = z.object({
+  /** User-facing suggestion text */
+  suggestionText: z.string().min(1, 'Suggestion text is required'),
+  /** AI reasoning for transparency */
+  reasoning: z.string().min(1, 'Reasoning is required'),
+  /** Confidence score (0.00-1.00) */
+  confidenceScore: ConfidenceScoreSchema,
+  /** Optional educational resources */
+  educationalResources: EducationalResourcesSchema.optional(),
+});
+
+export type BaseAnalysisResult = z.infer<typeof BaseAnalysisResultSchema>;
+
+/**
+ * Helper function to safely parse analysis results
+ * Returns a discriminated result object with success/error information
+ */
+export function safeParseAnalysis<T extends z.ZodTypeAny>(schema: T, data: unknown) {
+  return schema.safeParse(data);
+}

--- a/packages/event-schemas/src/ai-schemas/bias-analysis.schema.ts
+++ b/packages/event-schemas/src/ai-schemas/bias-analysis.schema.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * BiasAnalysis output schema contract (#406)
+ *
+ * Validates output from the Bias Analyzer service which detects
+ * cognitive biases such as confirmation bias and System 1 thinking patterns.
+ */
+
+import { z } from 'zod';
+import { BaseAnalysisResultSchema } from './base.schema.js';
+
+/**
+ * Bias analysis subtypes detected by the analyzer
+ */
+export const BiasSubtypeSchema = z.enum([
+  'confirmation_bias', // Selective attention to confirming evidence
+  'system1_thinking', // Intuitive responses without deliberation
+  'anchoring_bias', // Over-reliance on first piece of information
+  'availability_bias', // Overweighting easily recalled information
+]);
+
+export type BiasSubtype = z.infer<typeof BiasSubtypeSchema>;
+
+/**
+ * Full BiasAnalysis output schema
+ */
+export const BiasAnalysisSchema = BaseAnalysisResultSchema.extend({
+  /** Type is always 'bias' for bias analysis */
+  type: z.literal('bias'),
+  /** Specific subtype of bias detected */
+  subtype: BiasSubtypeSchema,
+});
+
+export type BiasAnalysis = z.infer<typeof BiasAnalysisSchema>;
+
+/**
+ * Schema for an array of bias analysis results
+ */
+export const BiasAnalysisArraySchema = z.array(BiasAnalysisSchema);
+
+export type BiasAnalysisArray = z.infer<typeof BiasAnalysisArraySchema>;
+
+/**
+ * Validate a bias analysis result
+ * @param data - The data to validate
+ * @returns Safe parse result with success/error information
+ */
+export function validateBiasAnalysis(data: unknown) {
+  return BiasAnalysisSchema.safeParse(data);
+}
+
+/**
+ * Parse and validate a bias analysis result, throwing on invalid data
+ * @param data - The data to parse
+ * @returns Validated BiasAnalysis
+ * @throws ZodError if validation fails
+ */
+export function parseBiasAnalysis(data: unknown): BiasAnalysis {
+  return BiasAnalysisSchema.parse(data);
+}
+
+/**
+ * Type guard for BiasAnalysis
+ */
+export function isBiasAnalysis(data: unknown): data is BiasAnalysis {
+  return BiasAnalysisSchema.safeParse(data).success;
+}

--- a/packages/event-schemas/src/ai-schemas/claim-extraction.schema.ts
+++ b/packages/event-schemas/src/ai-schemas/claim-extraction.schema.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * ClaimExtraction output schema contract (#408)
+ *
+ * Validates output from the Claim Extraction service which identifies
+ * claims that need source citations or fact-checking.
+ */
+
+import { z } from 'zod';
+import { BaseAnalysisResultSchema } from './base.schema.js';
+
+/**
+ * Claim extraction subtypes detected by the analyzer
+ */
+export const ClaimSubtypeSchema = z.enum([
+  'factual_claim', // Statement of fact that can be verified
+  'statistical_claim', // Claim involving numbers or statistics
+  'causal_claim', // Claim about cause and effect relationships
+  'predictive_claim', // Claim about future outcomes
+  'comparative_claim', // Claim comparing two or more things
+]);
+
+export type ClaimSubtype = z.infer<typeof ClaimSubtypeSchema>;
+
+/**
+ * Schema for an extracted claim
+ */
+export const ExtractedClaimSchema = z.object({
+  /** The claim text extracted from the content */
+  claimText: z.string().min(1, 'Claim text is required'),
+  /** Type of claim */
+  claimType: ClaimSubtypeSchema,
+  /** Whether this claim requires a citation */
+  requiresCitation: z.boolean(),
+  /** Suggested search terms for fact-checking */
+  searchTerms: z.array(z.string()).optional(),
+});
+
+export type ExtractedClaim = z.infer<typeof ExtractedClaimSchema>;
+
+/**
+ * Full ClaimExtraction output schema
+ */
+export const ClaimExtractionSchema = BaseAnalysisResultSchema.extend({
+  /** Type is always 'unsourced' for claim extraction */
+  type: z.literal('unsourced'),
+  /** Subtype indicating the nature of the unsourced content */
+  subtype: ClaimSubtypeSchema,
+  /** List of extracted claims from the content */
+  extractedClaims: z.array(ExtractedClaimSchema).optional(),
+});
+
+export type ClaimExtraction = z.infer<typeof ClaimExtractionSchema>;
+
+/**
+ * Schema for an array of claim extraction results
+ */
+export const ClaimExtractionArraySchema = z.array(ClaimExtractionSchema);
+
+export type ClaimExtractionArray = z.infer<typeof ClaimExtractionArraySchema>;
+
+/**
+ * Validate a claim extraction result
+ * @param data - The data to validate
+ * @returns Safe parse result with success/error information
+ */
+export function validateClaimExtraction(data: unknown) {
+  return ClaimExtractionSchema.safeParse(data);
+}
+
+/**
+ * Parse and validate a claim extraction result, throwing on invalid data
+ * @param data - The data to parse
+ * @returns Validated ClaimExtraction
+ * @throws ZodError if validation fails
+ */
+export function parseClaimExtraction(data: unknown): ClaimExtraction {
+  return ClaimExtractionSchema.parse(data);
+}
+
+/**
+ * Type guard for ClaimExtraction
+ */
+export function isClaimExtraction(data: unknown): data is ClaimExtraction {
+  return ClaimExtractionSchema.safeParse(data).success;
+}

--- a/packages/event-schemas/src/ai-schemas/fallacy-detection.schema.ts
+++ b/packages/event-schemas/src/ai-schemas/fallacy-detection.schema.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * FallacyDetection output schema contract (#407)
+ *
+ * Validates output from the Fallacy Detection service which identifies
+ * logical fallacies in arguments and reasoning.
+ */
+
+import { z } from 'zod';
+import { BaseAnalysisResultSchema } from './base.schema.js';
+
+/**
+ * Fallacy subtypes detected by the analyzer
+ * Based on common logical fallacies in argumentation
+ */
+export const FallacySubtypeSchema = z.enum([
+  'ad_hominem', // Attacking the person rather than the argument
+  'straw_man', // Misrepresenting someone's argument to attack it
+  'false_dichotomy', // Presenting only two options when more exist
+  'appeal_to_authority', // Using authority as evidence without proper support
+  'slippery_slope', // Assuming one event will lead to extreme outcomes
+  'circular_reasoning', // Using the conclusion as a premise
+  'red_herring', // Introducing irrelevant information to distract
+  'hasty_generalization', // Drawing broad conclusions from limited examples
+  'appeal_to_emotion', // Using emotions instead of logic
+  'false_cause', // Assuming causation from correlation
+]);
+
+export type FallacySubtype = z.infer<typeof FallacySubtypeSchema>;
+
+/**
+ * Full FallacyDetection output schema
+ */
+export const FallacyDetectionSchema = BaseAnalysisResultSchema.extend({
+  /** Type is always 'fallacy' for fallacy detection */
+  type: z.literal('fallacy'),
+  /** Specific type of fallacy detected */
+  subtype: FallacySubtypeSchema,
+  /** Optional: The specific text that contains the fallacy */
+  fallacyText: z.string().optional(),
+});
+
+export type FallacyDetection = z.infer<typeof FallacyDetectionSchema>;
+
+/**
+ * Schema for an array of fallacy detection results
+ */
+export const FallacyDetectionArraySchema = z.array(FallacyDetectionSchema);
+
+export type FallacyDetectionArray = z.infer<typeof FallacyDetectionArraySchema>;
+
+/**
+ * Validate a fallacy detection result
+ * @param data - The data to validate
+ * @returns Safe parse result with success/error information
+ */
+export function validateFallacyDetection(data: unknown) {
+  return FallacyDetectionSchema.safeParse(data);
+}
+
+/**
+ * Parse and validate a fallacy detection result, throwing on invalid data
+ * @param data - The data to parse
+ * @returns Validated FallacyDetection
+ * @throws ZodError if validation fails
+ */
+export function parseFallacyDetection(data: unknown): FallacyDetection {
+  return FallacyDetectionSchema.parse(data);
+}
+
+/**
+ * Type guard for FallacyDetection
+ */
+export function isFallacyDetection(data: unknown): data is FallacyDetection {
+  return FallacyDetectionSchema.safeParse(data).success;
+}

--- a/packages/event-schemas/src/ai-schemas/index.ts
+++ b/packages/event-schemas/src/ai-schemas/index.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * AI Analyzer Output Schema Contracts
+ *
+ * This module exports Zod schemas for validating AI analyzer outputs.
+ * Each schema corresponds to a specific analyzer type and provides:
+ * - Runtime validation
+ * - Type inference
+ * - Type guards
+ * - Parse functions (safe and throwing)
+ */
+
+// Base schema components
+export {
+  BaseAnalysisResultSchema,
+  ConfidenceScoreSchema,
+  EducationalResourceSchema,
+  EducationalResourcesSchema,
+  FeedbackTypeSchema,
+  safeParseAnalysis,
+  type BaseAnalysisResult,
+  type EducationalResource,
+  type EducationalResources,
+  type FeedbackType,
+} from './base.schema.js';
+
+// ToneAnalysis schema (#405)
+export {
+  isToneAnalysis,
+  parseToneAnalysis,
+  ToneAnalysisArraySchema,
+  ToneAnalysisSchema,
+  ToneSubtypeSchema,
+  validateToneAnalysis,
+  type ToneAnalysis,
+  type ToneAnalysisArray,
+  type ToneSubtype,
+} from './tone-analysis.schema.js';
+
+// BiasAnalysis schema (#406)
+export {
+  BiasAnalysisArraySchema,
+  BiasAnalysisSchema,
+  BiasSubtypeSchema,
+  isBiasAnalysis,
+  parseBiasAnalysis,
+  validateBiasAnalysis,
+  type BiasAnalysis,
+  type BiasAnalysisArray,
+  type BiasSubtype,
+} from './bias-analysis.schema.js';
+
+// FallacyDetection schema (#407)
+export {
+  FallacyDetectionArraySchema,
+  FallacyDetectionSchema,
+  FallacySubtypeSchema,
+  isFallacyDetection,
+  parseFallacyDetection,
+  validateFallacyDetection,
+  type FallacyDetection,
+  type FallacyDetectionArray,
+  type FallacySubtype,
+} from './fallacy-detection.schema.js';
+
+// ClaimExtraction schema (#408)
+export {
+  ClaimExtractionArraySchema,
+  ClaimExtractionSchema,
+  ClaimSubtypeSchema,
+  ExtractedClaimSchema,
+  isClaimExtraction,
+  parseClaimExtraction,
+  validateClaimExtraction,
+  type ClaimExtraction,
+  type ClaimExtractionArray,
+  type ClaimSubtype,
+  type ExtractedClaim,
+} from './claim-extraction.schema.js';

--- a/packages/event-schemas/src/ai-schemas/tone-analysis.schema.ts
+++ b/packages/event-schemas/src/ai-schemas/tone-analysis.schema.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * ToneAnalysis output schema contract (#405)
+ *
+ * Validates output from the Tone Analyzer service which detects
+ * inflammatory language, personal attacks, hostile tone, and aggressive language.
+ */
+
+import { z } from 'zod';
+import { BaseAnalysisResultSchema } from './base.schema.js';
+
+/**
+ * Tone analysis subtypes detected by the analyzer
+ */
+export const ToneSubtypeSchema = z.enum([
+  'personal_attack', // Direct attacks on a person (e.g., "you're stupid")
+  'hostile_tone', // Condescending or hostile phrasing (e.g., "obviously you don't understand")
+  'aggressive_language', // Threatening or aggressive statements (e.g., "I hate you")
+  'dismissive', // Dismissive generalizations (e.g., "typical liberal", "wake up sheeple")
+]);
+
+export type ToneSubtype = z.infer<typeof ToneSubtypeSchema>;
+
+/**
+ * Full ToneAnalysis output schema
+ */
+export const ToneAnalysisSchema = BaseAnalysisResultSchema.extend({
+  /** Type is always 'inflammatory' for tone analysis */
+  type: z.literal('inflammatory'),
+  /** Specific subtype of inflammatory content detected */
+  subtype: ToneSubtypeSchema,
+});
+
+export type ToneAnalysis = z.infer<typeof ToneAnalysisSchema>;
+
+/**
+ * Schema for an array of tone analysis results
+ */
+export const ToneAnalysisArraySchema = z.array(ToneAnalysisSchema);
+
+export type ToneAnalysisArray = z.infer<typeof ToneAnalysisArraySchema>;
+
+/**
+ * Validate a tone analysis result
+ * @param data - The data to validate
+ * @returns Safe parse result with success/error information
+ */
+export function validateToneAnalysis(data: unknown) {
+  return ToneAnalysisSchema.safeParse(data);
+}
+
+/**
+ * Parse and validate a tone analysis result, throwing on invalid data
+ * @param data - The data to parse
+ * @returns Validated ToneAnalysis
+ * @throws ZodError if validation fails
+ */
+export function parseToneAnalysis(data: unknown): ToneAnalysis {
+  return ToneAnalysisSchema.parse(data);
+}
+
+/**
+ * Type guard for ToneAnalysis
+ */
+export function isToneAnalysis(data: unknown): data is ToneAnalysis {
+  return ToneAnalysisSchema.safeParse(data).success;
+}

--- a/packages/event-schemas/src/index.ts
+++ b/packages/event-schemas/src/index.ts
@@ -19,6 +19,9 @@ export * from './ai.js';
 export * from './moderation.js';
 export * from './user.js';
 
+// AI output schema contracts (Zod schemas for runtime validation)
+export * from './ai-schemas/index.js';
+
 // Import event type constants
 import { DISCUSSION_EVENT_TYPES } from './discussion.js';
 import { AI_EVENT_TYPES } from './ai.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,6 +305,10 @@ importers:
         version: 2.1.9(@types/node@25.2.3)(@vitest/ui@2.1.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))
 
   packages/event-schemas:
+    dependencies:
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.6
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -329,7 +333,7 @@ importers:
         version: link:../db-models
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.2.3)(@vitest/ui@2.1.9)(jsdom@28.1.0(@noble/hashes@1.8.0))
+        version: 1.6.1(@types/node@25.2.3)(@vitest/ui@2.1.9(vitest@2.1.9))(jsdom@28.1.0(@noble/hashes@1.8.0))
     devDependencies:
       '@types/node':
         specifier: ^25.2.3
@@ -613,7 +617,7 @@ importers:
         version: 25.2.3
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@2.1.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@2.1.9(vitest@2.1.9))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2))
       tsx:
         specifier: ^4.7.0
         version: 4.21.0
@@ -622,7 +626,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@2.1.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@2.1.9(vitest@2.1.9))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
   services/discussion-service:
     dependencies:
@@ -10125,7 +10129,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@2.1.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@2.1.9(vitest@2.1.9))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -10137,7 +10141,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@2.1.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@2.1.9(vitest@2.1.9))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/expect@1.6.1':
     dependencies:
@@ -14426,7 +14430,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@1.6.1(@types/node@25.2.3)(@vitest/ui@2.1.9)(jsdom@28.1.0(@noble/hashes@1.8.0)):
+  vitest@1.6.1(@types/node@25.2.3)(@vitest/ui@2.1.9(vitest@2.1.9))(jsdom@28.1.0(@noble/hashes@1.8.0)):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -14499,7 +14503,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@2.1.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@2.1.9(vitest@2.1.9))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))


### PR DESCRIPTION
## Summary

Adds Zod validation schemas for AI analyzer outputs to enable runtime type checking and validation of AI service responses.

### Issues Addressed
- Closes #405 - ToneAnalysis output schema contract
- Closes #406 - BiasAnalysis output schema contract
- Closes #407 - FallacyDetection output schema contract
- Closes #408 - ClaimExtraction output schema contract

### Implementation Details

**New files in `packages/event-schemas/src/ai-schemas/`:**

| File | Purpose |
|------|---------|
| `base.schema.ts` | Shared components: EducationalResource, ConfidenceScore, BaseAnalysisResult |
| `tone-analysis.schema.ts` | ToneAnalysis schema (type: 'inflammatory') |
| `bias-analysis.schema.ts` | BiasAnalysis schema (type: 'bias') |
| `fallacy-detection.schema.ts` | FallacyDetection schema (type: 'fallacy') |
| `claim-extraction.schema.ts` | ClaimExtraction schema (type: 'unsourced') |
| `index.ts` | Barrel export for all schemas |

**Each schema provides:**
- Zod schema for runtime validation
- TypeScript types via `z.infer`
- `validate*()` - Safe parse with success/error info
- `parse*()` - Throwing parse for strict validation
- `is*()` - Type guard for runtime checks

**Subtypes:**
- **ToneAnalysis**: personal_attack, hostile_tone, aggressive_language, dismissive
- **BiasAnalysis**: confirmation_bias, system1_thinking, anchoring_bias, availability_bias
- **FallacyDetection**: ad_hominem, straw_man, false_dichotomy, appeal_to_authority, slippery_slope, circular_reasoning, red_herring, hasty_generalization, appeal_to_emotion, false_cause
- **ClaimExtraction**: factual_claim, statistical_claim, causal_claim, predictive_claim, comparative_claim

## Test plan
- [x] TypeScript build passes (`pnpm --filter @reason-bridge/event-schemas build`)
- [x] Typecheck passes (`pnpm --filter @reason-bridge/event-schemas typecheck`)
- [x] Unit tests pass (2691 tests)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)