### PR TITLE
fix(frontend): Modal closing race condition in EditTopicModal (#808)

### DIFF
--- a/frontend/src/pages/Topics/TopicDetailPage.tsx
+++ b/frontend/src/pages/Topics/TopicDetailPage.tsx
@@ -5,6 +5,7 @@
 
 import { useParams, Link } from 'react-router-dom';
 import { useState, useCallback, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useTopic } from '../../lib/useTopic';
 import { useCommonGroundAnalysis } from '../../lib/useCommonGroundAnalysis';
 import { useCommonGroundUpdates } from '../../hooks/useCommonGroundUpdates';
@@ -24,6 +25,7 @@ import type { CreateResponseRequest } from '../../types/response';
 function TopicDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { user } = useAuthContext();
+  const queryClient = useQueryClient();
   const { data: topic, isLoading, error } = useTopic(id);
   const { data: commonGroundAnalysis } = useCommonGroundAnalysis(id);
   const showSkeleton = useDelayedLoading(isLoading);
@@ -86,10 +88,11 @@ function TopicDetailPage() {
       if (!id) return;
 
       await apiClient.patch(`/topics/${id}`, updates);
-      // Refresh topic data after successful edit
-      window.location.reload();
+      // Invalidate and refetch topic data after successful edit
+      // This allows the modal to close properly before data refreshes
+      await queryClient.invalidateQueries({ queryKey: ['topic', id] });
     },
-    [id],
+    [id, queryClient],
   );
 
   // Fetch bridging suggestions when analysis is available


### PR DESCRIPTION
## Summary
- Fixed modal closing race condition where `window.location.reload()` was called before the modal's `onClose()` callback could run
- Replaced full page reload with React Query's `invalidateQueries()` for proper data refresh

## Root Cause Analysis
In `TopicDetailPage.tsx`, the `handleEditSubmit` function was structured as:
```typescript
await apiClient.patch(`/topics/${id}`, updates);
window.location.reload(); // ❌ Executes immediately, before modal closes
```

When `EditTopicModal` awaits `onSubmit(updates)`, the `window.location.reload()` fires and the page starts reloading **before** `onClose()` runs, causing:
1. Modal remains visible during reload transition
2. Playwright E2E tests fail with "expected not visible, received visible"

## Fix
Replace `window.location.reload()` with React Query invalidation:
```typescript
await apiClient.patch(`/topics/${id}`, updates);
await queryClient.invalidateQueries({ queryKey: ['topic', id] });
// ✅ Returns control to EditTopicModal, allowing onClose() to run
```

## Test plan
- [x] Unit tests pass (1143 tests)
- [x] TypeScript compiles without errors
- [ ] CI E2E tests verify modal closes properly after edit submission

Fixes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)