### PR TITLE
fix(e2e): Enable WebSocket real-time update tests with improved timing (#677)

### DIFF
--- a/frontend/e2e/explore-divergence-points.spec.ts
+++ b/frontend/e2e/explore-divergence-points.spec.ts
@@ -508,108 +508,112 @@ test.describe('Explore Divergence Points', () => {
     }
   });
 
-  // TODO(#677): Re-enable when WebSocket mock timing is fixed in CI
-  // Issue: Tests timeout with 'Target page, context or browser has been closed'
-  // The WebSocket mock infrastructure is in place but needs CI debugging
-  test.skip('should update divergence points in real-time via WebSocket', async ({ page }) => {
-    // Setup WebSocket mock
+  // WebSocket real-time update test - uses mock to simulate server events
+  // Uses test.slow() to double timeout for CI environments with slower page loads
+  test('should update divergence points in real-time via WebSocket', async ({ page }) => {
+    test.slow(); // Double the default timeout for this test
+
+    // Setup WebSocket mock before any navigation
     const wsMock = await setupWebSocketMock(page);
 
-    await page.goto('/topics');
-    await page.waitForSelector('text=Loading topics...', { state: 'hidden', timeout: 10000 });
+    try {
+      await page.goto('/topics');
+      await page.waitForSelector('text=Loading topics...', { state: 'hidden', timeout: 15000 });
 
-    const firstTopicLink = page.locator('a[href^="/topics/"]').first();
-    const linkCount = await firstTopicLink.count();
+      const firstTopicLink = page.locator('a[href^="/topics/"]').first();
+      const linkCount = await firstTopicLink.count();
 
-    if (linkCount > 0) {
-      const href = await firstTopicLink.getAttribute('href');
-      const topicId = href?.split('/topics/')[1];
+      if (linkCount > 0) {
+        const href = await firstTopicLink.getAttribute('href');
+        const topicId = href?.split('/topics/')[1];
 
-      if (!topicId) {
-        throw new Error('Could not extract topic ID from href');
+        if (!topicId) {
+          throw new Error('Could not extract topic ID from href');
+        }
+
+        await page.goto(`/topics/${topicId}`);
+        await page.waitForSelector('text=Loading topic details...', {
+          state: 'hidden',
+          timeout: 15000,
+        });
+
+        // Wait for WebSocket connection (mock should be instant)
+        await wsMock.waitForConnection('/notifications');
+
+        // Get initial state
+        const divergenceSection = page.locator('[data-testid="divergence-points"]');
+        const initialText = await divergenceSection.textContent().catch(() => '');
+
+        // Create new divergence point with unique proposition
+        // Note: buildDivergencePoint is used for reference but payload uses genuineDisagreements format
+        buildDivergencePoint({
+          proposition: 'Nuclear energy should be part of the clean energy mix',
+          propositionId: 'prop-nuclear-energy',
+          viewpoints: [
+            {
+              position: 'Support nuclear as clean energy',
+              participantCount: 5,
+              percentage: 50,
+              reasoning: ['Zero carbon emissions', 'Reliable baseload power'],
+            },
+            {
+              position: 'Oppose nuclear due to risks',
+              participantCount: 5,
+              percentage: 50,
+              reasoning: ['Waste disposal concerns', 'Safety risks'],
+            },
+          ],
+          polarizationScore: 0.9,
+          totalParticipants: 10,
+          underlyingValues: ['Energy security vs Environmental safety'],
+        });
+
+        // Emit WebSocket event with new divergence point
+        const payload = buildCommonGroundUpdatedPayload({
+          topicId,
+          genuineDisagreements: [
+            {
+              id: 'disagreement-nuclear',
+              topic: 'Nuclear energy in clean energy mix',
+              description: 'Disagreement on role of nuclear energy',
+              positions: [
+                {
+                  stance: 'Support nuclear',
+                  reasoning: 'Zero carbon, reliable baseload',
+                  participants: ['user-1', 'user-2', 'user-3', 'user-4', 'user-5'],
+                  underlyingValue: 'Energy security',
+                },
+                {
+                  stance: 'Oppose nuclear',
+                  reasoning: 'Safety and waste concerns',
+                  participants: ['user-6', 'user-7', 'user-8', 'user-9', 'user-10'],
+                  underlyingValue: 'Environmental safety',
+                },
+              ],
+              moralFoundations: ['care-harm', 'liberty-oppression'],
+            },
+          ],
+        });
+
+        await wsMock.emitCommonGroundUpdated(topicId, payload.analysis);
+
+        // Wait for React state update and re-render
+        await page.waitForTimeout(500);
+
+        // Verify UI updated with new content
+        const updatedText = await divergenceSection.textContent().catch(() => '');
+
+        // Verify content changed or contains expected text
+        // (exact assertion depends on component implementation)
+        expect(
+          updatedText !== initialText ||
+            updatedText.includes('Nuclear') ||
+            updatedText.includes('disagreement'),
+        ).toBe(true);
       }
-
-      await page.goto(`/topics/${topicId}`);
-      await page.waitForSelector('text=Loading topic details...', {
-        state: 'hidden',
-        timeout: 10000,
-      });
-
-      // Wait for WebSocket connection
-      await wsMock.waitForConnection('/notifications');
-
-      // Get initial state
-      const divergenceSection = page.locator('[data-testid="divergence-points"]');
-      const initialText = await divergenceSection.textContent().catch(() => '');
-
-      // Create new divergence point with unique proposition
-      const newDivergencePoint = buildDivergencePoint({
-        proposition: 'Nuclear energy should be part of the clean energy mix',
-        propositionId: 'prop-nuclear-energy',
-        viewpoints: [
-          {
-            position: 'Support nuclear as clean energy',
-            participantCount: 5,
-            percentage: 50,
-            reasoning: ['Zero carbon emissions', 'Reliable baseload power'],
-          },
-          {
-            position: 'Oppose nuclear due to risks',
-            participantCount: 5,
-            percentage: 50,
-            reasoning: ['Waste disposal concerns', 'Safety risks'],
-          },
-        ],
-        polarizationScore: 0.9,
-        totalParticipants: 10,
-        underlyingValues: ['Energy security vs Environmental safety'],
-      });
-
-      // Emit WebSocket event with new divergence point
-      const payload = buildCommonGroundUpdatedPayload({
-        topicId,
-        genuineDisagreements: [
-          {
-            id: 'disagreement-nuclear',
-            topic: 'Nuclear energy in clean energy mix',
-            description: 'Disagreement on role of nuclear energy',
-            positions: [
-              {
-                stance: 'Support nuclear',
-                reasoning: 'Zero carbon, reliable baseload',
-                participants: ['user-1', 'user-2', 'user-3', 'user-4', 'user-5'],
-                underlyingValue: 'Energy security',
-              },
-              {
-                stance: 'Oppose nuclear',
-                reasoning: 'Safety and waste concerns',
-                participants: ['user-6', 'user-7', 'user-8', 'user-9', 'user-10'],
-                underlyingValue: 'Environmental safety',
-              },
-            ],
-            moralFoundations: ['care-harm', 'liberty-oppression'],
-          },
-        ],
-      });
-
-      await wsMock.emitCommonGroundUpdated(topicId, payload.analysis);
-
-      // Wait for React state update and re-render
-      await page.waitForTimeout(1500);
-
-      // Verify UI updated with new content
-      const updatedText = await divergenceSection.textContent().catch(() => '');
-
-      // Verify content changed or contains expected text
-      // (exact assertion depends on component implementation)
-      expect(
-        updatedText !== initialText ||
-          updatedText.includes('Nuclear') ||
-          updatedText.includes('disagreement'),
-      ).toBe(true);
+    } finally {
+      await wsMock.cleanup();
     }
-
-    await wsMock.cleanup();
   });
 
   test('should be responsive on mobile viewport', async ({ page }) => {

--- a/frontend/e2e/helpers/websocket-mock.ts
+++ b/frontend/e2e/helpers/websocket-mock.ts
@@ -126,16 +126,18 @@ export async function setupWebSocketMock(page: Page): Promise<WebSocketMock> {
   return {
     /**
      * Wait for WebSocket connection to establish (mock is instant)
+     * Uses shorter timeout since mock should be ready immediately after page load.
      */
     async waitForConnection(_namespace: string = '/notifications'): Promise<void> {
       // Wait for the mock socket to be available (set by addInitScript)
+      // Use shorter timeout (5s) since mock should be instant - longer waits indicate a problem
       await page.waitForFunction(
         () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const socket = (window as any).__testSocket;
           return socket && socket.connected;
         },
-        { timeout: 10000 },
+        { timeout: 5000 },
       );
 
       // Trigger the connect event so any listeners are notified
@@ -147,8 +149,8 @@ export async function setupWebSocketMock(page: Page): Promise<WebSocketMock> {
         }
       });
 
-      // Small wait for React to process
-      await page.waitForTimeout(100);
+      // Brief wait for React to process the connect event
+      await page.waitForTimeout(50);
     },
 
     /**
@@ -173,8 +175,8 @@ export async function setupWebSocketMock(page: Page): Promise<WebSocketMock> {
         { event: eventName, data: payload },
       );
 
-      // Small delay to allow React to process the event
-      await page.waitForTimeout(100);
+      // Brief delay to allow React to process the event
+      await page.waitForTimeout(50);
     },
 
     /**

--- a/frontend/e2e/view-bridging-suggestions.spec.ts
+++ b/frontend/e2e/view-bridging-suggestions.spec.ts
@@ -848,73 +848,76 @@ test.describe('View Bridging Suggestions', () => {
     }
   });
 
-  // TODO(#677): Re-enable when WebSocket mock timing is fixed in CI
-  // Issue: Tests timeout with 'Target page, context or browser has been closed'
-  // The WebSocket mock infrastructure is in place but needs CI debugging
-  test.skip('should update bridging suggestions in real-time via WebSocket', async ({ page }) => {
-    // Setup WebSocket mock
+  // WebSocket real-time update test - uses mock to simulate server events
+  // Uses test.slow() to double timeout for CI environments with slower page loads
+  test('should update bridging suggestions in real-time via WebSocket', async ({ page }) => {
+    test.slow(); // Double the default timeout for this test
+
+    // Setup WebSocket mock before any navigation
     const wsMock = await setupWebSocketMock(page);
 
-    await page.goto('/topics');
-    await page.waitForSelector('text=Loading topics...', { state: 'hidden', timeout: 10000 });
+    try {
+      await page.goto('/topics');
+      await page.waitForSelector('text=Loading topics...', { state: 'hidden', timeout: 15000 });
 
-    const firstTopicLink = page.locator('a[href^="/topics/"]').first();
-    const linkCount = await firstTopicLink.count();
+      const firstTopicLink = page.locator('a[href^="/topics/"]').first();
+      const linkCount = await firstTopicLink.count();
 
-    if (linkCount > 0) {
-      const href = await firstTopicLink.getAttribute('href');
-      const topicId = href?.split('/topics/')[1];
+      if (linkCount > 0) {
+        const href = await firstTopicLink.getAttribute('href');
+        const topicId = href?.split('/topics/')[1];
 
-      if (!topicId) {
-        throw new Error('Could not extract topic ID from href');
+        if (!topicId) {
+          throw new Error('Could not extract topic ID from href');
+        }
+
+        await page.goto(`/topics/${topicId}`);
+        await page.waitForSelector('text=Loading topic details...', {
+          state: 'hidden',
+          timeout: 15000,
+        });
+
+        // Wait for WebSocket connection (mock should be instant)
+        await wsMock.waitForConnection('/notifications');
+
+        // Get initial state
+        const suggestionsSection = page.locator('[data-testid="bridging-suggestions"]');
+        const initialText = await suggestionsSection.textContent().catch(() => '');
+
+        // Create new agreement zone with bridging opportunity
+        const newAgreementZone = buildAgreementZone({
+          id: 'agreement-zone-renewable',
+          title: 'Renewable Energy Benefits',
+          description: 'Agreement on environmental benefits of renewable energy',
+          participantCount: 15,
+          consensusLevel: 'high',
+        });
+
+        // Emit WebSocket event with updated common ground including new agreement zone
+        const payload = buildCommonGroundUpdatedPayload({
+          topicId,
+          agreementZones: [newAgreementZone],
+          overallConsensusScore: 0.75,
+        });
+
+        await wsMock.emitCommonGroundUpdated(topicId, payload.analysis);
+
+        // Wait for React state update and re-render
+        await page.waitForTimeout(500);
+
+        // Verify UI updated
+        const updatedText = await suggestionsSection.textContent().catch(() => '');
+
+        // Verify content changed or contains expected text
+        expect(
+          updatedText !== initialText ||
+            updatedText.includes('Renewable') ||
+            updatedText.includes('suggestion'),
+        ).toBe(true);
       }
-
-      await page.goto(`/topics/${topicId}`);
-      await page.waitForSelector('text=Loading topic details...', {
-        state: 'hidden',
-        timeout: 10000,
-      });
-
-      // Wait for WebSocket connection
-      await wsMock.waitForConnection('/notifications');
-
-      // Get initial state
-      const suggestionsSection = page.locator('[data-testid="bridging-suggestions"]');
-      const initialText = await suggestionsSection.textContent().catch(() => '');
-
-      // Create new agreement zone with bridging opportunity
-      const newAgreementZone = buildAgreementZone({
-        id: 'agreement-zone-renewable',
-        title: 'Renewable Energy Benefits',
-        description: 'Agreement on environmental benefits of renewable energy',
-        participantCount: 15,
-        consensusLevel: 'high',
-      });
-
-      // Emit WebSocket event with updated common ground including new agreement zone
-      const payload = buildCommonGroundUpdatedPayload({
-        topicId,
-        agreementZones: [newAgreementZone],
-        overallConsensusScore: 0.75,
-      });
-
-      await wsMock.emitCommonGroundUpdated(topicId, payload.analysis);
-
-      // Wait for React state update and re-render
-      await page.waitForTimeout(1500);
-
-      // Verify UI updated
-      const updatedText = await suggestionsSection.textContent().catch(() => '');
-
-      // Verify content changed or contains expected text
-      expect(
-        updatedText !== initialText ||
-          updatedText.includes('Renewable') ||
-          updatedText.includes('suggestion'),
-      ).toBe(true);
+    } finally {
+      await wsMock.cleanup();
     }
-
-    await wsMock.cleanup();
   });
 
   test('should display maximum suggestion count limit if configured', async ({ page }) => {

--- a/frontend/e2e/view-common-ground-summary.spec.ts
+++ b/frontend/e2e/view-common-ground-summary.spec.ts
@@ -352,95 +352,98 @@ test.describe('View Common Ground Summary', () => {
     }
   });
 
-  // TODO(#677): Re-enable when WebSocket mock timing is fixed in CI
-  // Issue: Tests timeout with 'Target page, context or browser has been closed'
-  // The WebSocket mock infrastructure is in place but needs CI debugging
-  test.skip('should update common ground summary in real-time when new responses are added', async ({
+  // WebSocket real-time update test - uses mock to simulate server events
+  // Uses test.slow() to double timeout for CI environments with slower page loads
+  test('should update common ground summary in real-time when new responses are added', async ({
     page,
   }) => {
-    // Setup WebSocket mock
+    test.slow(); // Double the default timeout for this test
+
+    // Setup WebSocket mock before any navigation
     const wsMock = await setupWebSocketMock(page);
 
-    // Navigate to discussions page (three-panel layout)
-    await page.goto('/discussions');
+    try {
+      // Navigate to discussions page (three-panel layout)
+      await page.goto('/discussions');
 
-    // Wait for topics list to load
-    const firstTopic = page.locator('[data-testid="topic-list-item"]').first();
-    await expect(firstTopic).toBeVisible({ timeout: 10000 });
+      // Wait for topics list to load
+      const firstTopic = page.locator('[data-testid="topic-list-item"]').first();
+      await expect(firstTopic).toBeVisible({ timeout: 15000 });
 
-    // Get topic ID from data attribute
-    const topicId = await firstTopic.getAttribute('data-topic-id');
-    if (!topicId) {
-      throw new Error('Could not get topic ID from data attribute');
+      // Get topic ID from data attribute
+      const topicId = await firstTopic.getAttribute('data-topic-id');
+      if (!topicId) {
+        throw new Error('Could not get topic ID from data attribute');
+      }
+
+      // Select the first topic
+      await firstTopic.click();
+
+      // Wait for conversation panel to load
+      await expect(page.locator('.conversation-panel h1')).toBeVisible({ timeout: 15000 });
+
+      // Wait for WebSocket connection (mock should be instant)
+      await wsMock.waitForConnection('/notifications');
+
+      // Click on Common Ground tab
+      const commonGroundTab = page.getByRole('tab', { name: /Common Ground/i });
+      await expect(commonGroundTab).toBeVisible();
+      await commonGroundTab.click();
+
+      // Get initial state of the Common Ground content
+      const rightPanel = page.locator('[role="complementary"]').first();
+      const initialText = await rightPanel.textContent().catch(() => '');
+
+      // Create updated common ground with new agreement zone and misunderstanding
+      const newAgreementZone = buildAgreementZone({
+        id: 'agreement-zone-climate',
+        title: 'Climate Science Consensus',
+        description: 'Agreement on basic climate science facts',
+        participantCount: 18,
+        consensusLevel: 'high',
+      });
+
+      const newMisunderstanding = buildMisunderstanding({
+        id: 'misunderstanding-carbon',
+        term: 'carbon neutral',
+        definitions: [
+          {
+            definition: 'Zero net carbon emissions',
+            participants: ['user-1', 'user-2', 'user-3'],
+          },
+          {
+            definition: 'Carbon offset through capture',
+            participants: ['user-4', 'user-5'],
+          },
+        ],
+      });
+
+      // Emit WebSocket event with updated common ground
+      const payload = buildCommonGroundUpdatedPayload({
+        topicId,
+        agreementZones: [newAgreementZone],
+        misunderstandings: [newMisunderstanding],
+        overallConsensusScore: 0.8,
+      });
+
+      await wsMock.emitCommonGroundUpdated(topicId, payload.analysis);
+
+      // Wait for React state update and re-render
+      await page.waitForTimeout(500);
+
+      // Verify UI updated
+      const updatedText = await rightPanel.textContent().catch(() => '');
+
+      // Verify content changed or contains expected text
+      expect(
+        updatedText !== initialText ||
+          updatedText.includes('Climate') ||
+          updatedText.includes('consensus') ||
+          updatedText.includes('80'),
+      ).toBe(true);
+    } finally {
+      await wsMock.cleanup();
     }
-
-    // Select the first topic
-    await firstTopic.click();
-
-    // Wait for conversation panel to load
-    await expect(page.locator('.conversation-panel h1')).toBeVisible({ timeout: 10000 });
-
-    // Wait for WebSocket connection
-    await wsMock.waitForConnection('/notifications');
-
-    // Click on Common Ground tab
-    const commonGroundTab = page.getByRole('tab', { name: /Common Ground/i });
-    await expect(commonGroundTab).toBeVisible();
-    await commonGroundTab.click();
-
-    // Get initial state of the Common Ground content
-    const rightPanel = page.locator('[role="complementary"]').first();
-    const initialText = await rightPanel.textContent().catch(() => '');
-
-    // Create updated common ground with new agreement zone and misunderstanding
-    const newAgreementZone = buildAgreementZone({
-      id: 'agreement-zone-climate',
-      title: 'Climate Science Consensus',
-      description: 'Agreement on basic climate science facts',
-      participantCount: 18,
-      consensusLevel: 'high',
-    });
-
-    const newMisunderstanding = buildMisunderstanding({
-      id: 'misunderstanding-carbon',
-      term: 'carbon neutral',
-      definitions: [
-        {
-          definition: 'Zero net carbon emissions',
-          participants: ['user-1', 'user-2', 'user-3'],
-        },
-        {
-          definition: 'Carbon offset through capture',
-          participants: ['user-4', 'user-5'],
-        },
-      ],
-    });
-
-    // Emit WebSocket event with updated common ground
-    const payload = buildCommonGroundUpdatedPayload({
-      topicId,
-      agreementZones: [newAgreementZone],
-      misunderstandings: [newMisunderstanding],
-      overallConsensusScore: 0.8,
-    });
-
-    await wsMock.emitCommonGroundUpdated(topicId, payload.analysis);
-
-    // Wait for React state update and re-render
-    await page.waitForTimeout(1500);
-
-    // Verify UI updated
-    const updatedText = await rightPanel.textContent().catch(() => '');
-
-    // Verify content changed or contains expected text
-    expect(
-      updatedText !== initialText ||
-        updatedText.includes('Climate') ||
-        updatedText.includes('consensus') ||
-        updatedText.includes('80'),
-    ).toBe(true);
-
-    await wsMock.cleanup();
   });
 
   // Skip: Test uses old /topics/:id navigation pattern replaced by discussion page redesign


### PR DESCRIPTION
## Summary
- Enables 3 WebSocket E2E tests that were previously skipped due to CI timeout issues
- Improves WebSocket mock timing for better CI reliability
- Adds test.slow() to give tests adequate time in slower CI environments

## Test plan
- [ ] CI pipeline passes all tests
- [ ] 3 WebSocket tests now run instead of being skipped
- [ ] No increase in flakiness from these tests

Fixes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)