### PR TITLE
fix(tests): increase waitFor timeout for modal close test

### DIFF
--- a/frontend/src/components/credentials/__tests__/CredentialReviewQueue.test.tsx
+++ b/frontend/src/components/credentials/__tests__/CredentialReviewQueue.test.tsx
@@ -562,7 +562,7 @@ describe('CredentialReviewQueue', () => {
     });
 
     it('should close modal after successful action', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null });
       render(
         <CredentialReviewQueue
           credentials={mockCredentials}
@@ -577,9 +577,13 @@ describe('CredentialReviewQueue', () => {
       const confirmButton = screen.getByRole('button', { name: /confirm/i });
       await user.click(confirmButton);
 
-      await waitFor(() => {
-        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-      });
+      // Component has 1000ms delay before closing modal - need longer timeout
+      await waitFor(
+        () => {
+          expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        },
+        { timeout: 2000 },
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix race condition in CredentialReviewQueue test where `waitFor` timeout (default 1000ms) matched the component's modal close delay (1000ms)
- Increase `waitFor` timeout to 2000ms for reliable test execution
- Add `delay: null` to `userEvent.setup` for faster CI execution

## Problem
The `should close modal after successful action` test was failing intermittently in Jenkins CI (build #294) because:
1. Component shows success message and waits 1000ms before closing modal
2. Test's `waitFor` had default 1000ms timeout
3. Race condition caused test to timeout right at the boundary

## Test plan
- [x] Verified all 32 CredentialReviewQueue tests pass locally
- [x] Specific failing test now passes consistently (~1082ms execution time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)