### PR TITLE
fix(cache): make CacheModule global to fix DI errors

### DIFF
--- a/services/recommendation-service/src/cache/cache.module.ts
+++ b/services/recommendation-service/src/cache/cache.module.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Module, Logger } from '@nestjs/common';
+import { Module, Global, Logger } from '@nestjs/common';
 import { CacheModule as NestCacheModule } from '@nestjs/cache-manager';
 import { redisStore } from 'cache-manager-redis-store';
 
@@ -22,6 +22,7 @@ const logger = new Logger('CacheModule');
  * - CACHE_TTL: Cache TTL in seconds (default: 3600 = 1 hour)
  * - CACHE_MAX_ITEMS: Maximum cached items (default: 1000)
  */
+@Global()
 @Module({
   imports: [
     NestCacheModule.registerAsync({

--- a/services/user-service/src/cache/cache.module.ts
+++ b/services/user-service/src/cache/cache.module.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Module, Logger } from '@nestjs/common';
+import { Module, Global, Logger } from '@nestjs/common';
 import { CacheModule as NestCacheModule } from '@nestjs/cache-manager';
 import { redisStore } from 'cache-manager-redis-store';
 
@@ -22,6 +22,7 @@ const logger = new Logger('CacheModule');
  * - CACHE_TTL: Cache TTL in seconds (default: 3600 = 1 hour)
  * - CACHE_MAX_ITEMS: Maximum cached items (default: 1000)
  */
+@Global()
 @Module({
   imports: [
     NestCacheModule.registerAsync({


### PR DESCRIPTION
## Summary
- Fix E2E test failures caused by `user-service` and `recommendation-service` failing to start
- Add `@Global()` decorator to `CacheModule` in both services
- Makes `CACHE_MANAGER` provider available to all modules without explicit imports

## Problem
Jenkins build #295 on main was UNSTABLE because:
1. `CacheInterceptor` in controllers requires `CACHE_MANAGER` provider
2. `CacheModule` was imported in `AppModule` but feature modules (`UsersModule`, `TopicRecommendationsModule`) couldn't access it
3. NestJS throws `UnknownDependenciesException` when trying to inject `CACHE_MANAGER`

**Error:**
```
UnknownDependenciesException: Nest can't resolve dependencies of the 
CacheInterceptor (?, Reflector). Please make sure that the argument 
"CACHE_MANAGER" at index [0] is available in the [Module] context.
```

## Solution
Mark `CacheModule` as `@Global()` so it's automatically available to all modules in the application. This is the standard pattern for cross-cutting concerns like caching.

## Affected endpoints
- `GET /users/:id` (30min cache)
- `GET /users/:id/followers` (1hr cache)  
- `GET /users/:id/following` (1hr cache)
- `GET /topic-recommendations/similar/:topicId` (24hr cache)
- `GET /topic-recommendations/trending` (5min cache)

## Test plan
- [x] TypeScript compilation passes for recommendation-service
- [x] Pre-commit hooks pass (unit tests for core services)
- [ ] E2E tests should now pass with services starting successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)