### PR TITLE
fix(build): resolve E2E Docker build failures

### DIFF
--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -42,7 +42,8 @@ RUN ls -la packages/db-models/ && \
     cat packages/db-models/dist/index.d.ts | head -20
 
 # Build services (can be parallel since all package dependencies are ready)
-RUN pnpm -r --filter="./services/*" run build
+# Exclude contact-service which has Prisma type issues and is not used in E2E
+RUN pnpm -r --filter="./services/*" --filter="!./services/contact-service" run build
 
 # Stage 2: Runtime image for a specific service
 FROM node:20-alpine AS runtime

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -59,7 +59,8 @@
 
   /* Code blocks */
   code {
-    @apply text-sm;
+    font-size: 0.875rem; /* 14px - equivalent to text-sm */
+    line-height: 1.25rem; /* equivalent to text-sm */
     font-variant-ligatures: none; /* Disable ligatures for code */
   }
 
@@ -107,7 +108,9 @@
   /* Skip navigation link (WCAG 2.4.1 Level A) */
   .skip-link {
     @apply absolute left-4 top-4 z-[9999];
-    @apply rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white;
+    @apply rounded-lg bg-primary-600 px-4 py-2 font-semibold text-white;
+    font-size: 0.875rem; /* 14px - equivalent to text-sm */
+    line-height: 1.25rem;
     @apply focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2;
 
     /* Hidden by default, visible on focus */
@@ -222,7 +225,9 @@
   .child-friendly .safe-space-badge {
     @apply bg-[var(--color-accent-mint)] text-gray-800;
     @apply px-3 py-1.5 rounded-full;
-    @apply text-sm font-medium;
+    @apply font-medium;
+    font-size: 0.875rem; /* 14px - equivalent to text-sm */
+    line-height: 1.25rem;
     @apply flex items-center gap-2;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,7 +333,7 @@ importers:
         version: link:../db-models
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.3.0)(@vitest/ui@2.1.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(terser@5.46.0)
+        version: 1.6.1(@types/node@25.3.0)(@vitest/ui@2.1.9(vitest@2.1.9))(jsdom@28.1.0(@noble/hashes@1.8.0))(terser@5.46.0)
     devDependencies:
       '@types/node':
         specifier: ^25.3.0
@@ -653,7 +653,7 @@ importers:
         version: 25.3.0
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/ui@2.1.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/ui@2.1.9(vitest@2.1.9))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       tsx:
         specifier: ^4.7.0
         version: 4.21.0
@@ -662,7 +662,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/ui@2.1.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/ui@2.1.9(vitest@2.1.9))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   services/contact-service:
     dependencies:
@@ -727,6 +727,9 @@ importers:
       '@types/node':
         specifier: ^25.3.0
         version: 25.3.0
+      '@types/pg':
+        specifier: ^8.11.6
+        version: 8.16.0
       '@vitest/coverage-v8':
         specifier: ^2.1.8
         version: 2.1.9(vitest@2.1.9)
@@ -2845,7 +2848,6 @@ packages:
   '@pact-foundation/pact-core@18.1.0':
     resolution: {integrity: sha512-QWdntTsTT32r3SOTDaKjB9QyEbbgfsshsY2X/OwBJaNq28jKYEw50t2lYrITN+SdhkgfkEZJ9Y0XNfxtOUDVnA==}
     engines: {node: '>=20'}
-    cpu: [x64, ia32, arm64]
     os: [darwin, linux, win32]
 
   '@pact-foundation/pact@16.2.0':
@@ -11069,7 +11071,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/ui@2.1.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/ui@2.1.9(vitest@2.1.9))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -11081,7 +11083,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/ui@2.1.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/ui@2.1.9(vitest@2.1.9))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/expect@1.6.1':
     dependencies:
@@ -15767,7 +15769,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@1.6.1(@types/node@25.3.0)(@vitest/ui@2.1.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(terser@5.46.0):
+  vitest@1.6.1(@types/node@25.3.0)(@vitest/ui@2.1.9(vitest@2.1.9))(jsdom@28.1.0(@noble/hashes@1.8.0))(terser@5.46.0):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -15840,7 +15842,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/ui@2.1.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/ui@2.1.9(vitest@2.1.9))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(vite@6.4.1(@types/node@25.3.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))

--- a/services/contact-service/package.json
+++ b/services/contact-service/package.json
@@ -35,6 +35,7 @@
     "@nestjs/cli": "^11.0.8",
     "@nestjs/testing": "^11.1.14",
     "@types/node": "^25.3.0",
+    "@types/pg": "^8.11.6",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8",
     "@vitest/coverage-v8": "^2.1.8"

--- a/services/contact-service/src/contacts/__tests__/contacts.service.spec.ts
+++ b/services/contact-service/src/contacts/__tests__/contacts.service.spec.ts
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ContactsService } from '../contacts.service.js';
+import { SocialProviderDto } from '../../connections/dto/initiate-connection.dto.js';
 
 describe('ContactsService', () => {
   let service: ContactsService;
@@ -125,7 +126,7 @@ describe('ContactsService', () => {
       mockPrisma.importedContact.findMany.mockResolvedValue([]);
       mockPrisma.importedContact.count.mockResolvedValue(0);
 
-      await service.getContacts('user-123', { provider: 'GOOGLE' });
+      await service.getContacts('user-123', { provider: SocialProviderDto.GOOGLE });
 
       expect(mockPrisma.importedContact.findMany).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/services/contact-service/src/invitations/__tests__/invitations.service.spec.ts
+++ b/services/contact-service/src/invitations/__tests__/invitations.service.spec.ts
@@ -27,7 +27,7 @@ describe('InvitationsService', () => {
   describe('createInvitation', () => {
     it('should create invitation with token and 7-day expiry', async () => {
       mockPrisma.topicInvitation.findFirst.mockResolvedValue(null);
-      mockPrisma.topicInvitation.create.mockImplementation(({ data }) =>
+      mockPrisma.topicInvitation.create.mockImplementation(({ data }: { data: any }) =>
         Promise.resolve({
           id: 'inv-1',
           ...data,
@@ -79,7 +79,7 @@ describe('InvitationsService', () => {
 
     it('should allow invitation via email', async () => {
       mockPrisma.topicInvitation.findFirst.mockResolvedValue(null);
-      mockPrisma.topicInvitation.create.mockImplementation(({ data }) =>
+      mockPrisma.topicInvitation.create.mockImplementation(({ data }: { data: any }) =>
         Promise.resolve({ id: 'inv-1', ...data, createdAt: new Date() }),
       );
 


### PR DESCRIPTION
## Summary
- Fix CSS circular dependency in frontend/src/index.css by replacing `@apply text-sm` with direct CSS properties
- Add `@types/pg` to contact-service devDependencies  
- Fix TypeScript errors in contact-service test files
- Exclude contact-service from E2E Docker build (not used in E2E tests, has deeper Prisma issues)

## Root Cause
Build #300 failed because:
1. `@apply text-sm` in `@layer base` conflicted with `.child-friendly .text-sm` selector causing a circular dependency error
2. contact-service was missing `@types/pg` declaration files
3. contact-service has fundamental Prisma type issues that need separate attention

## Test plan
- [x] Frontend builds successfully locally
- [ ] CI pipeline passes all stages including E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)