### PR TITLE
feat(ux): Implement conversation UI improvements - all 4 phases

### DIFF
--- a/frontend/src/components/discussion-layout/CollapsedMetadataBar.tsx
+++ b/frontend/src/components/discussion-layout/CollapsedMetadataBar.tsx
@@ -1,0 +1,234 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Collapsed Metadata Bar
+ *
+ * A 48px wide vertical icon bar that displays when the metadata panel
+ * is collapsed. Icons provide quick access to different panel tabs.
+ *
+ * @remarks
+ * **Layout**:
+ * - Vertical stack of icon buttons
+ * - 48px width to accommodate 44px touch targets (WCAG 2.1 AA)
+ * - Fixed position on right edge of layout
+ *
+ * **Icons**:
+ * - Propositions: List/document icon
+ * - Common Ground: Handshake/people icon
+ * - Bridging: Lightning/connection icon
+ * - Preview: Eye icon (shown only when composing)
+ * - Expand: Chevron left to expand panel
+ *
+ * **Interaction**:
+ * - Click icon → Expand panel to that specific tab
+ * - Tooltips on hover for accessibility
+ *
+ * @example
+ * ```tsx
+ * <CollapsedMetadataBar
+ *   onExpandToTab={(tab) => handleExpandToTab(tab)}
+ *   isComposing={isComposing}
+ *   activeTab={activeTab}
+ * />
+ * ```
+ */
+
+import type { MetadataPanelTab } from './MetadataPanel';
+
+export interface CollapsedMetadataBarProps {
+  /** Callback when an icon is clicked to expand to that tab */
+  onExpandToTab: (tab: MetadataPanelTab) => void;
+  /** Whether user is currently composing (shows Preview icon) */
+  isComposing?: boolean;
+  /** Currently active tab (for highlighting) */
+  activeTab?: MetadataPanelTab;
+  /** Callback when expand button is clicked */
+  onExpand: () => void;
+  /** CSS class name */
+  className?: string;
+}
+
+interface IconButtonProps {
+  tab: MetadataPanelTab;
+  label: string;
+  icon: React.ReactNode;
+  isActive?: boolean;
+  onClick: () => void;
+}
+
+/**
+ * Individual icon button with tooltip
+ */
+function IconButton({ tab, label, icon, isActive, onClick }: IconButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`
+        w-11 h-11 flex items-center justify-center rounded-lg
+        transition-colors duration-150
+        ${
+          isActive
+            ? 'bg-primary-100 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300'
+            : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100'
+        }
+      `}
+      aria-label={`Open ${label} panel`}
+      title={label}
+      data-tab={tab}
+    >
+      {icon}
+    </button>
+  );
+}
+
+/**
+ * SVG Icons for each tab
+ */
+const PropositionsIcon = () => (
+  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"
+    />
+  </svg>
+);
+
+const CommonGroundIcon = () => (
+  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+    />
+  </svg>
+);
+
+const BridgingIcon = () => (
+  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M13 10V3L4 14h7v7l9-11h-7z"
+    />
+  </svg>
+);
+
+const PreviewIcon = () => (
+  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+    />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+    />
+  </svg>
+);
+
+const ExpandIcon = () => (
+  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+  </svg>
+);
+
+export function CollapsedMetadataBar({
+  onExpandToTab,
+  isComposing = false,
+  activeTab = 'propositions',
+  onExpand,
+  className = '',
+}: CollapsedMetadataBarProps) {
+  const handleIconClick = (tab: MetadataPanelTab) => {
+    onExpandToTab(tab);
+  };
+
+  return (
+    <div
+      className={`
+        collapsed-metadata-bar
+        w-12 h-full flex flex-col items-center
+        bg-gray-50 dark:bg-gray-900
+        border-l border-gray-200 dark:border-gray-700
+        py-2 gap-1
+        ${className}
+      `}
+      role="toolbar"
+      aria-label="Metadata panel shortcuts"
+      aria-orientation="vertical"
+    >
+      {/* Tab Icons */}
+      <div className="flex flex-col items-center gap-1">
+        <IconButton
+          tab="propositions"
+          label="Propositions"
+          icon={<PropositionsIcon />}
+          isActive={activeTab === 'propositions'}
+          onClick={() => handleIconClick('propositions')}
+        />
+
+        <IconButton
+          tab="commonGround"
+          label="Common Ground"
+          icon={<CommonGroundIcon />}
+          isActive={activeTab === 'commonGround'}
+          onClick={() => handleIconClick('commonGround')}
+        />
+
+        <IconButton
+          tab="bridging"
+          label="Bridging Suggestions"
+          icon={<BridgingIcon />}
+          isActive={activeTab === 'bridging'}
+          onClick={() => handleIconClick('bridging')}
+        />
+
+        {/* Preview icon - only shown when composing */}
+        {isComposing && (
+          <IconButton
+            tab="preview"
+            label="Preview Feedback"
+            icon={<PreviewIcon />}
+            isActive={activeTab === 'preview'}
+            onClick={() => handleIconClick('preview')}
+          />
+        )}
+      </div>
+
+      {/* Spacer */}
+      <div className="flex-1" />
+
+      {/* Divider */}
+      <div className="w-8 h-px bg-gray-200 dark:bg-gray-700 my-2" />
+
+      {/* Expand Button */}
+      <button
+        type="button"
+        onClick={onExpand}
+        className="
+          w-11 h-11 flex items-center justify-center rounded-lg
+          text-gray-600 dark:text-gray-400
+          hover:bg-gray-100 dark:hover:bg-gray-800
+          hover:text-gray-900 dark:hover:text-gray-100
+          transition-colors duration-150
+        "
+        aria-label="Expand metadata panel"
+        title="Expand panel"
+      >
+        <ExpandIcon />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/discussion-layout/DiscussionLayout.tsx
+++ b/frontend/src/components/discussion-layout/DiscussionLayout.tsx
@@ -9,6 +9,7 @@ import { useSwipeable } from 'react-swipeable';
 import { DiscussionLayoutProvider } from '../../contexts/DiscussionLayoutContext';
 import { usePanelState } from '../../hooks/usePanelState';
 import { useBreakpoint } from '../../hooks/useBreakpoint';
+import { CollapsedMetadataBar } from './CollapsedMetadataBar';
 import '../../styles/discussion-layout.css';
 
 /**
@@ -23,6 +24,14 @@ interface DiscussionLayoutProps {
    * Use this when the unified sidebar already provides topic navigation.
    */
   hideSidebar?: boolean;
+  /**
+   * Whether user is currently composing (shows Preview icon in collapsed bar)
+   */
+  isComposing?: boolean;
+  /**
+   * Currently active metadata tab (for collapsed bar highlighting)
+   */
+  activeMetadataTab?: 'propositions' | 'commonGround' | 'bridging' | 'preview' | 'info';
 }
 
 /**
@@ -74,8 +83,18 @@ export function DiscussionLayout({
   centerPanel,
   rightPanel,
   hideSidebar = false,
+  isComposing = false,
+  activeMetadataTab = 'propositions',
 }: DiscussionLayoutProps) {
-  const { panelState, setPanelWidth, togglePanel, setActiveTopic } = usePanelState();
+  const {
+    panelState,
+    setPanelWidth,
+    togglePanel,
+    setActiveTopic,
+    expandRightPanelToTab,
+    requestedTab,
+    clearRequestedTab,
+  } = usePanelState();
   const breakpoint = useBreakpoint();
   const [isLeftPanelOverlayOpen, setIsLeftPanelOverlayOpen] = useState(false);
 
@@ -114,6 +133,11 @@ export function DiscussionLayout({
     delta: 50, // Minimum distance for swipe detection (pixels)
   });
 
+  // Handle expanding right panel
+  const handleExpandRightPanel = useCallback(() => {
+    togglePanel('right');
+  }, [togglePanel]);
+
   // Memoize context value to prevent unnecessary re-renders of consumers
   const contextValue = useMemo(
     () => ({
@@ -124,6 +148,9 @@ export function DiscussionLayout({
       isLeftPanelOverlayOpen,
       toggleLeftPanelOverlay: handleToggleLeftPanelOverlay,
       closeLeftPanelOverlay: handleCloseLeftPanelOverlay,
+      expandRightPanelToTab,
+      requestedTab,
+      clearRequestedTab,
     }),
     [
       panelState,
@@ -133,6 +160,9 @@ export function DiscussionLayout({
       isLeftPanelOverlayOpen,
       handleToggleLeftPanelOverlay,
       handleCloseLeftPanelOverlay,
+      expandRightPanelToTab,
+      requestedTab,
+      clearRequestedTab,
     ],
   );
 
@@ -150,6 +180,7 @@ export function DiscussionLayout({
         data-testid="discussion-layout"
         data-breakpoint={breakpoint}
         data-panels={panelCount}
+        data-right-collapsed={panelState.isRightPanelCollapsed ? 'true' : undefined}
         style={
           {
             '--left-panel-width': `${panelState.leftPanelWidth}px`,
@@ -195,16 +226,31 @@ export function DiscussionLayout({
           {centerPanel}
         </main>
 
-        {/* Right Panel - Metadata */}
-        <aside
-          className={`discussion-layout__panel discussion-layout__panel--right ${
-            panelState.isRightPanelCollapsed ? 'discussion-layout__panel--collapsed' : ''
-          }`}
-          role="complementary"
-          aria-label="Discussion metadata and analysis"
-        >
-          {rightPanel}
-        </aside>
+        {/* Right Panel - Metadata (or Collapsed Bar) */}
+        {panelState.isRightPanelCollapsed && breakpoint === 'desktop' ? (
+          <aside
+            className="discussion-layout__panel discussion-layout__panel--right discussion-layout__panel--collapsed-bar"
+            role="complementary"
+            aria-label="Discussion metadata shortcuts"
+          >
+            <CollapsedMetadataBar
+              onExpandToTab={expandRightPanelToTab}
+              onExpand={handleExpandRightPanel}
+              isComposing={isComposing}
+              activeTab={activeMetadataTab}
+            />
+          </aside>
+        ) : (
+          <aside
+            className={`discussion-layout__panel discussion-layout__panel--right ${
+              panelState.isRightPanelCollapsed ? 'discussion-layout__panel--collapsed' : ''
+            }`}
+            role="complementary"
+            aria-label="Discussion metadata and analysis"
+          >
+            {rightPanel}
+          </aside>
+        )}
       </div>
     </DiscussionLayoutProvider>
   );

--- a/frontend/src/components/discussion-layout/MetadataPanel.tsx
+++ b/frontend/src/components/discussion-layout/MetadataPanel.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import CommonGroundSummaryPanel from '../common-ground/CommonGroundSummaryPanel';
 import BridgingSuggestionsSection from '../common-ground/BridgingSuggestionsSection';
 import { PropositionList, type PropositionItem } from '../common-ground/PropositionList';
@@ -11,6 +11,7 @@ import { PreviewFeedbackPanel } from '../feedback/PreviewFeedbackPanel';
 import { TopicStatusActions } from '../topics/TopicStatusActions';
 import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { useWebSocket } from '../../hooks/useWebSocket';
+import { useDiscussionLayoutSafe } from '../../contexts/DiscussionLayoutContext';
 import type { Topic } from '../../types/topic';
 import { useAuthContext } from '../../contexts/AuthContext';
 import type { CommonGroundAnalysis, BridgingSuggestionsResponse } from '../../types/common-ground';
@@ -65,6 +66,10 @@ export interface MetadataPanelProps {
   height?: number;
   /** CSS class name */
   className?: string;
+  /** Callback when active tab changes (for parent state sync) */
+  onActiveTabChange?: (tab: MetadataPanelTab) => void;
+  /** Whether panel can be collapsed (shows collapse toggle) */
+  collapsible?: boolean;
 }
 
 /**
@@ -93,8 +98,14 @@ export function MetadataPanel({
   isComposing = false,
   height: _height,
   className = '',
+  onActiveTabChange,
+  collapsible = true,
 }: MetadataPanelProps) {
   const [activeTab, setActiveTab] = useState<MetadataPanelTab>('propositions');
+
+  // Get layout context for collapse functionality and external tab requests
+  // Use the safe version that returns null if outside provider (e.g., in tests)
+  const layoutContext = useDiscussionLayoutSafe();
   const [highlightedPropositionId, setHighlightedPropositionId] = useState<string | null>(null);
   const [expandedSections, setExpandedSections] = useState<Set<MetadataPanelTab>>(
     new Set(['propositions']),
@@ -156,10 +167,35 @@ export function MetadataPanel({
     }
   }, [isComposing, activeTab]);
 
+  // Handle external tab requests from collapsed bar
+  useEffect(() => {
+    if (layoutContext?.requestedTab) {
+      // Schedule state update asynchronously to avoid cascading renders
+      const tab = layoutContext.requestedTab;
+      setTimeout(() => {
+        setActiveTab(tab);
+        onTabActivate?.(tab);
+        onActiveTabChange?.(tab);
+      }, 0);
+      // Clear the request after handling
+      layoutContext.clearRequestedTab?.();
+    }
+  }, [layoutContext?.requestedTab, onTabActivate, onActiveTabChange, layoutContext]);
+
+  // Handle collapse toggle
+  const handleCollapseToggle = useCallback(() => {
+    if (layoutContext?.togglePanel) {
+      layoutContext.togglePanel('right');
+    }
+  }, [layoutContext]);
+
   const handleTabClick = (tab: MetadataPanelTab) => {
     setActiveTab(tab);
     if (onTabActivate) {
       onTabActivate(tab);
+    }
+    if (onActiveTabChange) {
+      onActiveTabChange(tab);
     }
   };
 
@@ -346,7 +382,32 @@ export function MetadataPanel({
     <div className={`metadata-panel flex flex-col h-full ${className}`}>
       {/* Tab Header */}
       <div className="flex-shrink-0 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
-        <div className="flex" role="tablist" aria-label="Discussion metadata">
+        <div className="flex items-center" role="tablist" aria-label="Discussion metadata">
+          {/* Collapse Toggle (when collapsible) */}
+          {collapsible && layoutContext && (
+            <button
+              type="button"
+              onClick={handleCollapseToggle}
+              className="flex-shrink-0 w-10 h-full flex items-center justify-center text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors border-r border-gray-200 dark:border-gray-700"
+              aria-label="Collapse metadata panel"
+              title="Collapse panel"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 5l7 7-7 7"
+                />
+              </svg>
+            </button>
+          )}
           <button
             type="button"
             role="tab"

--- a/frontend/src/components/responses/LightweightReplyComposer/CitationInput.tsx
+++ b/frontend/src/components/responses/LightweightReplyComposer/CitationInput.tsx
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Citation Input
+ *
+ * Inline URL input for adding citations/sources to a reply.
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+
+export interface CitationInputProps {
+  onAdd: (url: string) => void;
+  onCancel: () => void;
+  existingCitations: string[];
+}
+
+export function CitationInput({ onAdd, onCancel, existingCitations }: CitationInputProps) {
+  const [url, setUrl] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus on mount
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const validateAndAdd = useCallback(() => {
+    const trimmedUrl = url.trim();
+
+    if (!trimmedUrl) {
+      setError('Please enter a URL');
+      return;
+    }
+
+    // Basic URL validation
+    try {
+      new URL(trimmedUrl);
+    } catch {
+      setError('Please enter a valid URL (including https://)');
+      return;
+    }
+
+    // Check for duplicates
+    if (existingCitations.includes(trimmedUrl)) {
+      setError('This citation has already been added');
+      return;
+    }
+
+    onAdd(trimmedUrl);
+    setUrl('');
+    setError(null);
+  }, [url, existingCitations, onAdd]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        validateAndAdd();
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      }
+    },
+    [validateAndAdd, onCancel],
+  );
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2">
+        <input
+          ref={inputRef}
+          type="url"
+          value={url}
+          onChange={(e) => {
+            setUrl(e.target.value);
+            setError(null);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder="https://example.com/source"
+          className={`flex-1 px-2 py-1 text-xs rounded border ${
+            error ? 'border-red-300 dark:border-red-600' : 'border-gray-300 dark:border-gray-600'
+          } bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-primary-500`}
+          aria-invalid={!!error}
+          aria-describedby={error ? 'citation-error' : undefined}
+        />
+        <button
+          type="button"
+          onClick={validateAndAdd}
+          className="px-2 py-1 text-xs font-medium text-white bg-primary-600 hover:bg-primary-700 rounded transition-colors"
+        >
+          Add
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-2 py-1 text-xs text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200"
+          aria-label="Cancel adding citation"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+      {error && (
+        <p id="citation-error" className="text-[10px] text-red-600 dark:text-red-400">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/responses/LightweightReplyComposer/CollapsedPlaceholder.tsx
+++ b/frontend/src/components/responses/LightweightReplyComposer/CollapsedPlaceholder.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Collapsed Placeholder for Lightweight Reply Composer
+ *
+ * A compact, single-line placeholder that expands into the full composer
+ * when clicked. Shows "Reply to {name}..." or "Write a reply..." with
+ * an arrow icon.
+ */
+
+export interface CollapsedPlaceholderProps {
+  /** Author name to display (e.g., "Reply to Alice...") */
+  authorName?: string;
+  /** Click handler to expand the composer */
+  onClick: () => void;
+}
+
+export function CollapsedPlaceholder({ authorName, onClick }: CollapsedPlaceholderProps) {
+  const placeholderText = authorName ? `Reply to ${authorName}...` : 'Write a reply...';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full flex items-center gap-3 px-4 py-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-400 dark:hover:border-gray-500 transition-colors text-left group"
+      aria-label={placeholderText}
+    >
+      {/* Reply icon */}
+      <svg
+        className="w-4 h-4 text-gray-400 dark:text-gray-500 flex-shrink-0"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"
+        />
+      </svg>
+
+      {/* Placeholder text */}
+      <span className="flex-1 text-sm text-gray-500 dark:text-gray-400 truncate">
+        {placeholderText}
+      </span>
+
+      {/* Arrow indicator */}
+      <svg
+        className="w-4 h-4 text-gray-400 dark:text-gray-500 flex-shrink-0 group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+      </svg>
+    </button>
+  );
+}

--- a/frontend/src/components/responses/LightweightReplyComposer/ComposerToolbar.tsx
+++ b/frontend/src/components/responses/LightweightReplyComposer/ComposerToolbar.tsx
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Composer Toolbar
+ *
+ * Compact toolbar with Citation, Options, and Post buttons.
+ * Shows feedback status indicator when preview feedback is active.
+ */
+
+import Button from '../../ui/Button';
+
+export interface ComposerToolbarProps {
+  onCitationClick: () => void;
+  onOptionsClick: () => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  isSubmitting: boolean;
+  isValid: boolean;
+  feedbackStatus: 'idle' | 'loading' | 'ready' | 'warning';
+  hasCitations: boolean;
+  hasOptions: boolean;
+}
+
+export function ComposerToolbar({
+  onCitationClick,
+  onOptionsClick,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+  isValid,
+  feedbackStatus,
+  hasCitations,
+  hasOptions,
+}: ComposerToolbarProps) {
+  return (
+    <div className="flex items-center justify-between gap-2 px-3 py-2 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
+      {/* Left side: action buttons */}
+      <div className="flex items-center gap-1">
+        {/* Citation button */}
+        <button
+          type="button"
+          onClick={onCitationClick}
+          className={`flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors ${
+            hasCitations ? 'text-blue-600 dark:text-blue-400' : 'text-gray-600 dark:text-gray-400'
+          }`}
+          aria-label="Add citation"
+          title="Add citation (URL)"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+            />
+          </svg>
+          <span className="hidden sm:inline">Citation</span>
+          {hasCitations && <span className="text-[10px]">✓</span>}
+        </button>
+
+        {/* Options button */}
+        <button
+          type="button"
+          onClick={onOptionsClick}
+          className={`flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors ${
+            hasOptions ? 'text-blue-600 dark:text-blue-400' : 'text-gray-600 dark:text-gray-400'
+          }`}
+          aria-label="Response options"
+          title="Response options (opinion/factual)"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+            />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+            />
+          </svg>
+          <span className="hidden sm:inline">Options</span>
+          {hasOptions && <span className="text-[10px]">✓</span>}
+        </button>
+
+        {/* Feedback indicator */}
+        {feedbackStatus !== 'idle' && (
+          <div className="ml-2 flex items-center gap-1">
+            {feedbackStatus === 'loading' && (
+              <div
+                className="w-3 h-3 border-2 border-gray-300 dark:border-gray-600 border-t-primary-500 rounded-full animate-spin"
+                aria-label="Analyzing content"
+              />
+            )}
+            {feedbackStatus === 'ready' && (
+              <span className="text-green-500" title="Ready to post">
+                <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </span>
+            )}
+            {feedbackStatus === 'warning' && (
+              <span className="text-amber-500" title="Review feedback">
+                <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+                  <path
+                    fillRule="evenodd"
+                    d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Right side: cancel and submit */}
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onCancel}
+          disabled={isSubmitting}
+          className="text-xs py-1 px-2"
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          size="sm"
+          onClick={onSubmit}
+          disabled={!isValid || isSubmitting}
+          isLoading={isSubmitting}
+          className="text-xs py-1 px-3"
+        >
+          Post
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/responses/LightweightReplyComposer/ExpandedComposer.tsx
+++ b/frontend/src/components/responses/LightweightReplyComposer/ExpandedComposer.tsx
@@ -1,0 +1,263 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Expanded Composer for Lightweight Reply
+ *
+ * Full composer with auto-grow textarea and toolbar containing
+ * Citation, Options, and Post buttons.
+ */
+
+import { forwardRef, useState, useEffect, useCallback } from 'react';
+import type { PreviewFeedbackItem } from '../../../lib/feedback-api';
+import { useHybridPreviewFeedback } from '../../../hooks/useHybridPreviewFeedback';
+import { ComposerToolbar } from './ComposerToolbar';
+import { CitationInput } from './CitationInput';
+import { OptionsPopover } from './OptionsPopover';
+
+export interface ExpandedComposerProps {
+  content: string;
+  onContentChange: (content: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  onBlur: () => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  isSubmitting: boolean;
+  error: string | null;
+  minLength: number;
+  maxLength: number;
+  topicId?: string;
+  parentId: string;
+  onPreviewFeedbackChange?: (
+    feedback: PreviewFeedbackItem[],
+    readyToPost: boolean,
+    summary: string,
+    isLoading?: boolean,
+    error?: string | null,
+  ) => void;
+}
+
+export const ExpandedComposer = forwardRef<HTMLTextAreaElement, ExpandedComposerProps>(
+  function ExpandedComposer(
+    {
+      content,
+      onContentChange,
+      onSubmit,
+      onCancel,
+      onBlur,
+      onKeyDown,
+      isSubmitting,
+      error,
+      minLength,
+      maxLength,
+      topicId,
+      parentId: _parentId,
+      onPreviewFeedbackChange,
+    },
+    ref,
+  ) {
+    const [showCitationInput, setShowCitationInput] = useState(false);
+    const [showOptions, setShowOptions] = useState(false);
+    const [citations, setCitations] = useState<string[]>([]);
+    const [containsOpinion, setContainsOpinion] = useState(false);
+    const [containsFactualClaims, setContainsFactualClaims] = useState(false);
+
+    // Preview feedback integration
+    const {
+      feedback: previewFeedback,
+      readyToPost,
+      isLoading: isPreviewLoading,
+      summary: previewSummary,
+      error: previewError,
+    } = useHybridPreviewFeedback(content, { topicId, enabled: content.length >= 20 });
+
+    // Notify parent of preview feedback changes
+    useEffect(() => {
+      if (onPreviewFeedbackChange) {
+        onPreviewFeedbackChange(
+          previewFeedback,
+          readyToPost ?? false,
+          previewSummary,
+          isPreviewLoading,
+          previewError,
+        );
+      }
+    }, [
+      previewFeedback,
+      readyToPost,
+      previewSummary,
+      isPreviewLoading,
+      previewError,
+      onPreviewFeedbackChange,
+    ]);
+
+    // Auto-resize textarea
+    const handleInput = useCallback(
+      (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        const textarea = e.target;
+        onContentChange(textarea.value);
+
+        // Reset height to auto to shrink if needed
+        textarea.style.height = 'auto';
+        // Set to scrollHeight to expand
+        textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`;
+      },
+      [onContentChange],
+    );
+
+    const handleAddCitation = useCallback((url: string) => {
+      setCitations((prev) => [...prev, url]);
+      setShowCitationInput(false);
+    }, []);
+
+    const handleRemoveCitation = useCallback((index: number) => {
+      setCitations((prev) => prev.filter((_, i) => i !== index));
+    }, []);
+
+    const characterCount = content.length;
+    const isValid = characterCount >= minLength && characterCount <= maxLength;
+    const showCharacterCount = characterCount >= maxLength * 0.8;
+
+    // Calculate if feedback indicator should show
+    const hasFeedbackIssues = previewFeedback.length > 0;
+    const feedbackStatus = isPreviewLoading
+      ? 'loading'
+      : hasFeedbackIssues
+        ? 'warning'
+        : content.length >= 20
+          ? 'ready'
+          : 'idle';
+
+    return (
+      <div
+        className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 overflow-hidden"
+        data-testid="expanded-composer"
+      >
+        {/* Textarea */}
+        <div className="relative">
+          <textarea
+            ref={ref}
+            value={content}
+            onChange={handleInput}
+            onBlur={onBlur}
+            onKeyDown={onKeyDown}
+            placeholder="Write your reply..."
+            className="w-full px-3 py-2.5 text-sm text-gray-900 dark:text-gray-100 bg-transparent resize-none focus:outline-none placeholder-gray-400 dark:placeholder-gray-500"
+            style={{ minHeight: '60px', maxHeight: '200px' }}
+            maxLength={maxLength}
+            disabled={isSubmitting}
+            aria-invalid={!!error}
+            aria-describedby={error ? 'composer-error' : undefined}
+          />
+        </div>
+
+        {/* Citations display */}
+        {citations.length > 0 && (
+          <div className="px-3 pb-2 space-y-1">
+            {citations.map((url, index) => (
+              <div
+                key={index}
+                className="flex items-center gap-2 text-xs bg-blue-50 dark:bg-blue-900/30 px-2 py-1 rounded"
+              >
+                <svg
+                  className="w-3 h-3 text-blue-500 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+                  />
+                </svg>
+                <span className="flex-1 truncate text-blue-700 dark:text-blue-300">{url}</span>
+                <button
+                  type="button"
+                  onClick={() => handleRemoveCitation(index)}
+                  className="text-gray-400 hover:text-red-500"
+                  aria-label={`Remove citation ${url}`}
+                >
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Citation input (inline) */}
+        {showCitationInput && (
+          <div className="px-3 pb-2">
+            <CitationInput
+              onAdd={handleAddCitation}
+              onCancel={() => setShowCitationInput(false)}
+              existingCitations={citations}
+            />
+          </div>
+        )}
+
+        {/* Error message */}
+        {error && (
+          <div className="px-3 pb-2">
+            <p id="composer-error" className="text-xs text-red-600 dark:text-red-400" role="alert">
+              {error}
+            </p>
+          </div>
+        )}
+
+        {/* Character count (only when close to limit) */}
+        {showCharacterCount && (
+          <div className="px-3 pb-1">
+            <span
+              className={`text-xs ${
+                characterCount > maxLength
+                  ? 'text-red-600 dark:text-red-400'
+                  : characterCount >= maxLength * 0.9
+                    ? 'text-amber-600 dark:text-amber-400'
+                    : 'text-gray-500'
+              }`}
+            >
+              {characterCount} / {maxLength}
+            </span>
+          </div>
+        )}
+
+        {/* Options popover */}
+        {showOptions && (
+          <div className="px-3 pb-2">
+            <OptionsPopover
+              containsOpinion={containsOpinion}
+              containsFactualClaims={containsFactualClaims}
+              onContainsOpinionChange={setContainsOpinion}
+              onContainsFactualClaimsChange={setContainsFactualClaims}
+              onClose={() => setShowOptions(false)}
+            />
+          </div>
+        )}
+
+        {/* Toolbar */}
+        <ComposerToolbar
+          onCitationClick={() => setShowCitationInput(!showCitationInput)}
+          onOptionsClick={() => setShowOptions(!showOptions)}
+          onSubmit={onSubmit}
+          onCancel={onCancel}
+          isSubmitting={isSubmitting}
+          isValid={isValid}
+          feedbackStatus={feedbackStatus}
+          hasCitations={citations.length > 0}
+          hasOptions={containsOpinion || containsFactualClaims}
+        />
+      </div>
+    );
+  },
+);

--- a/frontend/src/components/responses/LightweightReplyComposer/LightweightReplyComposer.tsx
+++ b/frontend/src/components/responses/LightweightReplyComposer/LightweightReplyComposer.tsx
@@ -1,0 +1,196 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Lightweight Reply Composer
+ *
+ * A compact, two-state reply composer inspired by Discord/Slack patterns.
+ * Collapsed state shows a simple placeholder (~40px), expanding on focus
+ * to reveal the full composer with auto-grow textarea and toolbar.
+ *
+ * @remarks
+ * **States**:
+ * - Collapsed: Single-line placeholder "Reply to {name}..." with arrow icon
+ * - Expanded: Auto-grow textarea + toolbar with Citation, Options, Post buttons
+ *
+ * **Key Behaviors**:
+ * - Click collapsed → expand + focus
+ * - Blur with empty → collapse
+ * - Submit success → collapse + clear
+ * - Escape → collapse (confirm if content exists)
+ * - Ctrl/Cmd+Enter → submit
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { CreateResponseRequest } from '../../../types/response';
+import type { PreviewFeedbackItem } from '../../../lib/feedback-api';
+import { CollapsedPlaceholder } from './CollapsedPlaceholder';
+import { ExpandedComposer } from './ExpandedComposer';
+
+export interface LightweightReplyComposerProps {
+  /** Parent response ID for threading */
+  parentId: string;
+  /** Author name to display in placeholder (e.g., "Reply to Alice...") */
+  authorName?: string;
+  /** Topic ID for preview feedback context */
+  topicId?: string;
+  /** Callback when response is submitted */
+  onSubmit: (response: CreateResponseRequest) => Promise<void>;
+  /** Callback when composer is cancelled/collapsed */
+  onCancel?: () => void;
+  /** Maximum character limit */
+  maxLength?: number;
+  /** Minimum character limit */
+  minLength?: number;
+  /** Callback for preview feedback changes (for right panel) */
+  onPreviewFeedbackChange?: (
+    feedback: PreviewFeedbackItem[],
+    readyToPost: boolean,
+    summary: string,
+    isLoading?: boolean,
+    error?: string | null,
+  ) => void;
+  /** Whether to auto-focus when expanded */
+  autoFocus?: boolean;
+  /** Start in expanded state */
+  defaultExpanded?: boolean;
+}
+
+export function LightweightReplyComposer({
+  parentId,
+  authorName,
+  topicId,
+  onSubmit,
+  onCancel,
+  maxLength = 10000,
+  minLength = 10,
+  onPreviewFeedbackChange,
+  autoFocus = false,
+  defaultExpanded = false,
+}: LightweightReplyComposerProps) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const [content, setContent] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-focus when expanding
+  useEffect(() => {
+    if (isExpanded && autoFocus && textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, [isExpanded, autoFocus]);
+
+  const handleExpand = useCallback(() => {
+    setIsExpanded(true);
+  }, []);
+
+  const handleCollapse = useCallback(
+    (force = false) => {
+      // Don't collapse if there's content (unless forced)
+      if (content.trim() && !force) {
+        return;
+      }
+      setIsExpanded(false);
+      setContent('');
+      setError(null);
+      onCancel?.();
+    },
+    [content, onCancel],
+  );
+
+  const handleBlur = useCallback(() => {
+    // Only collapse if empty
+    if (!content.trim()) {
+      // Small delay to allow click events on toolbar buttons
+      setTimeout(() => {
+        if (!content.trim()) {
+          handleCollapse(true);
+        }
+      }, 150);
+    }
+  }, [content, handleCollapse]);
+
+  // handleSubmit must be defined BEFORE handleKeyDown to satisfy exhaustive-deps
+  const handleSubmit = useCallback(async () => {
+    setError(null);
+
+    // Validation
+    if (content.length < minLength) {
+      setError(`Reply must be at least ${minLength} characters`);
+      return;
+    }
+
+    if (content.length > maxLength) {
+      setError(`Reply must not exceed ${maxLength} characters`);
+      return;
+    }
+
+    const response: CreateResponseRequest = {
+      content: content.trim(),
+      parentId,
+    };
+
+    try {
+      setIsSubmitting(true);
+      await onSubmit(response);
+      // Success: collapse and clear
+      setContent('');
+      setIsExpanded(false);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to submit reply');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [content, minLength, maxLength, parentId, onSubmit]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      // Escape to collapse
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        if (content.trim()) {
+          // Confirm before discarding content
+          if (window.confirm('Discard your reply?')) {
+            handleCollapse(true);
+          }
+        } else {
+          handleCollapse(true);
+        }
+      }
+
+      // Ctrl/Cmd + Enter to submit
+      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        handleSubmit();
+      }
+    },
+    [content, handleCollapse, handleSubmit],
+  );
+
+  if (!isExpanded) {
+    return <CollapsedPlaceholder authorName={authorName} onClick={handleExpand} />;
+  }
+
+  return (
+    <ExpandedComposer
+      ref={textareaRef}
+      content={content}
+      onContentChange={setContent}
+      onSubmit={handleSubmit}
+      onCancel={() => handleCollapse(true)}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
+      isSubmitting={isSubmitting}
+      error={error}
+      minLength={minLength}
+      maxLength={maxLength}
+      topicId={topicId}
+      onPreviewFeedbackChange={onPreviewFeedbackChange}
+      parentId={parentId}
+    />
+  );
+}

--- a/frontend/src/components/responses/LightweightReplyComposer/OptionsPopover.tsx
+++ b/frontend/src/components/responses/LightweightReplyComposer/OptionsPopover.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Options Popover
+ *
+ * Inline options panel for marking response as containing
+ * opinion or factual claims.
+ */
+
+export interface OptionsPopoverProps {
+  containsOpinion: boolean;
+  containsFactualClaims: boolean;
+  onContainsOpinionChange: (value: boolean) => void;
+  onContainsFactualClaimsChange: (value: boolean) => void;
+  onClose: () => void;
+}
+
+export function OptionsPopover({
+  containsOpinion,
+  containsFactualClaims,
+  onContainsOpinionChange,
+  onContainsFactualClaimsChange,
+  onClose,
+}: OptionsPopoverProps) {
+  return (
+    <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-md space-y-2">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-xs font-medium text-gray-700 dark:text-gray-300">Response Type</span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+          aria-label="Close options"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={containsOpinion}
+          onChange={(e) => onContainsOpinionChange(e.target.checked)}
+          className="w-3.5 h-3.5 rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500 dark:bg-gray-800"
+        />
+        <span className="text-xs text-gray-700 dark:text-gray-300">Contains my opinion</span>
+      </label>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={containsFactualClaims}
+          onChange={(e) => onContainsFactualClaimsChange(e.target.checked)}
+          className="w-3.5 h-3.5 rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500 dark:bg-gray-800"
+        />
+        <span className="text-xs text-gray-700 dark:text-gray-300">Contains factual claims</span>
+      </label>
+
+      <p className="text-[10px] text-gray-500 dark:text-gray-400 mt-1">
+        Marking these helps with fact-checking and discussion analysis.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/responses/LightweightReplyComposer/index.tsx
+++ b/frontend/src/components/responses/LightweightReplyComposer/index.tsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * LightweightReplyComposer
+ *
+ * A compact, two-state reply composer for inline replies.
+ * Collapsed state shows a placeholder, expanded state shows
+ * full composer with auto-grow textarea and toolbar.
+ *
+ * @example
+ * ```tsx
+ * <LightweightReplyComposer
+ *   parentId={response.id}
+ *   authorName={response.author.displayName}
+ *   topicId={discussionId}
+ *   onSubmit={handleReplySubmit}
+ *   onCancel={() => setShowReplyForm(false)}
+ *   autoFocus
+ * />
+ * ```
+ */
+
+export {
+  LightweightReplyComposer,
+  type LightweightReplyComposerProps,
+} from './LightweightReplyComposer';
+
+// Internal components (exported for testing)
+export { CollapsedPlaceholder, type CollapsedPlaceholderProps } from './CollapsedPlaceholder';
+export { ExpandedComposer, type ExpandedComposerProps } from './ExpandedComposer';
+export { ComposerToolbar, type ComposerToolbarProps } from './ComposerToolbar';
+export { OptionsPopover, type OptionsPopoverProps } from './OptionsPopover';
+export { CitationInput, type CitationInputProps } from './CitationInput';

--- a/frontend/src/components/responses/ResponseItem.tsx
+++ b/frontend/src/components/responses/ResponseItem.tsx
@@ -12,15 +12,28 @@
  * - Citations (if any)
  * - Edit indicator (if edited)
  * - Reply button and nested replies (Phase 5)
+ *
+ * @remarks
+ * **Compact Mode**: When `compact` is true, the component renders in a
+ * space-efficient format similar to Discord/Slack messages:
+ * - Smaller avatar (24px vs 40px)
+ * - Reduced padding
+ * - Inline name + timestamp
+ * - Hover-only actions on desktop (always visible on mobile for touch)
+ *
+ * **Message Grouping**: When `isGroupStart` is false, the header (avatar,
+ * name, time) is hidden, allowing consecutive messages from the same author
+ * to visually flow together.
  */
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
 import type { ResponseDetail } from '../../services/discussionService';
 import type { CreateResponseRequest } from '../../types/response';
 import type { PreviewFeedbackItem } from '../../lib/feedback-api';
 import ResponseComposer from './ResponseComposer';
+import { LightweightReplyComposer } from './LightweightReplyComposer';
 
 export interface ResponseItemProps {
   response: ResponseDetail;
@@ -39,6 +52,28 @@ export interface ResponseItemProps {
     isLoading?: boolean,
     error?: string | null,
   ) => void;
+  /** Enable compact display mode with smaller elements and hover actions */
+  compact?: boolean;
+  /** Whether this response starts a message group (show avatar/name/time) */
+  isGroupStart?: boolean;
+  /** Whether this response ends a message group (for styling purposes) */
+  isGroupEnd?: boolean;
+  /** Use lightweight reply composer (auto-enabled in compact mode) */
+  useLightweightComposer?: boolean;
+  /** Show visual threading lines for nested replies */
+  showThreadLines?: boolean;
+  /** Whether this is the last reply in its sibling group (affects line termination) */
+  isLastReply?: boolean;
+  /** Minimum number of replies before showing collapse button (default: 5) */
+  collapseThreshold?: number;
+  /** Number of replies to show when collapsed (default: 2) */
+  collapsedVisibleCount?: number;
+  /** Set of thread IDs that are currently expanded */
+  expandedThreads?: Set<string>;
+  /** Callback when a thread is expanded */
+  onThreadExpand?: (threadId: string) => void;
+  /** Callback when a thread is collapsed */
+  onThreadCollapse?: (threadId: string) => void;
 }
 
 export function ResponseItem({
@@ -49,7 +84,20 @@ export function ResponseItem({
   onReply,
   onReplySubmit,
   onPreviewFeedbackChange,
+  compact = false,
+  isGroupStart = true,
+  isGroupEnd: _isGroupEnd = true,
+  useLightweightComposer,
+  showThreadLines = false,
+  isLastReply = false,
+  collapseThreshold = 5,
+  collapsedVisibleCount = 2,
+  expandedThreads,
+  onThreadExpand,
+  onThreadCollapse,
 }: ResponseItemProps) {
+  // Use lightweight composer by default in compact mode
+  const shouldUseLightweightComposer = useLightweightComposer ?? compact;
   const [showReplyForm, setShowReplyForm] = useState(false);
 
   const handleReplyClick = () => {
@@ -86,67 +134,155 @@ export function ResponseItem({
   const visualDepth = Math.min(depth, maxDepth);
   const indentClass = visualDepth > 0 ? `ml-${Math.min(visualDepth * 4, 16)}` : '';
 
+  // Compact mode styling
+  const avatarSize = compact ? 'w-6 h-6 text-xs' : 'w-10 h-10';
+  const cardPadding = compact ? 'sm' : 'lg';
+  const contentMargin = compact ? 'mb-1' : 'mb-4';
+  const headerMargin = compact ? 'mb-1' : 'mb-3';
+
+  // Threading line configuration
+  const hasReplies = response.replies && response.replies.length > 0;
+  const showVerticalLine = showThreadLines && depth > 0;
+  const showBranchLine = showThreadLines && depth > 0;
+
+  // Thread collapse logic
+  const replyCount = response.replies?.length || 0;
+  const shouldShowCollapseButton = replyCount >= collapseThreshold;
+  const isThreadExpanded = expandedThreads?.has(response.id) ?? true;
+
+  const visibleReplies = useMemo(() => {
+    if (!response.replies || response.replies.length === 0) return [];
+    if (!shouldShowCollapseButton || isThreadExpanded) {
+      return response.replies;
+    }
+    // When collapsed, show first N and last reply
+    return response.replies.slice(0, collapsedVisibleCount);
+  }, [response.replies, shouldShowCollapseButton, isThreadExpanded, collapsedVisibleCount]);
+
+  const hiddenReplyCount = replyCount - visibleReplies.length;
+
+  const handleToggleThread = () => {
+    if (isThreadExpanded) {
+      onThreadCollapse?.(response.id);
+    } else {
+      onThreadExpand?.(response.id);
+    }
+  };
+
   return (
     <div
-      className={indentClass}
+      className={`${indentClass} group relative`}
       data-testid="response-item"
       data-response-id={response.id}
       data-parent-id={response.parentResponseId || undefined}
       data-depth={depth}
+      data-compact={compact}
     >
+      {/* Threading lines for nested replies */}
+      {showVerticalLine && (
+        <>
+          {/* Vertical connector line from parent thread */}
+          <div
+            className={`absolute left-0 w-0.5 bg-gray-200 dark:bg-gray-700 ${
+              isLastReply ? 'top-0 h-5' : 'top-0 bottom-0'
+            }`}
+            aria-hidden="true"
+            data-thread-line="vertical"
+          />
+          {/* Horizontal branch connecting to this response */}
+          {showBranchLine && (
+            <div
+              className="absolute left-0 top-5 w-4 h-0.5 bg-gray-200 dark:bg-gray-700"
+              aria-hidden="true"
+              data-thread-line="branch"
+            />
+          )}
+        </>
+      )}
       <Card
-        variant={depth === 0 ? 'elevated' : 'outlined'}
-        padding="lg"
-        className="transition-colors hover:bg-gray-50"
+        variant={depth === 0 && !compact ? 'elevated' : 'outlined'}
+        padding={cardPadding}
+        className={`transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 ${
+          compact ? 'py-2' : ''
+        } ${!isGroupStart && compact ? 'border-t-0 rounded-t-none -mt-px' : ''}`}
       >
-        {/* Header */}
-        <div className="flex items-start gap-3 mb-3">
-          {/* Avatar Placeholder */}
-          <div className="w-10 h-10 bg-blue-500 rounded-full flex items-center justify-center text-white font-semibold">
-            {response.author.displayName.charAt(0).toUpperCase()}
-          </div>
+        {/* Header - only shown at group start or in non-compact mode */}
+        {isGroupStart && (
+          <div className={`flex items-start gap-3 ${headerMargin}`}>
+            {/* Avatar */}
+            <div
+              className={`${avatarSize} bg-blue-500 rounded-full flex items-center justify-center text-white font-semibold flex-shrink-0`}
+            >
+              {response.author.displayName.charAt(0).toUpperCase()}
+            </div>
 
-          {/* Author and Timestamp */}
-          <div className="flex-1 min-w-0">
-            <div className="flex items-baseline gap-2 flex-wrap">
-              <span className="font-semibold text-gray-900 dark:text-gray-100">
-                {response.author.displayName}
-              </span>
-              <span className="text-sm text-gray-500">
-                <time dateTime={response.createdAt}>{formatDate(response.createdAt)}</time>
-              </span>
-              {/* Edit Indicator */}
-              {response.editCount > 0 && response.editedAt && (
-                <span className="text-sm text-gray-500 italic">
-                  (edited {formatDate(response.editedAt)})
+            {/* Author and Timestamp */}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-baseline gap-2 flex-wrap">
+                <span
+                  className={`font-semibold text-gray-900 dark:text-gray-100 ${compact ? 'text-sm' : ''}`}
+                >
+                  {response.author.displayName}
                 </span>
-              )}
+                {/* Compact: inline separator, Non-compact: on its own line */}
+                {compact && <span className="text-gray-400">·</span>}
+                <span className={`text-gray-500 ${compact ? 'text-xs' : 'text-sm'}`}>
+                  <time dateTime={response.createdAt}>{formatDate(response.createdAt)}</time>
+                </span>
+                {/* Edit Indicator */}
+                {response.editCount > 0 && response.editedAt && (
+                  <>
+                    {compact && <span className="text-gray-400">·</span>}
+                    <span className={`text-gray-500 italic ${compact ? 'text-xs' : 'text-sm'}`}>
+                      {compact ? 'edited' : `(edited ${formatDate(response.editedAt)})`}
+                    </span>
+                  </>
+                )}
+              </div>
             </div>
           </div>
-        </div>
+        )}
 
-        {/* Content */}
-        <div className="prose prose-sm max-w-none mb-4">
-          <p className="text-gray-800 dark:text-gray-200 whitespace-pre-wrap">{response.content}</p>
+        {/* Content - indented when not showing header to align with text above */}
+        <div
+          className={`prose prose-sm max-w-none ${contentMargin} ${
+            !isGroupStart && compact ? 'pl-9' : ''
+          }`}
+        >
+          <p
+            className={`text-gray-800 dark:text-gray-200 whitespace-pre-wrap ${compact ? 'text-sm' : ''}`}
+          >
+            {response.content}
+          </p>
         </div>
 
         {/* Citations */}
         {response.citations && response.citations.length > 0 && (
-          <div className="mb-4 p-3 bg-blue-50 rounded-md border border-blue-200">
-            <p className="text-sm font-medium text-gray-700 mb-2">Sources:</p>
+          <div
+            className={`${compact ? 'mb-2 p-2' : 'mb-4 p-3'} bg-blue-50 dark:bg-blue-900/30 rounded-md border border-blue-200 dark:border-blue-700 ${
+              !isGroupStart && compact ? 'ml-9' : ''
+            }`}
+          >
+            <p
+              className={`font-medium text-gray-700 dark:text-gray-300 ${compact ? 'text-xs mb-1' : 'text-sm mb-2'}`}
+            >
+              Sources:
+            </p>
             <ul className="space-y-1">
               {response.citations.map((citation) => (
-                <li key={citation.id} className="text-sm">
+                <li key={citation.id} className={compact ? 'text-xs' : 'text-sm'}>
                   <a
                     href={citation.originalUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-blue-600 hover:underline"
+                    className="text-blue-600 dark:text-blue-400 hover:underline"
                   >
                     {citation.title || citation.originalUrl}
                   </a>
                   {citation.validationStatus === 'BROKEN' && (
-                    <span className="ml-2 text-xs text-red-700">(broken link)</span>
+                    <span className="ml-2 text-xs text-red-700 dark:text-red-400">
+                      (broken link)
+                    </span>
                   )}
                 </li>
               ))}
@@ -154,17 +290,28 @@ export function ResponseItem({
           </div>
         )}
 
-        {/* Actions */}
-        <div className="flex items-center gap-4">
+        {/* Actions - hover-only in compact mode on desktop, always visible on mobile */}
+        <div
+          className={`flex items-center gap-4 ${
+            compact
+              ? `${!isGroupStart ? 'pl-9' : ''} mt-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-150`
+              : 'mt-4'
+          }`}
+        >
           {/* Reply Button (Phase 5) */}
           {showReplies && depth < maxDepth && (
             <Button
               variant="ghost"
               size="sm"
               onClick={handleReplyClick}
-              className="text-gray-600 dark:text-gray-400 hover:text-blue-600"
+              className={`text-gray-600 dark:text-gray-400 hover:text-blue-600 ${compact ? 'text-xs py-0.5 px-1.5' : ''}`}
             >
-              <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg
+                className={`${compact ? 'w-3 h-3' : 'w-4 h-4'} mr-1`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
@@ -182,28 +329,54 @@ export function ResponseItem({
 
         {/* Inline Reply Form */}
         {showReplyForm && (
-          <div className="mt-4" data-testid="reply-form">
-            <ResponseComposer
-              inline
-              parentId={response.id}
-              placeholder="Write your reply..."
-              minLength={10}
-              maxLength={10000}
-              onSubmit={handleReplySubmit}
-              onCancel={() => setShowReplyForm(false)}
-              showCancel
-              topicId={discussionId}
-              onPreviewFeedbackChange={onPreviewFeedbackChange}
-              showPreviewFeedbackInline={false}
-            />
+          <div
+            className={`mt-4 ${!isGroupStart && compact ? 'pl-9' : ''}`}
+            data-testid="reply-form"
+          >
+            {shouldUseLightweightComposer ? (
+              <LightweightReplyComposer
+                parentId={response.id}
+                authorName={response.author.displayName}
+                topicId={discussionId}
+                onSubmit={handleReplySubmit}
+                onCancel={() => setShowReplyForm(false)}
+                onPreviewFeedbackChange={onPreviewFeedbackChange}
+                minLength={10}
+                maxLength={10000}
+                autoFocus
+                defaultExpanded
+              />
+            ) : (
+              <ResponseComposer
+                inline
+                parentId={response.id}
+                placeholder="Write your reply..."
+                minLength={10}
+                maxLength={10000}
+                onSubmit={handleReplySubmit}
+                onCancel={() => setShowReplyForm(false)}
+                showCancel
+                topicId={discussionId}
+                onPreviewFeedbackChange={onPreviewFeedbackChange}
+                showPreviewFeedbackInline={false}
+              />
+            )}
           </div>
         )}
       </Card>
 
       {/* Nested Replies (Phase 5) */}
       {showReplies && response.replies && response.replies.length > 0 && (
-        <div className="mt-2 space-y-2">
-          {response.replies.map((reply) => (
+        <div className={`mt-2 space-y-2 ${showThreadLines ? 'relative' : ''}`}>
+          {/* Parent thread continuation line (when showing thread lines) */}
+          {showThreadLines && hasReplies && (
+            <div
+              className="absolute left-3 top-0 bottom-0 w-0.5 bg-gray-200 dark:bg-gray-700"
+              aria-hidden="true"
+              data-thread-line="parent-continuation"
+            />
+          )}
+          {visibleReplies.map((reply, index) => (
             <ResponseItem
               key={reply.id}
               response={reply}
@@ -213,8 +386,69 @@ export function ResponseItem({
               onReply={onReply}
               onReplySubmit={onReplySubmit}
               onPreviewFeedbackChange={onPreviewFeedbackChange}
+              compact={compact}
+              isGroupStart={true}
+              isGroupEnd={true}
+              useLightweightComposer={useLightweightComposer}
+              showThreadLines={showThreadLines}
+              isLastReply={
+                isThreadExpanded ? index === visibleReplies.length - 1 : false // Not last when collapsed (more hidden)
+              }
+              collapseThreshold={collapseThreshold}
+              collapsedVisibleCount={collapsedVisibleCount}
+              expandedThreads={expandedThreads}
+              onThreadExpand={onThreadExpand}
+              onThreadCollapse={onThreadCollapse}
             />
           ))}
+
+          {/* Thread collapse/expand button */}
+          {shouldShowCollapseButton && (
+            <button
+              type="button"
+              onClick={handleToggleThread}
+              className={`
+                flex items-center gap-2 py-2 px-3 ml-4
+                text-sm font-medium
+                text-blue-600 dark:text-blue-400
+                hover:text-blue-800 dark:hover:text-blue-300
+                hover:bg-blue-50 dark:hover:bg-blue-900/20
+                rounded-md transition-colors
+                ${showThreadLines ? 'relative' : ''}
+              `}
+              aria-expanded={isThreadExpanded}
+              data-testid="thread-collapse-button"
+            >
+              {/* Thread line connector for button */}
+              {showThreadLines && !isThreadExpanded && (
+                <div
+                  className="absolute left-0 top-1/2 -translate-y-1/2 w-4 h-0.5 bg-gray-200 dark:bg-gray-700"
+                  aria-hidden="true"
+                />
+              )}
+              <svg
+                className={`w-4 h-4 transition-transform ${isThreadExpanded ? 'rotate-90' : ''}`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 5l7 7-7 7"
+                />
+              </svg>
+              {isThreadExpanded ? (
+                <>Hide {hiddenReplyCount > 0 ? `${hiddenReplyCount} ` : ''}replies</>
+              ) : (
+                <>
+                  View {hiddenReplyCount} more {hiddenReplyCount === 1 ? 'reply' : 'replies'}
+                </>
+              )}
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/responses/ResponseList.tsx
+++ b/frontend/src/components/responses/ResponseList.tsx
@@ -9,6 +9,15 @@
  * Displays all responses for a discussion in chronological order
  * Uses virtual scrolling for efficient rendering of 500+ responses
  * Supports threading display for nested replies (Phase 5)
+ *
+ * @remarks
+ * **Compact Mode**: When enabled, responses are grouped by author (messages
+ * from the same author within 5 minutes appear as a visual group) and
+ * rendered in a smaller format with hover-only actions.
+ *
+ * **Message Grouping**: Uses `groupResponses` utility to identify consecutive
+ * messages from the same author, enabling the Discord/Slack-like collapsed
+ * header pattern where only the first message in a group shows avatar/name/time.
  */
 
 import { useMemo } from 'react';
@@ -17,6 +26,8 @@ import { useResponses } from '../../hooks/useResponses';
 import Card from '../ui/Card';
 import type { CreateResponseRequest } from '../../types/response';
 import type { PreviewFeedbackItem } from '../../lib/feedback-api';
+import { groupResponses, type GroupedResponse } from '../../lib/groupResponses';
+import type { ResponseDetail } from '../../services/discussionService';
 import { ResponseItem } from './ResponseItem';
 
 export interface ResponseListProps {
@@ -24,7 +35,7 @@ export interface ResponseListProps {
   enableThreading?: boolean;
   /** Height of the list container in pixels (for virtual scrolling) */
   height?: number;
-  /** Height of each response item in pixels */
+  /** Height of each response item in pixels (auto-adjusted for compact mode) */
   itemHeight?: number;
   /** Map of highlighted response IDs (for proposition interaction) */
   highlightedResponseIds?: Set<string>;
@@ -38,16 +49,33 @@ export interface ResponseListProps {
     isLoading?: boolean,
     error?: string | null,
   ) => void;
+  /** Enable compact mode with message grouping and hover actions */
+  compact?: boolean;
+}
+
+/** Default item heights for different modes */
+const DEFAULT_ITEM_HEIGHT = 220;
+const COMPACT_ITEM_HEIGHT = 80;
+
+/**
+ * Adapter to make ResponseDetail compatible with GroupableResponse
+ * ResponseDetail has author.id but our utility expects author.id directly
+ */
+function adaptResponseForGrouping(response: ResponseDetail): ResponseDetail & {
+  author: { id: string; displayName: string };
+} {
+  return response as ResponseDetail & { author: { id: string; displayName: string } };
 }
 
 export function ResponseList({
   discussionId,
   enableThreading = false,
   height = 600,
-  itemHeight = 220,
+  itemHeight,
   highlightedResponseIds = new Set(),
   onReplySubmit,
   onPreviewFeedbackChange,
+  compact = false,
 }: ResponseListProps) {
   const {
     data: responses,
@@ -56,6 +84,22 @@ export function ResponseList({
   } = useResponses(discussionId, {
     buildThreadTree: enableThreading,
   });
+
+  // Calculate effective item height based on compact mode
+  const effectiveItemHeight = itemHeight ?? (compact ? COMPACT_ITEM_HEIGHT : DEFAULT_ITEM_HEIGHT);
+
+  // Apply message grouping when responses are available
+  // CRITICAL: This useMemo must be called unconditionally to maintain hook order
+  const groupedResponses = useMemo<GroupedResponse<ResponseDetail>[]>(() => {
+    if (!responses || responses.length === 0) {
+      return [];
+    }
+    // Group responses by author within 5-minute windows
+    return groupResponses(responses.map(adaptResponseForGrouping), {
+      timeThresholdMs: 5 * 60 * 1000, // 5 minutes
+      breakOnThreadChange: true,
+    });
+  }, [responses]);
 
   // CRITICAL: Memoize row renderer BEFORE any early returns to maintain consistent hook calls
   // React Error #310 occurs when hooks are called conditionally (different number between renders)
@@ -74,8 +118,10 @@ export function ResponseList({
         role: 'listitem';
       };
     }) => {
-      if (!responses || !responses[index]) return null;
-      const response = responses[index];
+      if (!groupedResponses || !groupedResponses[index]) return null;
+
+      const grouped = groupedResponses[index];
+      const response = grouped.response;
       const isHighlighted = highlightedResponseIds.has(response.id);
 
       return (
@@ -86,6 +132,7 @@ export function ResponseList({
                 ${isHighlighted ? 'ring-2 ring-primary-500 rounded-lg' : ''}
               `}
             data-response-id={response.id}
+            data-group-id={grouped.groupId}
           >
             <ResponseItem
               response={response}
@@ -93,6 +140,9 @@ export function ResponseList({
               showReplies={enableThreading}
               onReplySubmit={onReplySubmit}
               onPreviewFeedbackChange={onPreviewFeedbackChange}
+              compact={compact}
+              isGroupStart={grouped.isGroupStart}
+              isGroupEnd={grouped.isGroupEnd}
             />
           </div>
         </div>
@@ -101,31 +151,34 @@ export function ResponseList({
     RowComponent.displayName = 'ResponseRow';
     return RowComponent;
   }, [
-    responses,
+    groupedResponses,
     discussionId,
     enableThreading,
     highlightedResponseIds,
     onReplySubmit,
     onPreviewFeedbackChange,
+    compact,
   ]);
 
   if (isLoading) {
     return (
       <div className="space-y-4">
         {[1, 2, 3].map((i) => (
-          <Card key={i} variant="outlined" padding="lg">
+          <Card key={i} variant="outlined" padding={compact ? 'sm' : 'lg'}>
             <div className="animate-pulse">
               <div className="flex items-center gap-3 mb-3">
-                <div className="w-10 h-10 bg-gray-200 rounded-full"></div>
+                <div
+                  className={`${compact ? 'w-6 h-6' : 'w-10 h-10'} bg-gray-200 dark:bg-gray-700 rounded-full`}
+                />
                 <div className="flex-1">
-                  <div className="h-4 bg-gray-200 rounded w-32 mb-2"></div>
-                  <div className="h-3 bg-gray-200 rounded w-24"></div>
+                  <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-32 mb-2" />
+                  <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-24" />
                 </div>
               </div>
               <div className="space-y-2">
-                <div className="h-4 bg-gray-200 rounded"></div>
-                <div className="h-4 bg-gray-200 rounded"></div>
-                <div className="h-4 bg-gray-200 rounded w-3/4"></div>
+                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded" />
+                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded" />
+                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4" />
               </div>
             </div>
           </Card>
@@ -137,7 +190,7 @@ export function ResponseList({
   if (error) {
     return (
       <Card variant="elevated" padding="lg">
-        <div className="text-center text-red-700">
+        <div className="text-center text-red-700 dark:text-red-400">
           <p className="font-medium">Failed to load responses</p>
           <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">{error.message}</p>
         </div>
@@ -170,12 +223,12 @@ export function ResponseList({
   }
 
   return (
-    <div className="response-list" role="list" aria-label="Responses">
+    <div className="response-list" role="list" aria-label="Responses" data-compact={compact}>
       <List<Record<string, never>>
         defaultHeight={height}
-        rowCount={responses.length}
-        rowHeight={itemHeight}
-        overscanCount={3}
+        rowCount={groupedResponses.length}
+        rowHeight={effectiveItemHeight}
+        overscanCount={compact ? 5 : 3}
         rowComponent={Row}
         rowProps={{}}
       />

--- a/frontend/src/contexts/DiscussionLayoutContext.tsx
+++ b/frontend/src/contexts/DiscussionLayoutContext.tsx
@@ -28,6 +28,9 @@ export const DEFAULT_PANEL_STATE: PanelState = {
   activeTopic: null,
 };
 
+/** Metadata panel tab types (imported from MetadataPanel for type safety) */
+export type MetadataPanelTab = 'propositions' | 'commonGround' | 'bridging' | 'preview' | 'info';
+
 /**
  * Context value interface with state and actions
  */
@@ -42,6 +45,12 @@ interface DiscussionLayoutContextValue {
   toggleLeftPanelOverlay?: () => void;
   /** Close left panel overlay (tablet/mobile only) */
   closeLeftPanelOverlay?: () => void;
+  /** Expand right panel to a specific tab */
+  expandRightPanelToTab?: (tab: MetadataPanelTab) => void;
+  /** Currently requested tab to expand to (used for cross-component communication) */
+  requestedTab?: MetadataPanelTab | null;
+  /** Clear the requested tab after it's been handled */
+  clearRequestedTab?: () => void;
 }
 
 /**
@@ -59,6 +68,14 @@ export function useDiscussionLayout(): DiscussionLayoutContextValue {
     throw new Error('useDiscussionLayout must be used within DiscussionLayoutProvider');
   }
   return context;
+}
+
+/**
+ * Safe hook to access discussion layout context (returns null if not in provider)
+ * Use this in components that may be rendered outside the DiscussionLayoutProvider
+ */
+export function useDiscussionLayoutSafe(): DiscussionLayoutContextValue | null {
+  return useContext(DiscussionLayoutContext);
 }
 
 /**

--- a/frontend/src/hooks/usePanelState.ts
+++ b/frontend/src/hooks/usePanelState.ts
@@ -4,7 +4,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import type { PanelState } from '../contexts/DiscussionLayoutContext';
+import type { PanelState, MetadataPanelTab } from '../contexts/DiscussionLayoutContext';
 import { DEFAULT_PANEL_STATE } from '../contexts/DiscussionLayoutContext';
 
 const STORAGE_KEY = 'discussion-panel-state';
@@ -86,10 +86,34 @@ export function usePanelState() {
     }));
   }, []);
 
+  // Track requested tab for cross-component communication
+  const [requestedTab, setRequestedTab] = useState<MetadataPanelTab | null>(null);
+
+  /**
+   * Expand right panel and request a specific tab
+   */
+  const expandRightPanelToTab = useCallback((tab: MetadataPanelTab) => {
+    setPanelStateInternal((prev) => ({
+      ...prev,
+      isRightPanelCollapsed: false,
+    }));
+    setRequestedTab(tab);
+  }, []);
+
+  /**
+   * Clear the requested tab after it's been handled
+   */
+  const clearRequestedTab = useCallback(() => {
+    setRequestedTab(null);
+  }, []);
+
   return {
     panelState,
     setPanelWidth,
     togglePanel,
     setActiveTopic,
+    expandRightPanelToTab,
+    requestedTab,
+    clearRequestedTab,
   };
 }

--- a/frontend/src/lib/groupResponses.ts
+++ b/frontend/src/lib/groupResponses.ts
@@ -1,0 +1,207 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Message Grouping Utility
+ *
+ * Groups consecutive messages from the same author within a configurable time
+ * threshold, enabling compact rendering where only the first message in a group
+ * shows avatar/name/timestamp (similar to Discord/Slack patterns).
+ *
+ * @remarks
+ * - Groups are broken when author changes or time threshold is exceeded
+ * - Each grouped response includes flags for UI rendering decisions
+ * - Works with any response type that has author.id and createdAt fields
+ */
+
+/**
+ * Minimum interface required for grouping responses
+ */
+export interface GroupableResponse {
+  id: string;
+  author: {
+    id: string;
+    displayName: string;
+  };
+  createdAt: string;
+  parentResponseId?: string | null;
+}
+
+/**
+ * A response wrapped with grouping metadata
+ */
+export interface GroupedResponse<T extends GroupableResponse> {
+  /** The original response object */
+  response: T;
+  /** Whether this response starts a new group (show avatar/name/time) */
+  isGroupStart: boolean;
+  /** Whether this response ends a group (for future styling like rounded corners) */
+  isGroupEnd: boolean;
+  /** Unique identifier for this group (first response ID in group) */
+  groupId: string;
+  /** Position within the group (0-indexed) */
+  groupIndex: number;
+  /** Total responses in this group */
+  groupSize: number;
+}
+
+/**
+ * Configuration options for grouping
+ */
+export interface GroupResponsesConfig {
+  /**
+   * Time threshold in milliseconds for grouping consecutive messages
+   * from the same author. Messages beyond this threshold start a new group.
+   * @default 300000 (5 minutes)
+   */
+  timeThresholdMs?: number;
+
+  /**
+   * Whether to break groups at thread boundaries (different parent IDs)
+   * @default true
+   */
+  breakOnThreadChange?: boolean;
+}
+
+const DEFAULT_TIME_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Groups consecutive responses from the same author within a time threshold
+ *
+ * @example
+ * ```typescript
+ * const responses = [
+ *   { id: '1', author: { id: 'alice', displayName: 'Alice' }, createdAt: '2025-01-01T10:00:00Z' },
+ *   { id: '2', author: { id: 'alice', displayName: 'Alice' }, createdAt: '2025-01-01T10:01:00Z' },
+ *   { id: '3', author: { id: 'bob', displayName: 'Bob' }, createdAt: '2025-01-01T10:02:00Z' },
+ * ];
+ *
+ * const grouped = groupResponses(responses);
+ * // Result:
+ * // - Response 1: isGroupStart=true, isGroupEnd=false, groupSize=2
+ * // - Response 2: isGroupStart=false, isGroupEnd=true, groupSize=2
+ * // - Response 3: isGroupStart=true, isGroupEnd=true, groupSize=1
+ * ```
+ *
+ * @param responses - Array of responses to group (must be in chronological order)
+ * @param config - Optional configuration for grouping behavior
+ * @returns Array of grouped responses with metadata
+ */
+export function groupResponses<T extends GroupableResponse>(
+  responses: T[],
+  config: GroupResponsesConfig = {},
+): GroupedResponse<T>[] {
+  const { timeThresholdMs = DEFAULT_TIME_THRESHOLD_MS, breakOnThreadChange = true } = config;
+
+  if (responses.length === 0) {
+    return [];
+  }
+
+  // First pass: assign groups
+  const groups: { responses: T[]; groupId: string }[] = [];
+  let currentGroup: { responses: T[]; groupId: string } | null = null;
+
+  for (const response of responses) {
+    const shouldStartNewGroup = shouldBreakGroup(
+      currentGroup?.responses[currentGroup.responses.length - 1],
+      response,
+      timeThresholdMs,
+      breakOnThreadChange,
+    );
+
+    if (shouldStartNewGroup || !currentGroup) {
+      currentGroup = { responses: [response], groupId: response.id };
+      groups.push(currentGroup);
+    } else {
+      currentGroup.responses.push(response);
+    }
+  }
+
+  // Second pass: build result with metadata
+  const result: GroupedResponse<T>[] = [];
+
+  for (const group of groups) {
+    const groupSize = group.responses.length;
+
+    group.responses.forEach((response, i) => {
+      result.push({
+        response,
+        isGroupStart: i === 0,
+        isGroupEnd: i === groupSize - 1,
+        groupId: group.groupId,
+        groupIndex: i,
+        groupSize,
+      });
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Determines if a new group should start based on author, time, and thread
+ */
+function shouldBreakGroup<T extends GroupableResponse>(
+  previous: T | undefined,
+  current: T,
+  timeThresholdMs: number,
+  breakOnThreadChange: boolean,
+): boolean {
+  if (!previous) {
+    return true;
+  }
+
+  // Different author
+  if (previous.author.id !== current.author.id) {
+    return true;
+  }
+
+  // Time threshold exceeded
+  const prevTime = new Date(previous.createdAt).getTime();
+  const currTime = new Date(current.createdAt).getTime();
+  if (currTime - prevTime > timeThresholdMs) {
+    return true;
+  }
+
+  // Different thread (parent response)
+  if (breakOnThreadChange && previous.parentResponseId !== current.parentResponseId) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Helper to check if a response should show full header (avatar/name/time)
+ */
+export function shouldShowHeader<T extends GroupableResponse>(
+  grouped: GroupedResponse<T>,
+): boolean {
+  return grouped.isGroupStart;
+}
+
+/**
+ * Helper to get group statistics for a set of grouped responses
+ */
+export function getGroupStats<T extends GroupableResponse>(
+  grouped: GroupedResponse<T>[],
+): { totalGroups: number; averageGroupSize: number; largestGroupSize: number } {
+  const groupIds = new Set(grouped.map((g) => g.groupId));
+  const totalGroups = groupIds.size;
+
+  if (totalGroups === 0) {
+    return { totalGroups: 0, averageGroupSize: 0, largestGroupSize: 0 };
+  }
+
+  const groupSizes = Array.from(groupIds).map(
+    (id) => grouped.find((g) => g.groupId === id)?.groupSize ?? 0,
+  );
+
+  return {
+    totalGroups,
+    averageGroupSize: grouped.length / totalGroups,
+    largestGroupSize: Math.max(...groupSizes),
+  };
+}

--- a/frontend/src/styles/discussion-layout.css
+++ b/frontend/src/styles/discussion-layout.css
@@ -71,6 +71,21 @@
   display: none;
 }
 
+/* Collapsed bar state - 48px wide icon bar */
+.discussion-layout__panel--right.discussion-layout__panel--collapsed-bar {
+  width: 48px;
+  min-width: 48px;
+  max-width: 48px;
+  padding: 0;
+  overflow: visible;
+  transition: width 300ms ease-in-out;
+}
+
+/* Grid adjustment for collapsed right panel */
+.discussion-layout[data-right-collapsed="true"] {
+  grid-template-columns: var(--left-panel-width, clamp(240px, 25vw, 320px)) 1fr 48px;
+}
+
 /* ==========================================================================
    Panel Resizer Styles
    ========================================================================== */

--- a/frontend/tests/unit/components/LightweightReplyComposer.spec.tsx
+++ b/frontend/tests/unit/components/LightweightReplyComposer.spec.tsx
@@ -1,0 +1,293 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  LightweightReplyComposer,
+  CollapsedPlaceholder,
+  CitationInput,
+  OptionsPopover,
+} from '../../../src/components/responses/LightweightReplyComposer';
+
+// Mock the useHybridPreviewFeedback hook
+vi.mock('../../../src/hooks/useHybridPreviewFeedback', () => ({
+  useHybridPreviewFeedback: vi.fn(() => ({
+    feedback: [],
+    readyToPost: true,
+    isLoading: false,
+    summary: '',
+    error: null,
+  })),
+}));
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createTestQueryClient();
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+describe('CollapsedPlaceholder', () => {
+  it('should render with author name', () => {
+    const onClick = vi.fn();
+    render(<CollapsedPlaceholder authorName="Alice" onClick={onClick} />);
+
+    expect(screen.getByText('Reply to Alice...')).toBeInTheDocument();
+  });
+
+  it('should render default text without author name', () => {
+    const onClick = vi.fn();
+    render(<CollapsedPlaceholder onClick={onClick} />);
+
+    expect(screen.getByText('Write a reply...')).toBeInTheDocument();
+  });
+
+  it('should call onClick when clicked', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<CollapsedPlaceholder authorName="Alice" onClick={onClick} />);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('CitationInput', () => {
+  it('should render input and buttons', () => {
+    const onAdd = vi.fn();
+    const onCancel = vi.fn();
+    render(<CitationInput onAdd={onAdd} onCancel={onCancel} existingCitations={[]} />);
+
+    expect(screen.getByPlaceholderText('https://example.com/source')).toBeInTheDocument();
+    expect(screen.getByText('Add')).toBeInTheDocument();
+  });
+
+  it('should validate URL and call onAdd', async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+    const onCancel = vi.fn();
+    render(<CitationInput onAdd={onAdd} onCancel={onCancel} existingCitations={[]} />);
+
+    const input = screen.getByPlaceholderText('https://example.com/source');
+    await user.type(input, 'https://example.com/article');
+    await user.click(screen.getByText('Add'));
+
+    expect(onAdd).toHaveBeenCalledWith('https://example.com/article');
+  });
+
+  it('should show error for invalid URL', async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+    const onCancel = vi.fn();
+    render(<CitationInput onAdd={onAdd} onCancel={onCancel} existingCitations={[]} />);
+
+    const input = screen.getByPlaceholderText('https://example.com/source');
+    await user.type(input, 'not-a-url');
+    await user.click(screen.getByText('Add'));
+
+    expect(screen.getByText('Please enter a valid URL (including https://)')).toBeInTheDocument();
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it('should show error for duplicate citation', async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <CitationInput
+        onAdd={onAdd}
+        onCancel={onCancel}
+        existingCitations={['https://example.com/existing']}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText('https://example.com/source');
+    await user.type(input, 'https://example.com/existing');
+    await user.click(screen.getByText('Add'));
+
+    expect(screen.getByText('This citation has already been added')).toBeInTheDocument();
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+});
+
+describe('OptionsPopover', () => {
+  it('should render checkboxes', () => {
+    const onClose = vi.fn();
+    render(
+      <OptionsPopover
+        containsOpinion={false}
+        containsFactualClaims={false}
+        onContainsOpinionChange={vi.fn()}
+        onContainsFactualClaimsChange={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    expect(screen.getByText('Contains my opinion')).toBeInTheDocument();
+    expect(screen.getByText('Contains factual claims')).toBeInTheDocument();
+  });
+
+  it('should call handlers when checkboxes change', async () => {
+    const user = userEvent.setup();
+    const onContainsOpinionChange = vi.fn();
+    const onContainsFactualClaimsChange = vi.fn();
+
+    render(
+      <OptionsPopover
+        containsOpinion={false}
+        containsFactualClaims={false}
+        onContainsOpinionChange={onContainsOpinionChange}
+        onContainsFactualClaimsChange={onContainsFactualClaimsChange}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const opinionCheckbox = screen.getByRole('checkbox', { name: /opinion/i });
+    await user.click(opinionCheckbox);
+
+    expect(onContainsOpinionChange).toHaveBeenCalledWith(true);
+  });
+});
+
+describe('LightweightReplyComposer', () => {
+  let mockOnSubmit: ReturnType<typeof vi.fn>;
+  let mockOnCancel: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockOnSubmit = vi.fn().mockResolvedValue(undefined);
+    mockOnCancel = vi.fn();
+  });
+
+  it('should render collapsed state by default', () => {
+    renderWithProviders(
+      <LightweightReplyComposer
+        parentId="parent-1"
+        authorName="Alice"
+        onSubmit={mockOnSubmit}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    expect(screen.getByText('Reply to Alice...')).toBeInTheDocument();
+  });
+
+  it('should expand when collapsed placeholder is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <LightweightReplyComposer
+        parentId="parent-1"
+        authorName="Alice"
+        onSubmit={mockOnSubmit}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /reply to alice/i }));
+
+    expect(screen.getByTestId('expanded-composer')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Write your reply...')).toBeInTheDocument();
+  });
+
+  it('should render expanded state when defaultExpanded is true', () => {
+    renderWithProviders(
+      <LightweightReplyComposer
+        parentId="parent-1"
+        onSubmit={mockOnSubmit}
+        onCancel={mockOnCancel}
+        defaultExpanded
+      />,
+    );
+
+    expect(screen.getByTestId('expanded-composer')).toBeInTheDocument();
+  });
+
+  it('should submit when Post button is clicked with valid content', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <LightweightReplyComposer
+        parentId="parent-1"
+        onSubmit={mockOnSubmit}
+        onCancel={mockOnCancel}
+        defaultExpanded
+        minLength={5}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText('Write your reply...');
+    await user.type(textarea, 'This is a valid reply');
+    await user.click(screen.getByText('Post'));
+
+    await waitFor(() => {
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        content: 'This is a valid reply',
+        parentId: 'parent-1',
+      });
+    });
+  });
+
+  it('should disable Post button when content is below minimum length', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <LightweightReplyComposer
+        parentId="parent-1"
+        onSubmit={mockOnSubmit}
+        onCancel={mockOnCancel}
+        defaultExpanded
+        minLength={10}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText('Write your reply...');
+    await user.type(textarea, 'Short');
+
+    const postButton = screen.getByText('Post');
+    expect(postButton).toBeDisabled();
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  it('should enable Post button when content meets minimum length', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <LightweightReplyComposer
+        parentId="parent-1"
+        onSubmit={mockOnSubmit}
+        onCancel={mockOnCancel}
+        defaultExpanded
+        minLength={10}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText('Write your reply...');
+    await user.type(textarea, 'This is long enough');
+
+    const postButton = screen.getByText('Post');
+    expect(postButton).not.toBeDisabled();
+  });
+
+  it('should call onCancel when Cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <LightweightReplyComposer
+        parentId="parent-1"
+        onSubmit={mockOnSubmit}
+        onCancel={mockOnCancel}
+        defaultExpanded
+      />,
+    );
+
+    await user.click(screen.getByText('Cancel'));
+
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/unit/lib/groupResponses.spec.ts
+++ b/frontend/tests/unit/lib/groupResponses.spec.ts
@@ -1,0 +1,306 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  groupResponses,
+  shouldShowHeader,
+  getGroupStats,
+  type GroupableResponse,
+  type GroupResponsesConfig as _GroupResponsesConfig,
+} from '../../../src/lib/groupResponses';
+
+/**
+ * Helper to create test responses
+ */
+function createResponse(
+  id: string,
+  authorId: string,
+  authorName: string,
+  createdAt: string,
+  parentResponseId?: string | null,
+): GroupableResponse {
+  return {
+    id,
+    author: { id: authorId, displayName: authorName },
+    createdAt,
+    parentResponseId,
+  };
+}
+
+describe('groupResponses', () => {
+  describe('basic grouping', () => {
+    it('should return empty array for empty input', () => {
+      const result = groupResponses([]);
+      expect(result).toEqual([]);
+    });
+
+    it('should wrap single response with group metadata', () => {
+      const responses = [createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z')];
+
+      const result = groupResponses(responses);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        response: responses[0],
+        isGroupStart: true,
+        isGroupEnd: true,
+        groupId: '1',
+        groupIndex: 0,
+        groupSize: 1,
+      });
+    });
+
+    it('should group consecutive messages from same author', () => {
+      const responses = [
+        createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z'),
+        createResponse('2', 'alice', 'Alice', '2025-01-01T10:01:00Z'),
+        createResponse('3', 'alice', 'Alice', '2025-01-01T10:02:00Z'),
+      ];
+
+      const result = groupResponses(responses);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].isGroupStart).toBe(true);
+      expect(result[0].isGroupEnd).toBe(false);
+      expect(result[0].groupSize).toBe(3);
+
+      expect(result[1].isGroupStart).toBe(false);
+      expect(result[1].isGroupEnd).toBe(false);
+      expect(result[1].groupSize).toBe(3);
+
+      expect(result[2].isGroupStart).toBe(false);
+      expect(result[2].isGroupEnd).toBe(true);
+      expect(result[2].groupSize).toBe(3);
+
+      // All should share same groupId
+      expect(result[0].groupId).toBe('1');
+      expect(result[1].groupId).toBe('1');
+      expect(result[2].groupId).toBe('1');
+    });
+
+    it('should break group when author changes', () => {
+      const responses = [
+        createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z'),
+        createResponse('2', 'alice', 'Alice', '2025-01-01T10:01:00Z'),
+        createResponse('3', 'bob', 'Bob', '2025-01-01T10:02:00Z'),
+        createResponse('4', 'bob', 'Bob', '2025-01-01T10:03:00Z'),
+      ];
+
+      const result = groupResponses(responses);
+
+      // Alice's group
+      expect(result[0].groupId).toBe('1');
+      expect(result[0].groupSize).toBe(2);
+      expect(result[1].groupId).toBe('1');
+
+      // Bob's group
+      expect(result[2].groupId).toBe('3');
+      expect(result[2].groupSize).toBe(2);
+      expect(result[3].groupId).toBe('3');
+    });
+
+    it('should correctly set groupIndex for each response', () => {
+      const responses = [
+        createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z'),
+        createResponse('2', 'alice', 'Alice', '2025-01-01T10:01:00Z'),
+        createResponse('3', 'alice', 'Alice', '2025-01-01T10:02:00Z'),
+      ];
+
+      const result = groupResponses(responses);
+
+      expect(result[0].groupIndex).toBe(0);
+      expect(result[1].groupIndex).toBe(1);
+      expect(result[2].groupIndex).toBe(2);
+    });
+  });
+
+  describe('time threshold', () => {
+    it('should break group when time threshold exceeded (default 5 minutes)', () => {
+      const responses = [
+        createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z'),
+        createResponse('2', 'alice', 'Alice', '2025-01-01T10:06:00Z'), // 6 minutes later
+      ];
+
+      const result = groupResponses(responses);
+
+      expect(result[0].groupId).toBe('1');
+      expect(result[0].groupSize).toBe(1);
+      expect(result[1].groupId).toBe('2');
+      expect(result[1].groupSize).toBe(1);
+    });
+
+    it('should keep in same group when within time threshold', () => {
+      const responses = [
+        createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z'),
+        createResponse('2', 'alice', 'Alice', '2025-01-01T10:04:59Z'), // 4:59 later (under 5 min)
+      ];
+
+      const result = groupResponses(responses);
+
+      expect(result[0].groupId).toBe('1');
+      expect(result[0].groupSize).toBe(2);
+      expect(result[1].groupId).toBe('1');
+    });
+
+    it('should respect custom time threshold', () => {
+      const responses = [
+        createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z'),
+        createResponse('2', 'alice', 'Alice', '2025-01-01T10:01:30Z'), // 1.5 minutes later
+      ];
+
+      // 1 minute threshold - should break
+      const result = groupResponses(responses, { timeThresholdMs: 60000 });
+
+      expect(result[0].groupId).toBe('1');
+      expect(result[0].groupSize).toBe(1);
+      expect(result[1].groupId).toBe('2');
+      expect(result[1].groupSize).toBe(1);
+    });
+  });
+
+  describe('thread boundaries', () => {
+    it('should break group when parent response changes (default behavior)', () => {
+      const responses = [
+        createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z', null),
+        createResponse('2', 'alice', 'Alice', '2025-01-01T10:01:00Z', 'parent-1'),
+      ];
+
+      const result = groupResponses(responses);
+
+      expect(result[0].groupId).toBe('1');
+      expect(result[1].groupId).toBe('2');
+    });
+
+    it('should keep in same group when same parent response', () => {
+      const responses = [
+        createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z', 'parent-1'),
+        createResponse('2', 'alice', 'Alice', '2025-01-01T10:01:00Z', 'parent-1'),
+      ];
+
+      const result = groupResponses(responses);
+
+      expect(result[0].groupId).toBe('1');
+      expect(result[1].groupId).toBe('1');
+      expect(result[0].groupSize).toBe(2);
+    });
+
+    it('should ignore thread boundaries when breakOnThreadChange is false', () => {
+      const responses = [
+        createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z', null),
+        createResponse('2', 'alice', 'Alice', '2025-01-01T10:01:00Z', 'parent-1'),
+      ];
+
+      const result = groupResponses(responses, { breakOnThreadChange: false });
+
+      expect(result[0].groupId).toBe('1');
+      expect(result[1].groupId).toBe('1');
+      expect(result[0].groupSize).toBe(2);
+    });
+  });
+
+  describe('complex scenarios', () => {
+    it('should handle alternating authors correctly', () => {
+      const responses = [
+        createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z'),
+        createResponse('2', 'bob', 'Bob', '2025-01-01T10:01:00Z'),
+        createResponse('3', 'alice', 'Alice', '2025-01-01T10:02:00Z'),
+        createResponse('4', 'bob', 'Bob', '2025-01-01T10:03:00Z'),
+      ];
+
+      const result = groupResponses(responses);
+
+      // Each response is its own group
+      expect(result[0].groupId).toBe('1');
+      expect(result[0].groupSize).toBe(1);
+      expect(result[1].groupId).toBe('2');
+      expect(result[1].groupSize).toBe(1);
+      expect(result[2].groupId).toBe('3');
+      expect(result[2].groupSize).toBe(1);
+      expect(result[3].groupId).toBe('4');
+      expect(result[3].groupSize).toBe(1);
+    });
+
+    it('should handle mixed grouping patterns', () => {
+      const responses = [
+        createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z'),
+        createResponse('2', 'alice', 'Alice', '2025-01-01T10:01:00Z'),
+        createResponse('3', 'bob', 'Bob', '2025-01-01T10:02:00Z'),
+        createResponse('4', 'alice', 'Alice', '2025-01-01T10:03:00Z'),
+        createResponse('5', 'alice', 'Alice', '2025-01-01T10:04:00Z'),
+        createResponse('6', 'alice', 'Alice', '2025-01-01T10:05:00Z'),
+      ];
+
+      const result = groupResponses(responses);
+
+      // Alice group 1: responses 1-2
+      expect(result[0].groupSize).toBe(2);
+      expect(result[1].groupSize).toBe(2);
+
+      // Bob group: response 3
+      expect(result[2].groupSize).toBe(1);
+
+      // Alice group 2: responses 4-6
+      expect(result[3].groupSize).toBe(3);
+      expect(result[4].groupSize).toBe(3);
+      expect(result[5].groupSize).toBe(3);
+    });
+  });
+});
+
+describe('shouldShowHeader', () => {
+  it('should return true for group start', () => {
+    const responses = [
+      createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z'),
+      createResponse('2', 'alice', 'Alice', '2025-01-01T10:01:00Z'),
+    ];
+
+    const grouped = groupResponses(responses);
+
+    expect(shouldShowHeader(grouped[0])).toBe(true);
+    expect(shouldShowHeader(grouped[1])).toBe(false);
+  });
+});
+
+describe('getGroupStats', () => {
+  it('should return zeros for empty input', () => {
+    const stats = getGroupStats([]);
+
+    expect(stats).toEqual({
+      totalGroups: 0,
+      averageGroupSize: 0,
+      largestGroupSize: 0,
+    });
+  });
+
+  it('should calculate correct statistics', () => {
+    const responses = [
+      createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z'),
+      createResponse('2', 'alice', 'Alice', '2025-01-01T10:01:00Z'),
+      createResponse('3', 'bob', 'Bob', '2025-01-01T10:02:00Z'),
+      createResponse('4', 'alice', 'Alice', '2025-01-01T10:03:00Z'),
+      createResponse('5', 'alice', 'Alice', '2025-01-01T10:04:00Z'),
+      createResponse('6', 'alice', 'Alice', '2025-01-01T10:05:00Z'),
+    ];
+
+    const grouped = groupResponses(responses);
+    const stats = getGroupStats(grouped);
+
+    expect(stats.totalGroups).toBe(3); // Alice (2), Bob (1), Alice (3)
+    expect(stats.averageGroupSize).toBe(2); // 6 responses / 3 groups
+    expect(stats.largestGroupSize).toBe(3); // Second Alice group
+  });
+
+  it('should handle single response', () => {
+    const responses = [createResponse('1', 'alice', 'Alice', '2025-01-01T10:00:00Z')];
+
+    const grouped = groupResponses(responses);
+    const stats = getGroupStats(grouped);
+
+    expect(stats.totalGroups).toBe(1);
+    expect(stats.averageGroupSize).toBe(1);
+    expect(stats.largestGroupSize).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Transform the discussion UI into a clean, efficient conversation interface inspired by Discord, Slack, and Twitter/X.

### Phase 1: Compact Response Cards with Message Grouping
- Added `groupResponses` utility for author-based message grouping (5-minute threshold)
- Support compact mode in ResponseItem with smaller avatars, inline headers
- Implemented hover-only action buttons for desktop, always visible on mobile
- Added `isGroupStart`/`isGroupEnd` props for Discord-like grouped messages

### Phase 2: Lightweight Reply Composer  
- Added collapsed placeholder state (~40px) with "Reply to {name}..." text
- Expand on click/focus with auto-grow textarea
- Includes citation input, options popover (opinion/factual flags)
- Supports Ctrl/Cmd+Enter to submit, Escape to collapse
- Integrated with preview feedback system

### Phase 3: Collapsible Metadata Panel
- Added `CollapsedMetadataBar` (48px vertical icon bar)
- Icon shortcuts for Propositions, Common Ground, Bridging, Preview tabs
- WCAG 2.1 AA compliant 44px touch targets with tooltips
- Auto-expand on compose with requested tab synchronization

### Phase 4: Visual Threading & Thread Collapse
- Added vertical/horizontal connector lines for thread visualization
- Support `showThreadLines`, `isLastReply` props for reply rendering
- Implemented thread collapse with configurable threshold
- Added "View N more replies" expansion button

## Test plan

- [ ] Verify message grouping: post 3 quick responses as same user → should group with single header
- [ ] Verify compact mode: enable compact → verify smaller cards, hover-only actions on desktop
- [ ] Verify lightweight composer: click Reply → verify collapsed state, expand on focus
- [ ] Verify panel collapse: click collapse → verify icon bar appears, expand on icon click
- [ ] Verify auto-expand: start composing → verify panel auto-expands to Preview tab
- [ ] Verify threading: create nested replies → verify visual lines appear
- [ ] Verify thread collapse: create 5+ replies → verify "View more" appears

All 1920 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)