### PR TITLE
fix(test): Increase timeouts for PhoneVerificationButton test CI stability

### DIFF
--- a/frontend/src/components/verification/__tests__/PhoneVerificationButton.test.tsx
+++ b/frontend/src/components/verification/__tests__/PhoneVerificationButton.test.tsx
@@ -111,9 +111,15 @@ describe('PhoneVerificationButton', () => {
     // Send code
     await user.click(screen.getByRole('button', { name: /send code/i }));
 
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /enter verification code/i })).toBeInTheDocument();
-    });
+    // Wait for OTP step with increased timeout for CI stability
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole('heading', { name: /enter verification code/i }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
 
     // Enter OTP
     const otpInputs = screen.getAllByLabelText(/digit \d/i);
@@ -124,10 +130,13 @@ describe('PhoneVerificationButton', () => {
     // Verify
     await user.click(screen.getByRole('button', { name: /verify code/i }));
 
-    // Wait for success step to appear (use specific heading text to avoid multiple matches)
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /verification complete/i })).toBeInTheDocument();
-    });
+    // Wait for success step to appear with increased timeout for CI stability
+    await waitFor(
+      () => {
+        expect(screen.getByRole('heading', { name: /verification complete/i })).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
 
     // Advance timers past the 2000ms setTimeout in PhoneVerificationModal
     await act(async () => {
@@ -139,7 +148,7 @@ describe('PhoneVerificationButton', () => {
 
     // Restore original jest object
     globalThis.jest = originalJest;
-  }, 15000);
+  }, 30000);
 
   it('closes modal when cancel is clicked', async () => {
     const user = userEvent.setup({ delay: null });


### PR DESCRIPTION
## Summary
- Add explicit timeout to waitFor calls (5000ms)
- Increase overall test timeout from 15s to 30s
- Addresses flaky test timeout in CI build #339

## Context
Build #339 on main branch failed with a single test timeout:
- `PhoneVerificationButton.test.tsx > calls onVerificationSuccess after successful verification`
- Error: Test timed out in 15000ms
- All other 4923 tests passed

The test uses fake timers with complex async operations and waitFor, which can cause timing issues under CI load. This fix increases the timeouts to make the test more resilient.

## Test plan
- [x] Test passes locally
- [ ] Verify CI build passes with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)