### PR TITLE
docs: Clean up CLAUDE.md and correct Jenkins CI improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1073,7 +1073,8 @@ The Jenkins pipeline uses the official Microsoft Playwright Docker image for E2E
 - **2026-03-02**: Jenkins CI stability improvements
   - Fixed PhoneVerificationButton test timeout (PR #975)
   - Added Docker image pull retry mechanism (3 retries with 5s delay)
-  - Fixed post-stage build result preservation (prevents Allure/JUnit from overriding result)
+  - Added Docker health check and system prune before image pulls
+  - Added catchError protection to Build stage
 - **2026-02-18**: Added AI/LLM testing infrastructure and documentation
   - Bedrock response mock fixtures, prompt snapshot tests, schema validation
   - Claim extractor service with 7 claim types, golden tests, latency benchmarks
@@ -1088,8 +1089,3 @@ The Jenkins pipeline uses the official Microsoft Playwright Docker image for E2E
   - All Phase 9 polish tasks complete (TSDoc, bundle validation)
 - **2026-02-01**: Consolidated pending PRs into staging branch
 - **2026-01-31**: Fixed recurring E2E OOM issues - reduced to chromium-only, skip allure in CI, reduced Jenkins agents 8→3
-
-# Trigger rebuild
-
-
-


### PR DESCRIPTION
## Summary
- Correct documentation to reflect actual Jenkins CI changes (the post-stage fix was reverted)
- Remove trailing "# Trigger rebuild" cruft from PR #976

## Changes
- Replace "Fixed post-stage build result preservation" with actual fixes:
  - Docker health check and system prune before image pulls
  - catchError protection for Build stage
- Remove trailing newlines and rebuild marker text

🤖 Generated with [Claude Code](https://claude.com/claude-code)