### PR TITLE
fix(db-models): Add missing discussion_topics tier/expertise columns

### DIFF
--- a/packages/db-models/prisma/migrations/20260302_add_social_integration_schema/migration.sql
+++ b/packages/db-models/prisma/migrations/20260302_add_social_integration_schema/migration.sql
@@ -4,11 +4,14 @@
 -- This migration adds:
 -- 1. email_hash column to users table (for contact matching)
 -- 2. allow_provisional_access column to discussion_topics table
--- 3. SocialProvider enum
--- 4. InvitationStatus enum
--- 5. social_connections table
--- 6. imported_contacts table
--- 7. topic_invitations table
+-- 3. minimum_tier_level column to discussion_topics table
+-- 4. minimum_expertise_level column to discussion_topics table
+-- 5. required_tag_id column to discussion_topics table
+-- 6. SocialProvider enum
+-- 7. InvitationStatus enum
+-- 8. social_connections table
+-- 9. imported_contacts table
+-- 10. topic_invitations table
 
 -- 1. Add email_hash column to users table
 ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "email_hash" TEXT;
@@ -17,21 +20,30 @@ CREATE INDEX IF NOT EXISTS "users_email_hash_idx" ON "users"("email_hash");
 -- 2. Add allow_provisional_access column to discussion_topics table
 ALTER TABLE "discussion_topics" ADD COLUMN IF NOT EXISTS "allow_provisional_access" BOOLEAN NOT NULL DEFAULT true;
 
--- 3. Create SocialProvider enum
+-- 3. Add minimum_tier_level column to discussion_topics table
+ALTER TABLE "discussion_topics" ADD COLUMN IF NOT EXISTS "minimum_tier_level" INTEGER;
+
+-- 4. Add minimum_expertise_level column to discussion_topics table
+ALTER TABLE "discussion_topics" ADD COLUMN IF NOT EXISTS "minimum_expertise_level" INTEGER;
+
+-- 5. Add required_tag_id column to discussion_topics table
+ALTER TABLE "discussion_topics" ADD COLUMN IF NOT EXISTS "required_tag_id" UUID;
+
+-- 6. Create SocialProvider enum
 DO $$ BEGIN
     CREATE TYPE "social_provider" AS ENUM ('GOOGLE', 'FACEBOOK');
 EXCEPTION
     WHEN duplicate_object THEN null;
 END $$;
 
--- 4. Create InvitationStatus enum
+-- 7. Create InvitationStatus enum
 DO $$ BEGIN
     CREATE TYPE "invitation_status" AS ENUM ('PENDING', 'ACCEPTED', 'DECLINED', 'EXPIRED');
 EXCEPTION
     WHEN duplicate_object THEN null;
 END $$;
 
--- 5. Create social_connections table
+-- 8. Create social_connections table
 CREATE TABLE IF NOT EXISTS "social_connections" (
     "id" UUID NOT NULL DEFAULT gen_random_uuid(),
     "user_id" UUID NOT NULL,
@@ -51,7 +63,7 @@ CREATE TABLE IF NOT EXISTS "social_connections" (
 CREATE UNIQUE INDEX IF NOT EXISTS "social_connections_user_id_provider_key" ON "social_connections"("user_id", "provider");
 CREATE INDEX IF NOT EXISTS "social_connections_user_id_idx" ON "social_connections"("user_id");
 
--- 6. Create imported_contacts table
+-- 9. Create imported_contacts table
 CREATE TABLE IF NOT EXISTS "imported_contacts" (
     "id" UUID NOT NULL DEFAULT gen_random_uuid(),
     "owner_id" UUID NOT NULL,
@@ -69,7 +81,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS "imported_contacts_owner_id_email_hash_key" ON
 CREATE INDEX IF NOT EXISTS "imported_contacts_email_hash_idx" ON "imported_contacts"("email_hash");
 CREATE INDEX IF NOT EXISTS "imported_contacts_owner_id_idx" ON "imported_contacts"("owner_id");
 
--- 7. Create topic_invitations table
+-- 10. Create topic_invitations table
 CREATE TABLE IF NOT EXISTS "topic_invitations" (
     "id" UUID NOT NULL DEFAULT gen_random_uuid(),
     "topic_id" UUID NOT NULL,


### PR DESCRIPTION
## Summary

PR #978 was merged but was still missing three columns on `discussion_topics`:
- `minimum_tier_level` (Int, nullable)
- `minimum_expertise_level` (Int, nullable)
- `required_tag_id` (UUID, nullable)

These columns exist in the Prisma schema but had no migration, causing main branch build #353 to fail with:

```
ERROR: column discussion_topics.minimum_tier_level does not exist
```

## Test plan

- [x] Migration uses `IF NOT EXISTS` for idempotency
- [ ] CI passes (E2E tests should now succeed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)