### PR TITLE
fix(ci): Increase postgres memory and add healthcheck start_period

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -23,16 +23,24 @@ services:
       POSTGRES_USER: reasonbridge_test
       POSTGRES_PASSWORD: reasonbridge_test
       POSTGRES_DB: reasonbridge_test
+      # Reduce shared_buffers to work within memory limits (default 128MB is too high)
+      POSTGRES_INITDB_ARGS: '--encoding=UTF8'
     # Host port removed to prevent CI conflicts - services communicate via Docker network
     # For local debugging, uncomment: ports: ['5434:5432']
+    command: >
+      postgres
+      -c shared_buffers=32MB
+      -c max_connections=50
+      -c work_mem=2MB
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U reasonbridge_test -d reasonbridge_test']
       interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 30s
     tmpfs:
       - /var/lib/postgresql/data
-    mem_limit: 256m
+    mem_limit: 384m
     networks:
       - reasonbridge-e2e
 


### PR DESCRIPTION
## Summary
- Increase postgres memory limit from 256m to 384m
- Reduce postgres shared_buffers from 128MB to 32MB for E2E environment
- Add 30s start_period to healthcheck for initialization time
- Increase healthcheck retries from 5 to 10

## Root Cause
PR #982 build #1 failed with: "dependency postgres failed to start: container exited (0)"

This happened because:
1. Default shared_buffers (128MB) + tmpfs overhead exceeded 256MB limit
2. No start_period meant healthchecks began during initialization

## Test plan
- [ ] E2E tests complete without postgres startup failure
- [ ] Postgres healthcheck passes within start_period

🤖 Generated with [Claude Code](https://claude.com/claude-code)