### PR TITLE
fix(e2e): Un-skip 13 additional tests with timing/flaky reasons

### DIFF
--- a/frontend/e2e/a11y-example.spec.ts
+++ b/frontend/e2e/a11y-example.spec.ts
@@ -9,7 +9,7 @@ import { test } from '@playwright/test';
 import { checkAccessibility } from './helpers/accessibility';
 
 test.describe('Accessibility Testing Example', () => {
-  test.skip('landing page should pass WCAG 2.2 AA checks', async ({ page }) => {
+  test('landing page should pass WCAG 2.2 AA checks', async ({ page }) => {
     await page.goto('/');
 
     // Run comprehensive accessibility scan
@@ -18,7 +18,7 @@ test.describe('Accessibility Testing Example', () => {
     });
   });
 
-  test.skip('check specific component accessibility', async ({ page }) => {
+  test('check specific component accessibility', async ({ page }) => {
     await page.goto('/');
 
     // Only check navigation accessibility

--- a/frontend/e2e/complete-verification-flow.spec.ts
+++ b/frontend/e2e/complete-verification-flow.spec.ts
@@ -65,9 +65,7 @@ test.describe('Complete Verification Flow', () => {
     testUser = generateTestUser();
   });
 
-  // Fixed: Added auth state waits to registerAndLogin helper
-  // TODO: Flaky in CI - registration/auth state timing issues. Tracked for investigation.
-  test.skip('should navigate to verification page directly', async ({ page }) => {
+  test('should navigate to verification page directly', async ({ page }) => {
     // Register and login first (verification page requires authentication)
     await registerAndLogin(page);
 
@@ -243,9 +241,7 @@ test.describe('Complete Verification Flow', () => {
     expect(page.url()).toContain('/verification');
   });
 
-  // Fixed: Auth state now properly stabilizes after registration
-  // TODO: Flaky in CI - auth state timing issues after registration. Tracked for investigation.
-  test.skip('should maintain state during navigation', async ({ page }) => {
+  test('should maintain state during navigation', async ({ page }) => {
     // Register and login first (verification page requires authentication)
     await registerAndLogin(page);
 

--- a/frontend/e2e/edit-topic.spec.ts
+++ b/frontend/e2e/edit-topic.spec.ts
@@ -58,8 +58,7 @@ test.describe('Topic Editing', () => {
       });
     });
 
-    // TODO: Flaky in CI - topic creation/editing timing issues. Tracked for investigation.
-    test.skip('should successfully edit topic title and description', async ({ page }) => {
+    test('should successfully edit topic title and description', async ({ page }) => {
       // Create a topic first
       await page.goto('/topics');
       await page.getByRole('button', { name: /create topic/i }).click();
@@ -115,8 +114,7 @@ test.describe('Topic Editing', () => {
       await expect(page.getByText(editedTitle)).toBeVisible({ timeout: 5000 });
     });
 
-    // TODO: Flaky in CI - topic creation/editing timing issues. Tracked for investigation.
-    test.skip('should edit topic tags', async ({ page }) => {
+    test('should edit topic tags', async ({ page }) => {
       // Create a topic first
       await page.goto('/topics');
       await page.getByRole('button', { name: /create topic/i }).click();
@@ -206,8 +204,7 @@ test.describe('Topic Editing', () => {
       await expect(page.getByText(/review changes/i)).toBeVisible();
     });
 
-    // TODO: Flaky in CI - topic creation/editing timing issues. Tracked for investigation.
-    test.skip('should allow flagging edit for moderation review', async ({ page }) => {
+    test('should allow flagging edit for moderation review', async ({ page }) => {
       // Create a topic first
       await page.goto('/topics');
       await page.getByRole('button', { name: /create topic/i }).click();
@@ -246,8 +243,7 @@ test.describe('Topic Editing', () => {
       await expect(page.getByText(/flagged for moderator review/i)).toBeVisible();
     });
 
-    // TODO: Flaky in CI - 'preview changes' button click timeout. Tracked for investigation.
-    test.skip('should display validation errors', async ({ page }) => {
+    test('should display validation errors', async ({ page }) => {
       // Create a topic first
       await page.goto('/topics');
       await page.getByRole('button', { name: /create topic/i }).click();
@@ -331,8 +327,7 @@ test.describe('Topic Editing', () => {
       await page.waitForTimeout(200); // Critical: Allow token storage and state propagation to complete
     });
 
-    // TODO: Flaky in CI - topic creation/editing timing issues. Tracked for investigation.
-    test.skip('should display edit history after editing', async ({ page }) => {
+    test('should display edit history after editing', async ({ page }) => {
       // Create a topic first
       await page.goto('/topics');
       await page.getByRole('button', { name: /create topic/i }).click();
@@ -377,8 +372,7 @@ test.describe('Topic Editing', () => {
       }
     });
 
-    // TODO: Flaky in CI - topic creation/editing timing issues. Tracked for investigation.
-    test.skip('should show changes in edit history', async ({ page }) => {
+    test('should show changes in edit history', async ({ page }) => {
       // Create and edit a topic
       await page.goto('/topics');
       await page.getByRole('button', { name: /create topic/i }).click();
@@ -438,8 +432,7 @@ test.describe('Topic Editing', () => {
       await expect(page.getByRole('button', { name: /edit topic/i })).not.toBeVisible();
     });
 
-    // TODO: Flaky in CI - login/navigation timing issues. Tracked for investigation.
-    test.skip('users should not see Edit button on topics created by others', async ({ page }) => {
+    test('users should not see Edit button on topics created by others', async ({ page }) => {
       // Login as one user
       await page.goto('/');
       await page.getByRole('button', { name: /log in/i }).click();

--- a/frontend/e2e/skeleton-loaders.spec.ts
+++ b/frontend/e2e/skeleton-loaders.spec.ts
@@ -49,8 +49,7 @@ test.describe('Page Loading States', () => {
   });
 
   test.describe('Topic Detail Page', () => {
-    // TODO: Flaky in CI - topic navigation timing issues. Tracked for investigation.
-    test.skip('should load topic detail page without errors', async ({ page }) => {
+    test('should load topic detail page without errors', async ({ page }) => {
       // First go to topics page
       await page.goto('/topics');
       await page.waitForLoadState('networkidle');

--- a/frontend/e2e/topic-status.spec.ts
+++ b/frontend/e2e/topic-status.spec.ts
@@ -77,9 +77,7 @@ test.describe('Topic Status Management', () => {
       });
     });
 
-    // Fixed: Added proper waits and extended description for validation
-    // TODO: Flaky in CI - topic activation timing issues. Tracked for investigation.
-    test.skip('should activate a topic from SEEDING state', async ({ page }) => {
+    test('should activate a topic from SEEDING state', async ({ page }) => {
       // Create a topic first
       await page.goto('/topics');
       await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Summary
- Remove outdated skip markers from 13 tests that were marked as flaky but use real backend
- Tests were previously skipped due to timing issues in CI
- All tests use real backend APIs (no mocks) and should run in E2E Docker mode

## Changes
| File | Tests | Reason |
|------|-------|--------|
| `a11y-example.spec.ts` | 2 | Accessibility WCAG checks |
| `complete-verification-flow.spec.ts` | 2 | Auth timing issues |
| `edit-topic.spec.ts` | 7 | Topic editing timing |
| `skeleton-loaders.spec.ts` | 1 | Topic navigation |
| `topic-status.spec.ts` | 1 | Topic activation |

## Test plan
- [x] Tests pass locally without backend (skip at runtime)
- [ ] Tests pass in E2E Docker CI with real backend
- [ ] No regressions in existing tests

## Skip count
- Before: 151 skip patterns
- After: 138 skip patterns
- **Net: 13 tests enabled**

🤖 Generated with [Claude Code](https://claude.com/claude-code)