### PR TITLE
fix(a11y): Add navigation role and Topics heading to Sidebar

### DIFF
--- a/frontend/src/components/layouts/Sidebar.tsx
+++ b/frontend/src/components/layouts/Sidebar.tsx
@@ -110,10 +110,18 @@ export function Sidebar() {
           transition-all duration-300 ease-in-out
           ${isCollapsed ? 'w-20' : 'w-80'}
         `}
+        role="navigation"
         aria-label="Topic navigation sidebar"
       >
         {/* Compact Site Navigation - always visible */}
         <CompactSiteNav isCollapsed={isCollapsed} />
+
+        {/* Topics Header - hidden when collapsed */}
+        {!isCollapsed && (
+          <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Topics</h2>
+          </div>
+        )}
 
         {/* Topic Navigation Content - hidden when collapsed */}
         {!isCollapsed && (


### PR DESCRIPTION
## Summary
- Add `role="navigation"` to Sidebar when in topics mode to fix E2E tests that expect `[role="navigation"]`
- Add "Topics" heading to Sidebar in topics mode to match test expectations

## Context
The discussion-page-redesign E2E tests expect:
- A `[role="navigation"]` element for the left panel
- A "Topics" heading visible in the topic navigation area

These tests were failing because the Sidebar component (which provides topic navigation on /discussions route) didn't have these accessibility attributes.

## Test plan
- [ ] E2E tests for discussion-page-redesign should pass
- [ ] No accessibility regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)