### PR TITLE
fix(seed): Add UserRole to demo personas for moderator access

### DIFF
--- a/packages/db-models/prisma/seed/demo-fixtures.ts
+++ b/packages/db-models/prisma/seed/demo-fixtures.ts
@@ -52,6 +52,7 @@ export async function seedDemoPersonas(prisma: PrismaClient): Promise<void> {
         phoneNumber: persona.phoneNumber,
         phoneVerified: persona.phoneVerified,
         status: persona.status,
+        role: persona.userRole,
       },
       create: {
         id: persona.id,
@@ -70,6 +71,7 @@ export async function seedDemoPersonas(prisma: PrismaClient): Promise<void> {
         trustScoreIntegrity: persona.trustScoreIntegrity,
         moralFoundationProfile: persona.moralFoundationProfile as unknown as Prisma.InputJsonValue,
         status: persona.status,
+        role: persona.userRole,
       },
     });
 

--- a/packages/db-models/prisma/seed/demo-personas.ts
+++ b/packages/db-models/prisma/seed/demo-personas.ts
@@ -21,6 +21,8 @@ type AuthMethod = 'EMAIL_PASSWORD' | 'GOOGLE_OAUTH' | 'APPLE_OAUTH';
 type VerificationLevel = 'BASIC' | 'ENHANCED' | 'VERIFIED_HUMAN';
 type AccountStatus = 'ACTIVE' | 'SUSPENDED' | 'DELETED';
 type UserStatus = 'ACTIVE' | 'SUSPENDED' | 'BANNED';
+// Prisma UserRole enum for database role field
+export type UserRole = 'USER' | 'MODERATOR' | 'ADMIN';
 
 export interface DemoPersona {
   id: string;
@@ -39,6 +41,8 @@ export interface DemoPersona {
   trustScoreIntegrity: number;
   moralFoundationProfile: MoralFoundationProfile;
   status: UserStatus;
+  // Database role field (maps to Prisma UserRole enum)
+  userRole: UserRole;
   // Metadata for demos
   role: DemoRole;
   description: string;
@@ -102,6 +106,7 @@ export const ADMIN_ADAMS: DemoPersona = {
     liberty: 0.75,
   },
   status: 'ACTIVE',
+  userRole: 'ADMIN',
   role: 'admin',
   description: 'Showcase admin features, moderation queue, user management',
   activityLevel: 'high',
@@ -135,6 +140,7 @@ export const MOD_MARTINEZ: DemoPersona = {
     liberty: 0.65,
   },
   status: 'ACTIVE',
+  userRole: 'MODERATOR',
   role: 'moderator',
   description: 'Demonstrate moderation workflows, appeals handling',
   activityLevel: 'high',
@@ -168,6 +174,7 @@ export const ALICE_ANDERSON: DemoPersona = {
     liberty: 0.85,
   },
   status: 'ACTIVE',
+  userRole: 'USER',
   role: 'power_user',
   description: 'Active participant, high engagement, progressive viewpoints',
   activityLevel: 'very_high',
@@ -201,6 +208,7 @@ export const BOB_BUILDER: DemoPersona = {
     liberty: 0.6,
   },
   status: 'ACTIVE',
+  userRole: 'USER',
   role: 'regular_user',
   description: 'Typical user experience, moderate activity, balanced views',
   activityLevel: 'medium',
@@ -234,6 +242,7 @@ export const NEW_USER: DemoPersona = {
     liberty: 0.5,
   },
   status: 'ACTIVE',
+  userRole: 'USER',
   role: 'new_user',
   description: 'Onboarding experience, first-time user flow, limited history',
   activityLevel: 'low',


### PR DESCRIPTION
## Summary
- Fixed demo seeding to set proper `UserRole` for Admin Adams (ADMIN) and Mod Martinez (MODERATOR)
- Added `userRole` field to `DemoPersona` interface that maps to Prisma's UserRole enum
- Updated `seedDemoPersonas` to include the `role` field in both create and update operations

## Problem
The `MergeTopicsModal` was properly integrated into `TopicsPage.tsx` but remained invisible because:
1. The "Merge Topics" button only shows for users with `MODERATOR` or `ADMIN` role
2. Demo users were being seeded without setting the `role` field
3. The Prisma User model defaults `role` to `USER`, so all demo users had `USER` role

## Solution
Added a `userRole` field to each demo persona that maps to the Prisma `UserRole` enum:
- **Admin Adams**: `ADMIN`
- **Mod Martinez**: `MODERATOR`  
- **Alice Anderson**: `USER`
- **Bob Builder**: `USER`
- **New User**: `USER`

## Test plan
- [ ] Verify Mod Martinez can see the "Merge Topics" button on `/topics`
- [ ] Verify the 7 merge-topics E2E tests now pass (they use runtime skips that auto-enable)
- [ ] Verify Admin Adams can also see the "Merge Topics" button

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)