### PR TITLE
fix(user-service): prevent verification token collision in E2E mode

### DIFF
--- a/services/user-service/src/auth/verification.service.ts
+++ b/services/user-service/src/auth/verification.service.ts
@@ -57,6 +57,18 @@ export class VerificationService {
         },
       });
 
+      // In E2E mode, delete any existing tokens with the same code to avoid
+      // unique constraint violations (token column has global uniqueness).
+      // This is safe in E2E because tests run sequentially and verification
+      // flows complete quickly.
+      if (process.env['E2E_VERIFICATION_CODE']) {
+        await this.prisma.verificationToken.deleteMany({
+          where: {
+            token: code,
+          },
+        });
+      }
+
       // Create new verification token
       // TODO: Add email and attempts fields to VerificationToken schema
       await this.prisma.verificationToken.create({


### PR DESCRIPTION
## Summary
- Fixes duplicate key constraint violation when multiple users register during E2E tests
- In E2E mode, deletes existing tokens with the fixed code before creating new ones
- All 827 user-service tests pass

## Root Cause
The verification service uses a fixed token (`123456`) in E2E mode to enable automated testing. However, the `token` column has a global unique constraint, so the second registration attempt fails with:
```
duplicate key value violates unique constraint "verification_tokens_token_key"
Key (token)=(123456) already exists.
```

## Fix
Before inserting a new token in E2E mode, delete any existing tokens with the same code. This is safe because:
1. E2E tests run sequentially
2. Verification flows complete quickly
3. The trade-off is acceptable for testability

## Test plan
- [x] user-service unit tests pass (827 tests)
- [x] TypeScript compiles without errors
- [x] Lint passes
- [ ] E2E signup tests should no longer fail with token collision

Fixes #1025

🤖 Generated with [Claude Code](https://claude.ai/claude-code)