### PR TITLE
fix(discussion-service): handle missing userId in read-state controller

### DIFF
--- a/services/discussion-service/src/read-state/read-state.controller.ts
+++ b/services/discussion-service/src/read-state/read-state.controller.ts
@@ -3,7 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Controller, Get, Put, Param, Body, Headers, Inject } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Put,
+  Param,
+  Body,
+  Headers,
+  Inject,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { ReadStateService } from './read-state.service.js';
 import type { UpdateReadStateDto } from './dto/update-read-state.dto.js';
 import type { ReadStateDto } from './dto/read-state.dto.js';
@@ -15,25 +24,34 @@ export class ReadStateController {
   /**
    * Update the read state for the current user in a topic
    * PUT /topics/:topicId/read-state
+   * Requires authentication (x-user-id header)
    */
   @Put(':topicId/read-state')
   async updateReadState(
     @Param('topicId') topicId: string,
-    @Headers('x-user-id') userId: string,
+    @Headers('x-user-id') userId: string | undefined,
     @Body() dto: UpdateReadStateDto,
   ): Promise<ReadStateDto> {
+    if (!userId) {
+      throw new UnauthorizedException('Authentication required to update read state');
+    }
     return this.readStateService.updateReadState(userId, topicId, dto);
   }
 
   /**
    * Get the read state for the current user in a topic
    * GET /topics/:topicId/read-state
+   * Returns null for unauthenticated users (guests have no read state)
    */
   @Get(':topicId/read-state')
   async getReadState(
     @Param('topicId') topicId: string,
-    @Headers('x-user-id') userId: string,
+    @Headers('x-user-id') userId: string | undefined,
   ): Promise<ReadStateDto | null> {
+    // Guest users have no read state - return null without querying
+    if (!userId) {
+      return null;
+    }
     return this.readStateService.getReadState(userId, topicId);
   }
 }


### PR DESCRIPTION
## Summary
- Fixes PrismaClientValidationError when guest users access read-state endpoints
- Guest users now get `null` for GET /read-state (no read state)
- Guest users get 401 Unauthorized for PUT /read-state

## Root Cause
The read-state controller used `@Headers('x-user-id') userId: string` without handling the case when the header is missing (unauthenticated/guest users). This caused Prisma to receive `undefined` and throw:
```
PrismaClientValidationError:
Invalid `prisma.userTopicReadState.findUnique()` invocation:
+ userId: String
```

## Fix
- Mark `userId` as `string | undefined`
- Return `null` for guests on GET (guests have no read state)
- Return `401 Unauthorized` for guests on PUT (can't update without auth)

This follows the same pattern used in `topic-drafts.controller.ts` and other controllers.

## Test plan
- [x] discussion-service unit tests pass (487 tests)
- [x] TypeScript compiles without errors
- [x] Lint passes
- [ ] E2E tests should no longer fail with Prisma validation error

Fixes #1026

🤖 Generated with [Claude Code](https://claude.ai/claude-code)