### PR TITLE
feat(notifications): connect notification hooks to real API endpoints (#1050)

### DIFF
--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -3,11 +3,41 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { apiClient, ApiError } from '../lib/api';
+
+/**
+ * API response type from the backend
+ */
+interface NotificationApiResponse {
+  id: string;
+  userId: string;
+  type: string;
+  title: string;
+  body: string;
+  actionUrl: string | null;
+  metadata: {
+    actorId?: string;
+    actorUsername?: string;
+    actorAvatarUrl?: string;
+    relatedContentType?: 'topic' | 'response' | 'user';
+    relatedContentId?: string;
+    relatedContentTitle?: string;
+  } | null;
+  isRead: boolean;
+  readAt: string | null;
+  createdAt: string;
+}
+
+interface NotificationListApiResponse {
+  notifications: NotificationApiResponse[];
+  total: number;
+  unreadCount: number;
+}
 
 export interface PageNotification {
   id: string;
-  type: 'comment' | 'mention' | 'system' | 'response' | 'like';
+  type: 'comment' | 'mention' | 'system' | 'response' | 'like' | 'follow' | 'common_ground';
   message: string;
   /** Optional actor information */
   actor?: {
@@ -38,135 +68,138 @@ interface UseNotificationsReturn {
 }
 
 /**
+ * Map backend notification type to frontend type
+ */
+function mapNotificationType(
+  backendType: string,
+): 'comment' | 'mention' | 'system' | 'response' | 'like' | 'follow' | 'common_ground' {
+  const typeMap: Record<string, PageNotification['type']> = {
+    mention: 'mention',
+    follow: 'follow',
+    common_ground: 'common_ground',
+    response: 'response',
+    reply: 'comment',
+    like: 'like',
+    system: 'system',
+  };
+  return typeMap[backendType] || 'system';
+}
+
+/**
+ * Transform backend notification to frontend format
+ */
+function transformNotification(apiNotification: NotificationApiResponse): PageNotification {
+  const notification: PageNotification = {
+    id: apiNotification.id,
+    type: mapNotificationType(apiNotification.type),
+    message: apiNotification.body,
+    timestamp: apiNotification.createdAt,
+    read: apiNotification.isRead,
+    url: apiNotification.actionUrl ?? undefined,
+  };
+
+  // Extract actor information from metadata
+  if (apiNotification.metadata?.actorId && apiNotification.metadata?.actorUsername) {
+    notification.actor = {
+      id: apiNotification.metadata.actorId,
+      username: apiNotification.metadata.actorUsername,
+      avatarUrl: apiNotification.metadata.actorAvatarUrl,
+    };
+  }
+
+  // Extract related content from metadata
+  if (apiNotification.metadata?.relatedContentType && apiNotification.metadata?.relatedContentId) {
+    notification.relatedContent = {
+      type: apiNotification.metadata.relatedContentType,
+      id: apiNotification.metadata.relatedContentId,
+      title: apiNotification.metadata.relatedContentTitle,
+    };
+  }
+
+  return notification;
+}
+
+/**
  * Hook for fetching and managing page notifications
  *
- * TODO: Connect to real API endpoint when backend is ready
- * Currently uses mock data for UI development
+ * Connects to the notification-service REST API for:
+ * - Fetching user notifications with pagination
+ * - Marking individual notifications as read
+ * - Marking all notifications as read
  */
 export function useNotifications(): UseNotificationsReturn {
   const [notifications, setNotifications] = useState<PageNotification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
-  // Mock data for initial implementation
-  useEffect(() => {
-    const fetchNotifications = async () => {
-      setIsLoading(true);
-      try {
-        // TODO: Replace with actual API call
-        // const data = await apiClient.get<PageNotification[]>('/notifications');
+  const fetchNotifications = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
 
-        // Mock data matching NotificationsPage structure
-        await new Promise((resolve) => setTimeout(resolve, 500)); // Simulate network delay
+    try {
+      const response = await apiClient.get<NotificationListApiResponse>('/notifications', {
+        params: { limit: 50 },
+      });
 
-        const mockNotifications: PageNotification[] = [
-          {
-            id: '1',
-            type: 'comment',
-            message: 'Alex Johnson commented on your post about climate change',
-            actor: {
-              id: 'user-1',
-              username: 'alexj',
-              avatarUrl: undefined,
-            },
-            relatedContent: {
-              type: 'response',
-              id: 'response-123',
-              title: 'Climate Change Discussion',
-            },
-            timestamp: new Date(Date.now() - 2 * 60 * 1000).toISOString(), // 2 min ago
-            read: false,
-            url: '/topics/topic-123#response-123',
-          },
-          {
-            id: '2',
-            type: 'mention',
-            message: 'Sam Davis mentioned you in a response',
-            actor: {
-              id: 'user-2',
-              username: 'samd',
-            },
-            relatedContent: {
-              type: 'response',
-              id: 'response-456',
-            },
-            timestamp: new Date(Date.now() - 15 * 60 * 1000).toISOString(), // 15 min ago
-            read: false,
-            url: '/topics/topic-456#response-456',
-          },
-          {
-            id: '3',
-            type: 'response',
-            message: 'Taylor Chen responded to your topic',
-            actor: {
-              id: 'user-3',
-              username: 'taylorc',
-            },
-            relatedContent: {
-              type: 'topic',
-              id: 'topic-789',
-              title: 'Education Reform',
-            },
-            timestamp: new Date(Date.now() - 60 * 60 * 1000).toISOString(), // 1 hour ago
-            read: true,
-            url: '/topics/topic-789',
-          },
-          {
-            id: '4',
-            type: 'system',
-            message: 'Your response received 10 likes',
-            timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2 hours ago
-            read: true,
-          },
-          {
-            id: '5',
-            type: 'comment',
-            message: 'Jordan Lee commented on your response',
-            actor: {
-              id: 'user-4',
-              username: 'jordanl',
-            },
-            timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // 1 day ago
-            read: true,
-            url: '/topics/topic-999#response-999',
-          },
-        ];
-
-        setNotifications(mockNotifications);
-        setError(null);
-      } catch (err) {
+      const transformedNotifications = response.notifications.map(transformNotification);
+      setNotifications(transformedNotifications);
+      setUnreadCount(response.unreadCount);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        // Handle 401 unauthorized - user not logged in
+        if (err.status === 401) {
+          setNotifications([]);
+          setUnreadCount(0);
+          return;
+        }
+        setError(new Error(`Failed to fetch notifications: ${err.message}`));
+      } else {
         setError(err instanceof Error ? err : new Error('Failed to fetch notifications'));
-      } finally {
-        setIsLoading(false);
       }
-    };
-
-    fetchNotifications();
+    } finally {
+      setIsLoading(false);
+    }
   }, []);
 
-  const unreadCount = notifications.filter((n) => !n.read).length;
+  useEffect(() => {
+    fetchNotifications();
+  }, [fetchNotifications]);
 
-  const markAsRead = async (id: string) => {
-    // TODO: Call API endpoint: PATCH /notifications/:id
-    // await apiClient.patch(`/notifications/${id}`, { read: true });
+  const markAsRead = useCallback(
+    async (id: string) => {
+      try {
+        await apiClient.patch<NotificationApiResponse>(`/notifications/${id}/read`);
 
-    setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
-  };
+        // Optimistically update local state
+        setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
+        setUnreadCount((prev) => Math.max(0, prev - 1));
+      } catch (err) {
+        // Refetch on error to sync state
+        await fetchNotifications();
+        throw err;
+      }
+    },
+    [fetchNotifications],
+  );
 
-  const markAllAsRead = async () => {
-    // TODO: Call API endpoint: PATCH /notifications/mark-all-read
-    // await apiClient.patch('/notifications/mark-all-read');
+  const markAllAsRead = useCallback(async () => {
+    try {
+      await apiClient.patch<{ count: number; message: string }>('/notifications/mark-all-read');
 
-    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
-  };
+      // Optimistically update local state
+      setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+      setUnreadCount(0);
+    } catch (err) {
+      // Refetch on error to sync state
+      await fetchNotifications();
+      throw err;
+    }
+  }, [fetchNotifications]);
 
-  const refetch = async () => {
-    // TODO: Re-fetch notifications from API
-    // For now, just reset loading state
-    setIsLoading(true);
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    setIsLoading(false);
-  };
+  const refetch = useCallback(async () => {
+    await fetchNotifications();
+  }, [fetchNotifications]);
 
   return {
     notifications,

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -4,8 +4,8 @@
  */
 
 import { useEffect, useRef, useState, useCallback } from 'react';
-// TODO: Integrate with AuthContext once it's implemented
-// import { useAuth } from '../contexts/AuthContext';
+import { useAuthContext } from '../contexts/AuthContext';
+import { authService } from '../services/authService';
 
 /**
  * WebSocket message types for real-time updates
@@ -202,9 +202,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     heartbeatInterval = 30000,
   } = options;
 
-  // TODO: Uncomment when AuthContext is implemented
-  // const { user } = useAuth();
-  const user: { token?: string } | null = null; // Placeholder until AuthContext is implemented
+  const { user, isAuthenticated } = useAuthContext();
   const [state, setState] = useState<WebSocketState>('disconnected');
   const [error, setError] = useState<string | null>(null);
 
@@ -291,10 +289,13 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     }
 
     // Don't connect if not authenticated
-    if (!user) {
+    if (!isAuthenticated || !user) {
       setError('User not authenticated');
       return;
     }
+
+    // Get auth token for WebSocket authentication
+    const token = authService.getAuthToken();
 
     setState('connecting');
     setError(null);
@@ -310,10 +311,9 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
         startHeartbeat();
 
         // Send authentication token
-        // TODO: Implement proper authentication when AuthContext is available
-        // if (user && 'token' in user && user.token) {
-        //   ws.send(JSON.stringify({ type: 'AUTH', token: user.token }));
-        // }
+        if (token) {
+          ws.send(JSON.stringify({ type: 'AUTH', token }));
+        }
       };
 
       ws.onmessage = handleMessage;
@@ -344,6 +344,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
     }
   }, [
     user,
+    isAuthenticated,
     state,
     getWebSocketUrl,
     handleMessage,
@@ -414,10 +415,10 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
   }, []);
 
   /**
-   * Auto-connect on mount if enabled
+   * Auto-connect on mount if enabled and authenticated
    */
   useEffect(() => {
-    if (autoConnect && user) {
+    if (autoConnect && isAuthenticated) {
       connect();
     }
 
@@ -425,7 +426,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
       disconnect();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoConnect, user]); // Only depend on autoConnect and user, not connect/disconnect
+  }, [autoConnect, isAuthenticated]); // Only depend on autoConnect and isAuthenticated, not connect/disconnect
 
   return {
     state,

--- a/services/api-gateway/src/proxy/notification-proxy.controller.ts
+++ b/services/api-gateway/src/proxy/notification-proxy.controller.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Controller, All, Req, Res, Headers, Inject } from '@nestjs/common';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { ProxyService } from './proxy.service.js';
+
+/**
+ * Notification Service Proxy Controller
+ * Proxies all /notifications/* requests to the notification service
+ */
+@Controller('notifications')
+export class NotificationProxyController {
+  constructor(@Inject(ProxyService) private readonly proxyService: ProxyService) {}
+
+  /**
+   * Proxy all notification service requests
+   * Handles: /notifications, /notifications/:id, /notifications/:id/read, etc.
+   */
+  @All('*')
+  async proxyToNotification(
+    @Req() req: FastifyRequest,
+    @Res() res: FastifyReply,
+    @Headers('authorization') authHeader?: string,
+  ) {
+    // Keep full path including /notifications prefix since the notification service expects it
+    // Strip query string from path since we pass it separately in 'query' parameter
+    const path = req.url.split('?')[0] || req.url;
+    const method = req.method as 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+
+    const response = await this.proxyService.proxyToNotificationService({
+      method,
+      path,
+      body: req.body,
+      query: req.query as Record<string, string>,
+      headers: authHeader ? { Authorization: authHeader } : undefined,
+    });
+
+    res.status(response.status).send(response.data);
+  }
+}

--- a/services/api-gateway/src/proxy/proxy.module.ts
+++ b/services/api-gateway/src/proxy/proxy.module.ts
@@ -16,6 +16,7 @@ import {
 import { DemoProxyController } from './demo-proxy.controller.js';
 import { DiscussionsProxyController } from './discussions-proxy.controller.js';
 import { ModerationProxyController } from './moderation-proxy.controller.js';
+import { NotificationProxyController } from './notification-proxy.controller.js';
 import { ResponsesProxyController } from './responses-proxy.controller.js';
 import { TopicsProxyController } from './topics-proxy.controller.js';
 import { UsersProxyController } from './users-proxy.controller.js';
@@ -40,6 +41,7 @@ import { ProxyService } from './proxy.service.js';
     DiscussionsProxyController,
     InvitationsProxyController,
     ModerationProxyController,
+    NotificationProxyController,
     ResponsesProxyController,
     TopicsProxyController,
     UsersProxyController,

--- a/services/api-gateway/src/proxy/proxy.service.ts
+++ b/services/api-gateway/src/proxy/proxy.service.ts
@@ -68,6 +68,7 @@ export class ProxyService {
   private readonly moderationService: ServiceConfig;
   private readonly activityService: ServiceConfig;
   private readonly contactService: ServiceConfig;
+  private readonly notificationService: ServiceConfig;
 
   constructor(
     @Inject(HttpService) private readonly httpService: HttpService,
@@ -123,6 +124,15 @@ export class ProxyService {
       timeout: getConfig<number>('CONTACT_SERVICE_TIMEOUT', DEFAULT_TIMEOUT),
       retryAttempts: getConfig<number>('CONTACT_SERVICE_RETRY_ATTEMPTS', DEFAULT_RETRY_ATTEMPTS),
     };
+
+    this.notificationService = {
+      url: getConfig<string>('NOTIFICATION_SERVICE_URL', getServiceUrl('NOTIFICATION_SERVICE')),
+      timeout: getConfig<number>('NOTIFICATION_SERVICE_TIMEOUT', DEFAULT_TIMEOUT),
+      retryAttempts: getConfig<number>(
+        'NOTIFICATION_SERVICE_RETRY_ATTEMPTS',
+        DEFAULT_RETRY_ATTEMPTS,
+      ),
+    };
   }
 
   async proxyToUserService<T = unknown>(request: ProxyRequest): Promise<AxiosResponse<T>> {
@@ -147,6 +157,10 @@ export class ProxyService {
 
   async proxyToContactService<T = unknown>(request: ProxyRequest): Promise<AxiosResponse<T>> {
     return this.proxyWithResilience<T>('contact-service', this.contactService, request);
+  }
+
+  async proxyToNotificationService<T = unknown>(request: ProxyRequest): Promise<AxiosResponse<T>> {
+    return this.proxyWithResilience<T>('notification-service', this.notificationService, request);
   }
 
   /**

--- a/services/notification-service/src/app.module.ts
+++ b/services/notification-service/src/app.module.ts
@@ -11,6 +11,7 @@ import { HandlersModule } from './handlers/handlers.module.js';
 import { GatewaysModule } from './gateways/gateways.module.js';
 import { JobsModule } from './jobs/jobs.module.js';
 import { ServicesModule } from './services/services.module.js';
+import { NotificationModule } from './notifications/notification.module.js';
 import { MetricsModule } from './observability/index.js';
 
 @Module({
@@ -27,6 +28,7 @@ import { MetricsModule } from './observability/index.js';
     GatewaysModule,
     JobsModule,
     ServicesModule,
+    NotificationModule,
   ],
   controllers: [],
   providers: [],

--- a/services/notification-service/src/auth/auth.module.ts
+++ b/services/notification-service/src/auth/auth.module.ts
@@ -4,19 +4,33 @@
  */
 
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
 import { JwtVerificationService } from './jwt-verification.service.js';
+import { JwtAuthGuard } from './jwt-auth.guard.js';
 
 /**
  * Auth Module for notification-service
  *
- * Provides JWT verification capabilities for WebSocket connections.
- * This is a lightweight auth module that only handles token verification,
- * not full authentication flows.
+ * Provides JWT verification capabilities for both WebSocket connections
+ * and HTTP endpoints.
  */
 @Module({
-  imports: [ConfigModule],
-  providers: [JwtVerificationService],
-  exports: [JwtVerificationService],
+  imports: [
+    ConfigModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET') ?? 'mock-jwt-secret-for-testing',
+        signOptions: {
+          expiresIn: (configService.get<string>('JWT_EXPIRES_IN') ??
+            '24h') as `${number}${'s' | 'm' | 'h' | 'd'}`,
+        },
+      }),
+    }),
+  ],
+  providers: [JwtVerificationService, JwtAuthGuard],
+  exports: [JwtVerificationService, JwtAuthGuard, JwtModule],
 })
 export class AuthModule {}

--- a/services/notification-service/src/auth/current-user.decorator.ts
+++ b/services/notification-service/src/auth/current-user.decorator.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createParamDecorator, type ExecutionContext } from '@nestjs/common';
+import type { JwtPayload } from './jwt-auth.guard.js';
+
+/**
+ * Decorator to extract the current authenticated user from the request.
+ * Use with @UseGuards(JwtAuthGuard) to ensure user is authenticated.
+ */
+export const CurrentUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): JwtPayload => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/services/notification-service/src/auth/index.ts
+++ b/services/notification-service/src/auth/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { JwtAuthGuard, type JwtPayload } from './jwt-auth.guard.js';
+export { CurrentUser } from './current-user.decorator.js';
+export { JwtVerificationService } from './jwt-verification.service.js';
+export { AuthModule } from './auth.module.js';

--- a/services/notification-service/src/auth/jwt-auth.guard.ts
+++ b/services/notification-service/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Inject,
+  Injectable,
+  Optional,
+  UnauthorizedException,
+  type CanActivate,
+  type ExecutionContext,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import * as jwksClient from 'jwks-rsa';
+
+export interface JwtPayload {
+  sub: string; // Cognito user ID (cognitoSub) or database user ID
+  email: string;
+  'cognito:username'?: string;
+  userId?: string; // Database user ID (for database auth mode)
+  exp: number;
+  iat: number;
+}
+
+/**
+ * JWT Auth Guard for HTTP endpoints
+ *
+ * Supports both mock/development mode (HS256 with secret) and
+ * production mode (RS256 with Cognito JWKS).
+ */
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  private readonly jwksClient?: jwksClient.JwksClient;
+  private readonly userPoolId?: string;
+  private readonly region: string;
+  private readonly useMockAuth: boolean;
+  private readonly jwtSecret?: string;
+
+  constructor(
+    @Optional() @Inject(JwtService) private jwtService?: JwtService,
+    @Optional() @Inject(ConfigService) private configService?: ConfigService,
+  ) {
+    const getConfig = (key: string) => this.configService?.get<string>(key) ?? process.env[key];
+
+    this.region = getConfig('AWS_REGION') ?? 'us-east-1';
+
+    const authMode = getConfig('AUTH_MODE');
+    const nodeEnv = getConfig('NODE_ENV');
+    this.useMockAuth =
+      authMode === 'database' ||
+      authMode === 'mock' ||
+      getConfig('AUTH_MOCK') === 'true' ||
+      nodeEnv === 'test' ||
+      nodeEnv === 'development' ||
+      !nodeEnv;
+
+    if (this.useMockAuth) {
+      this.jwtSecret = getConfig('JWT_SECRET') ?? 'mock-jwt-secret-for-testing';
+    } else {
+      this.userPoolId = getConfig('COGNITO_USER_POOL_ID');
+      if (!this.userPoolId) {
+        throw new Error('COGNITO_USER_POOL_ID is required in production mode');
+      }
+      this.jwksClient = jwksClient.default({
+        jwksUri: `https://cognito-idp.${this.region}.amazonaws.com/${this.userPoolId}/.well-known/jwks.json`,
+        cache: true,
+        cacheMaxAge: 86400000,
+      });
+    }
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const token = this.extractTokenFromHeader(request);
+
+    if (!token) {
+      throw new UnauthorizedException('No token provided');
+    }
+
+    try {
+      let payload: JwtPayload;
+
+      if (!this.jwtService) {
+        throw new UnauthorizedException(
+          'JWT service not available - guard not properly configured',
+        );
+      }
+
+      if (this.useMockAuth) {
+        payload = this.jwtService.verify<JwtPayload>(token, {
+          secret: this.jwtSecret!,
+          algorithms: ['HS256'],
+        });
+      } else {
+        const decodedToken = this.jwtService.decode(token, { complete: true }) as {
+          header: { kid: string };
+          payload: JwtPayload;
+        };
+
+        if (!decodedToken || !decodedToken.header.kid) {
+          throw new UnauthorizedException('Invalid token format');
+        }
+
+        const key = await this.jwksClient!.getSigningKey(decodedToken.header.kid);
+        const signingKey = key.getPublicKey();
+
+        payload = this.jwtService.verify<JwtPayload>(token, {
+          publicKey: signingKey,
+          algorithms: ['RS256'],
+        });
+      }
+
+      // Attach the payload to the request object
+      request.user = payload;
+
+      return true;
+    } catch (error) {
+      if (error instanceof UnauthorizedException) {
+        throw error;
+      }
+      throw new UnauthorizedException('Invalid or expired token');
+    }
+  }
+
+  private extractTokenFromHeader(request: any): string | undefined {
+    const authHeader = request.headers.authorization;
+    if (!authHeader) {
+      return undefined;
+    }
+
+    const [type, token] = authHeader.split(' ');
+    return type === 'Bearer' ? token : undefined;
+  }
+}

--- a/services/notification-service/src/notifications/index.ts
+++ b/services/notification-service/src/notifications/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { NotificationModule } from './notification.module.js';
+export {
+  NotificationService,
+  type CreateNotificationDto,
+  type NotificationListParams,
+  type NotificationListResult,
+} from './notification.service.js';
+export {
+  NotificationController,
+  type NotificationListResponse,
+  type MarkAllReadResponse,
+} from './notification.controller.js';

--- a/services/notification-service/src/notifications/notification.controller.ts
+++ b/services/notification-service/src/notifications/notification.controller.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Controller,
+  Get,
+  Patch,
+  Delete,
+  Param,
+  Query,
+  UseGuards,
+  ParseUUIDPipe,
+  ParseIntPipe,
+  ParseBoolPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { NotificationService } from './notification.service.js';
+import { JwtAuthGuard, CurrentUser, type JwtPayload } from '../auth/index.js';
+import type { Notification } from '@prisma/client';
+
+/**
+ * Response DTO for notification list
+ */
+export interface NotificationListResponse {
+  notifications: Notification[];
+  total: number;
+  unreadCount: number;
+}
+
+/**
+ * Response DTO for mark all as read
+ */
+export interface MarkAllReadResponse {
+  count: number;
+  message: string;
+}
+
+/**
+ * Controller for user notification management
+ *
+ * Provides REST endpoints for:
+ * - Listing notifications with pagination and filtering
+ * - Marking notifications as read (single or all)
+ * - Deleting notifications
+ */
+@Controller('notifications')
+@UseGuards(JwtAuthGuard)
+export class NotificationController {
+  constructor(private readonly notificationService: NotificationService) {}
+
+  /**
+   * Get user's notifications with optional filtering
+   *
+   * @param user - Authenticated user from JWT
+   * @param isRead - Filter by read status (optional)
+   * @param type - Filter by notification type (optional)
+   * @param limit - Maximum items to return (default: 20, max: 100)
+   * @param offset - Offset for pagination (default: 0)
+   */
+  @Get()
+  async getNotifications(
+    @CurrentUser() user: JwtPayload,
+    @Query('isRead', new ParseBoolPipe({ optional: true })) isRead?: boolean,
+    @Query('type') type?: string,
+    @Query('limit', new ParseIntPipe({ optional: true })) limit?: number,
+    @Query('offset', new ParseIntPipe({ optional: true })) offset?: number,
+  ): Promise<NotificationListResponse> {
+    const userId = user.userId ?? user.sub;
+    const effectiveLimit = Math.min(limit ?? 20, 100);
+
+    return this.notificationService.getNotifications({
+      userId,
+      isRead,
+      type,
+      limit: effectiveLimit,
+      offset: offset ?? 0,
+    });
+  }
+
+  /**
+   * Get a single notification by ID
+   */
+  @Get(':id')
+  async getNotification(
+    @CurrentUser() user: JwtPayload,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<Notification> {
+    const userId = user.userId ?? user.sub;
+    return this.notificationService.getNotificationById(id, userId);
+  }
+
+  /**
+   * Get unread notification count
+   */
+  @Get('unread/count')
+  async getUnreadCount(@CurrentUser() user: JwtPayload): Promise<{ count: number }> {
+    const userId = user.userId ?? user.sub;
+    const count = await this.notificationService.getUnreadCount(userId);
+    return { count };
+  }
+
+  /**
+   * Mark a notification as read
+   */
+  @Patch(':id/read')
+  async markAsRead(
+    @CurrentUser() user: JwtPayload,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<Notification> {
+    const userId = user.userId ?? user.sub;
+    return this.notificationService.markAsRead(id, userId);
+  }
+
+  /**
+   * Mark all notifications as read
+   */
+  @Patch('mark-all-read')
+  async markAllAsRead(@CurrentUser() user: JwtPayload): Promise<MarkAllReadResponse> {
+    const userId = user.userId ?? user.sub;
+    const result = await this.notificationService.markAllAsRead(userId);
+    return {
+      count: result.count,
+      message: `Marked ${result.count} notifications as read`,
+    };
+  }
+
+  /**
+   * Delete a notification
+   */
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteNotification(
+    @CurrentUser() user: JwtPayload,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<void> {
+    const userId = user.userId ?? user.sub;
+    await this.notificationService.deleteNotification(id, userId);
+  }
+
+  /**
+   * Delete all read notifications (cleanup)
+   */
+  @Delete('read')
+  async deleteReadNotifications(@CurrentUser() user: JwtPayload): Promise<{ count: number }> {
+    const userId = user.userId ?? user.sub;
+    return this.notificationService.deleteReadNotifications(userId);
+  }
+}

--- a/services/notification-service/src/notifications/notification.module.ts
+++ b/services/notification-service/src/notifications/notification.module.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Module } from '@nestjs/common';
+import { NotificationController } from './notification.controller.js';
+import { NotificationService } from './notification.service.js';
+import { PrismaModule } from '../prisma/prisma.module.js';
+import { AuthModule } from '../auth/auth.module.js';
+
+/**
+ * Module for user notification REST API
+ *
+ * Provides endpoints for listing, reading, and managing notifications.
+ */
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [NotificationController],
+  providers: [NotificationService],
+  exports: [NotificationService],
+})
+export class NotificationModule {}

--- a/services/notification-service/src/notifications/notification.service.ts
+++ b/services/notification-service/src/notifications/notification.service.ts
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import type { Notification } from '@prisma/client';
+
+export interface NotificationListParams {
+  userId: string;
+  isRead?: boolean;
+  type?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface NotificationListResult {
+  notifications: Notification[];
+  total: number;
+  unreadCount: number;
+}
+
+export interface CreateNotificationDto {
+  userId: string;
+  type: string;
+  title: string;
+  body: string;
+  actionUrl?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Service for managing user notifications
+ *
+ * Handles CRUD operations for in-app notifications stored in the database.
+ */
+@Injectable()
+export class NotificationService {
+  private readonly logger = new Logger(NotificationService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Get notifications for a user with pagination and filtering
+   */
+  async getNotifications(params: NotificationListParams): Promise<NotificationListResult> {
+    const { userId, isRead, type, limit = 20, offset = 0 } = params;
+
+    const where: Record<string, unknown> = { userId };
+
+    if (isRead !== undefined) {
+      where['isRead'] = isRead;
+    }
+
+    if (type) {
+      where['type'] = type;
+    }
+
+    const [notifications, total, unreadCount] = await Promise.all([
+      this.prisma.notification.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+        skip: offset,
+      }),
+      this.prisma.notification.count({ where }),
+      this.prisma.notification.count({
+        where: { userId, isRead: false },
+      }),
+    ]);
+
+    return { notifications, total, unreadCount };
+  }
+
+  /**
+   * Get a single notification by ID
+   */
+  async getNotificationById(id: string, userId: string): Promise<Notification> {
+    const notification = await this.prisma.notification.findFirst({
+      where: { id, userId },
+    });
+
+    if (!notification) {
+      throw new NotFoundException(`Notification ${id} not found`);
+    }
+
+    return notification;
+  }
+
+  /**
+   * Mark a notification as read
+   */
+  async markAsRead(id: string, userId: string): Promise<Notification> {
+    // Verify ownership
+    await this.getNotificationById(id, userId);
+
+    const notification = await this.prisma.notification.update({
+      where: { id },
+      data: {
+        isRead: true,
+        readAt: new Date(),
+      },
+    });
+
+    this.logger.debug(`Marked notification ${id} as read for user ${userId}`);
+
+    return notification;
+  }
+
+  /**
+   * Mark all notifications as read for a user
+   */
+  async markAllAsRead(userId: string): Promise<{ count: number }> {
+    const result = await this.prisma.notification.updateMany({
+      where: { userId, isRead: false },
+      data: {
+        isRead: true,
+        readAt: new Date(),
+      },
+    });
+
+    this.logger.debug(`Marked ${result.count} notifications as read for user ${userId}`);
+
+    return { count: result.count };
+  }
+
+  /**
+   * Get unread notification count for a user
+   */
+  async getUnreadCount(userId: string): Promise<number> {
+    return this.prisma.notification.count({
+      where: { userId, isRead: false },
+    });
+  }
+
+  /**
+   * Create a new notification
+   *
+   * This is typically called by notification handlers, not directly by users.
+   */
+  async createNotification(dto: CreateNotificationDto): Promise<Notification> {
+    const notification = await this.prisma.notification.create({
+      data: {
+        userId: dto.userId,
+        type: dto.type,
+        title: dto.title,
+        body: dto.body,
+        actionUrl: dto.actionUrl,
+        metadata: dto.metadata as object | undefined,
+      },
+    });
+
+    this.logger.log(`Created notification ${notification.id} for user ${dto.userId}`);
+
+    return notification;
+  }
+
+  /**
+   * Delete a notification
+   */
+  async deleteNotification(id: string, userId: string): Promise<void> {
+    // Verify ownership
+    await this.getNotificationById(id, userId);
+
+    await this.prisma.notification.delete({
+      where: { id },
+    });
+
+    this.logger.debug(`Deleted notification ${id} for user ${userId}`);
+  }
+
+  /**
+   * Delete all read notifications for a user (cleanup)
+   */
+  async deleteReadNotifications(userId: string): Promise<{ count: number }> {
+    const result = await this.prisma.notification.deleteMany({
+      where: { userId, isRead: true },
+    });
+
+    this.logger.debug(`Deleted ${result.count} read notifications for user ${userId}`);
+
+    return { count: result.count };
+  }
+}


### PR DESCRIPTION
## Summary
- Add REST API endpoints for user notifications in notification-service
- Create API gateway proxy for notification routes
- Update frontend hooks to call real API instead of mock data
- Integrate WebSocket with AuthContext for authenticated real-time updates

## Details

**Backend (notification-service):**
- Add `JwtAuthGuard` and `CurrentUser` decorator for HTTP authentication
- Create `NotificationService` with database operations
- Create `NotificationController` with REST endpoints:
  - `GET /notifications` - List with pagination and filtering
  - `GET /notifications/:id` - Get single notification
  - `GET /notifications/unread/count` - Get unread count
  - `PATCH /notifications/:id/read` - Mark as read
  - `PATCH /notifications/mark-all-read` - Mark all as read
  - `DELETE /notifications/:id` - Delete notification
  - `DELETE /notifications/read` - Delete all read notifications

**Backend (api-gateway):**
- Add notification service proxy configuration
- Create `NotificationProxyController` for request forwarding

**Frontend:**
- Update `useNotifications` hook to use real API with optimistic updates
- Integrate `useWebSocket` hook with `AuthContext` for authenticated connections

## Test plan
- [x] All 99 notification-service unit tests pass
- [x] All 2403 frontend unit tests pass
- [x] TypeScript type-check passes
- [x] ESLint passes
- [ ] E2E tests (runs in CI)

Closes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)