### PR TITLE
feat(moderation): implement Report model for content moderation (#1046)

### DIFF
--- a/frontend/src/lib/useFlagContent.ts
+++ b/frontend/src/lib/useFlagContent.ts
@@ -5,10 +5,19 @@
 
 /**
  * Hook for flagging content via the moderation API
+ *
+ * Uses the /moderation/reports endpoint (Issue #1046)
  */
 
 import { useState } from 'react';
-import type { FlagContentRequest, FlagContentResponse } from '../types/moderation';
+import type {
+  FlagContentRequest,
+  FlagContentResponse,
+  FlagCategory,
+  Report,
+  ReportCategory,
+  ReportContentType,
+} from '../types/moderation';
 import { apiClient } from './api';
 
 export interface UseFlagContentState {
@@ -22,6 +31,35 @@ export interface UseFlagContentState {
 export interface UseFlagContentResult extends UseFlagContentState {
   flagContent: (request: FlagContentRequest) => Promise<FlagContentResponse>;
   reset: () => void;
+}
+
+/**
+ * Map frontend FlagCategory to backend ReportCategory
+ */
+function mapCategoryToReportCategory(category: FlagCategory): ReportCategory {
+  const mapping: Record<FlagCategory, ReportCategory> = {
+    inappropriate: 'OTHER',
+    spam: 'SPAM',
+    misinformation: 'MISINFORMATION',
+    harassment: 'HARASSMENT',
+    'hate-speech': 'HATE_SPEECH',
+    violence: 'VIOLENCE',
+    copyright: 'COPYRIGHT',
+    privacy: 'OTHER', // No direct mapping, use OTHER
+    other: 'OTHER',
+  };
+  return mapping[category] || 'OTHER';
+}
+
+/**
+ * Map frontend content type to backend ReportContentType
+ */
+function mapContentType(contentType: FlagContentRequest['contentType']): ReportContentType {
+  // 'comment' and 'other' map to 'response' in the backend
+  if (contentType === 'comment' || contentType === 'other') {
+    return 'response';
+  }
+  return contentType as ReportContentType;
 }
 
 /**
@@ -43,12 +81,26 @@ export function useFlagContent(): UseFlagContentResult {
     setFlagId(null);
 
     try {
-      const response = await apiClient.post<FlagContentResponse>('/moderation/flag', request);
+      // Build report request for new /moderation/reports endpoint
+      const reportRequest = {
+        contentType: mapContentType(request.contentType),
+        contentId: request.contentId,
+        category: mapCategoryToReportCategory(request.category),
+        description: request.description || request.reason,
+      };
+
+      const report = await apiClient.post<Report>('/moderation/reports', reportRequest);
 
       setIsSuccess(true);
-      setFlagId(response.flagId);
+      setFlagId(report.id);
 
-      return response;
+      // Return legacy FlagContentResponse shape for backwards compatibility
+      return {
+        flagId: report.id,
+        status: report.status === 'PENDING' ? 'submitted' : 'processing',
+        createdAt: report.createdAt,
+        message: 'Report submitted successfully',
+      };
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to flag content';
       setIsError(true);

--- a/frontend/src/types/moderation.ts
+++ b/frontend/src/types/moderation.ts
@@ -290,3 +290,129 @@ export interface SafetyReportsStats {
   submittedToday: number;
   awaitingEvidence: number;
 }
+
+// ============================================================================
+// CONTENT REPORT TYPES (Issue #1046)
+// ============================================================================
+
+/**
+ * Content Report Status
+ */
+export type ReportStatus = 'PENDING' | 'REVIEWING' | 'RESOLVED' | 'DISMISSED';
+
+/**
+ * Content Report Category
+ */
+export type ReportCategory =
+  | 'SPAM'
+  | 'HARASSMENT'
+  | 'MISINFORMATION'
+  | 'HATE_SPEECH'
+  | 'VIOLENCE'
+  | 'COPYRIGHT'
+  | 'OTHER';
+
+/**
+ * Content type that can be reported
+ */
+export type ReportContentType = 'topic' | 'response' | 'user';
+
+/**
+ * User info for reporters and moderators
+ */
+export interface ReportUserInfo {
+  id: string;
+  displayName: string | null;
+}
+
+/**
+ * Content Report
+ */
+export interface Report {
+  id: string;
+  reporterId: string;
+  reporter: ReportUserInfo | null;
+  contentType: ReportContentType;
+  contentId: string;
+  category: ReportCategory;
+  description: string | null;
+  status: ReportStatus;
+  moderatorId: string | null;
+  moderator: ReportUserInfo | null;
+  resolution: string | null;
+  createdAt: string;
+  updatedAt: string;
+  resolvedAt: string | null;
+}
+
+/**
+ * Create Report Request
+ */
+export interface CreateReportRequest {
+  contentType: ReportContentType;
+  contentId: string;
+  category: ReportCategory;
+  description?: string;
+}
+
+/**
+ * Update Report Status Request
+ */
+export interface UpdateReportStatusRequest {
+  status: ReportStatus;
+  resolution?: string;
+}
+
+/**
+ * Report List Response
+ */
+export interface ReportListResponse {
+  reports: Report[];
+  nextCursor: string | null;
+  totalCount: number;
+}
+
+/**
+ * Report Statistics
+ */
+export interface ReportStats {
+  byStatus: Record<ReportStatus, number>;
+  byCategory: Record<ReportCategory, number>;
+  totalPending: number;
+  avgResolutionTimeMinutes: number;
+  oldestPendingAge: string;
+}
+
+/**
+ * Report category display information
+ */
+export const REPORT_CATEGORIES: Record<ReportCategory, { label: string; description: string }> = {
+  SPAM: {
+    label: 'Spam',
+    description: 'Repetitive, commercial, or off-topic content',
+  },
+  HARASSMENT: {
+    label: 'Harassment',
+    description: 'Targets or harasses individuals or groups',
+  },
+  MISINFORMATION: {
+    label: 'Misinformation',
+    description: 'Contains false or misleading information',
+  },
+  HATE_SPEECH: {
+    label: 'Hate Speech',
+    description: 'Contains hateful, discriminatory, or prejudiced language',
+  },
+  VIOLENCE: {
+    label: 'Violence',
+    description: 'Promotes or glorifies violence',
+  },
+  COPYRIGHT: {
+    label: 'Copyright Violation',
+    description: 'Infringes on intellectual property rights',
+  },
+  OTHER: {
+    label: 'Other',
+    description: 'Another reason not listed above',
+  },
+};

--- a/packages/db-models/prisma/schema.prisma
+++ b/packages/db-models/prisma/schema.prisma
@@ -114,6 +114,9 @@ model User {
   privacySettings               UserPrivacySettings?
   // Feature: Notification Service (Issue #1044)
   notifications                 Notification[]
+  // Feature: Content Reporting (Issue #1046)
+  reportsSubmitted              Report[]              @relation("ReportsSubmitted")
+  reportsModerated              Report[]              @relation("ReportsModerated")
 
   @@index([cognitoSub])
   @@index([email])
@@ -1310,6 +1313,57 @@ enum AppealStatus {
   DENIED
 
   @@map("appeal_status")
+}
+
+/// Status of a content report
+enum ReportStatus {
+  PENDING
+  REVIEWING
+  RESOLVED
+  DISMISSED
+
+  @@map("report_status")
+}
+
+/// Category of reported content
+enum ReportCategory {
+  SPAM
+  HARASSMENT
+  MISINFORMATION
+  HATE_SPEECH
+  VIOLENCE
+  COPYRIGHT
+  OTHER
+
+  @@map("report_category")
+}
+
+/// Content report submitted by users for moderation review
+/// Tracks user-flagged content through the moderation workflow
+model Report {
+  id          String         @id @default(uuid()) @db.Uuid
+  reporterId  String         @map("reporter_id") @db.Uuid
+  contentType String         @map("content_type") @db.VarChar(50) // "topic", "response", "user"
+  contentId   String         @map("content_id") @db.Uuid
+  category    ReportCategory
+  description String?        @db.Text
+  status      ReportStatus   @default(PENDING)
+  moderatorId String?        @map("moderator_id") @db.Uuid
+  resolution  String?        @db.Text
+  createdAt   DateTime       @default(now()) @map("created_at")
+  updatedAt   DateTime       @updatedAt @map("updated_at")
+  resolvedAt  DateTime?      @map("resolved_at")
+
+  // Relations
+  reporter  User  @relation("ReportsSubmitted", fields: [reporterId], references: [id], onDelete: Cascade)
+  moderator User? @relation("ReportsModerated", fields: [moderatorId], references: [id])
+
+  @@index([status])
+  @@index([contentType, contentId])
+  @@index([reporterId])
+  @@index([createdAt])
+  @@index([category])
+  @@map("reports")
 }
 
 // ============================================================================

--- a/packages/event-schemas/src/moderation.ts
+++ b/packages/event-schemas/src/moderation.ts
@@ -168,12 +168,90 @@ export interface SafetyReportCreatedEvent extends BaseEvent<
 }
 
 /**
- * Event types for moderation service - extended with safety reports
+ * Event types for moderation service - extended with safety reports and content reports
  */
 export const MODERATION_EVENT_TYPES_EXTENDED = {
   ...MODERATION_EVENT_TYPES,
   SAFETY_REPORT_CREATED: 'safety.report.created',
+  REPORT_CREATED: 'report.created',
+  REPORT_STATUS_CHANGED: 'report.status.changed',
 } as const;
+
+// ============================================================================
+// CONTENT REPORT EVENTS (Issue #1046)
+// ============================================================================
+
+/**
+ * Category of reported content
+ */
+export type ReportCategory =
+  | 'SPAM'
+  | 'HARASSMENT'
+  | 'MISINFORMATION'
+  | 'HATE_SPEECH'
+  | 'VIOLENCE'
+  | 'COPYRIGHT'
+  | 'OTHER';
+
+/**
+ * Status of a content report
+ */
+export type ReportStatus = 'PENDING' | 'REVIEWING' | 'RESOLVED' | 'DISMISSED';
+
+/**
+ * Payload for report.created event
+ * Published when a user submits a content report
+ */
+export interface ReportCreatedPayload {
+  /** Unique report ID */
+  reportId: string;
+  /** ID of the user who submitted the report */
+  reporterId: string;
+  /** Type of content being reported */
+  contentType: 'topic' | 'response' | 'user';
+  /** ID of the content being reported */
+  contentId: string;
+  /** Category of the report */
+  category: ReportCategory;
+  /** When the report was created */
+  createdAt: string;
+}
+
+/**
+ * Event published when a content report is created
+ */
+export interface ReportCreatedEvent extends BaseEvent<'report.created', ReportCreatedPayload> {
+  type: 'report.created';
+}
+
+/**
+ * Payload for report.status.changed event
+ * Published when a report's status is updated
+ */
+export interface ReportStatusChangedPayload {
+  /** Report ID */
+  reportId: string;
+  /** Previous status */
+  previousStatus: ReportStatus;
+  /** New status */
+  newStatus: ReportStatus;
+  /** ID of the moderator who changed the status */
+  moderatorId: string;
+  /** Resolution notes (for RESOLVED/DISMISSED) */
+  resolution?: string;
+  /** When the status was changed */
+  changedAt: string;
+}
+
+/**
+ * Event published when a report's status changes
+ */
+export interface ReportStatusChangedEvent extends BaseEvent<
+  'report.status.changed',
+  ReportStatusChangedPayload
+> {
+  type: 'report.status.changed';
+}
 
 /**
  * Union type of all moderation service events
@@ -181,4 +259,6 @@ export const MODERATION_EVENT_TYPES_EXTENDED = {
 export type ModerationEvent =
   | ModerationActionRequestedEvent
   | UserTrustUpdatedEvent
-  | SafetyReportCreatedEvent;
+  | SafetyReportCreatedEvent
+  | ReportCreatedEvent
+  | ReportStatusChangedEvent;

--- a/services/moderation-service/src/controllers/moderation.controller.ts
+++ b/services/moderation-service/src/controllers/moderation.controller.ts
@@ -25,6 +25,17 @@ import { ModerationQueueService } from '../services/moderation-queue.service.js'
 import type { QueueStats } from '../services/moderation-queue.service.js';
 import { SafetyReportService } from '../services/safety-report.service.js';
 import type { SafetyReportResponse, SafetyReportStats } from '../services/safety-report.service.js';
+import { ReportService } from '../services/report.service.js';
+import type {
+  CreateReportRequest,
+  UpdateReportStatusRequest,
+  ReportResponse,
+  ListReportsResponse,
+  ReportStatsResponse,
+  ReportCategory,
+  ReportStatus,
+  ReportContentType,
+} from '../dto/report.dto.js';
 import type { SafetyReportReason, SafetyReportStatus, ReviewPriority } from '@prisma/client';
 import type {
   CreateActionRequest,
@@ -65,6 +76,7 @@ export class ModerationController {
     private readonly actionsService: ModerationActionsService,
     private readonly queueService: ModerationQueueService,
     private readonly safetyReportService: SafetyReportService,
+    private readonly reportService: ReportService,
   ) {}
 
   @Post('screen')
@@ -459,5 +471,121 @@ export class ModerationController {
     @Query('limit') limit: number = 20,
   ): Promise<SafetyReportResponse[]> {
     return this.safetyReportService.getReportsByReporter(userId, limit);
+  }
+
+  // ============================================================================
+  // CONTENT REPORT ENDPOINTS (Issue #1046)
+  // ============================================================================
+
+  @Post('reports')
+  @UseGuards(JwtAuthGuard)
+  async createReport(
+    @CurrentUser() user: JwtPayload,
+    @Body() request: CreateReportRequest,
+  ): Promise<ReportResponse> {
+    if (!request.contentType) {
+      throw new BadRequestException('contentType is required');
+    }
+
+    if (!request.contentId) {
+      throw new BadRequestException('contentId is required');
+    }
+
+    if (!request.category) {
+      throw new BadRequestException('category is required');
+    }
+
+    const validContentTypes: ReportContentType[] = ['topic', 'response', 'user'];
+    if (!validContentTypes.includes(request.contentType)) {
+      throw new BadRequestException(`contentType must be one of: ${validContentTypes.join(', ')}`);
+    }
+
+    const validCategories: ReportCategory[] = [
+      'SPAM',
+      'HARASSMENT',
+      'MISINFORMATION',
+      'HATE_SPEECH',
+      'VIOLENCE',
+      'COPYRIGHT',
+      'OTHER',
+    ];
+    if (!validCategories.includes(request.category)) {
+      throw new BadRequestException(`category must be one of: ${validCategories.join(', ')}`);
+    }
+
+    return this.reportService.createReport(request, user.sub);
+  }
+
+  @Get('reports')
+  async listReports(
+    @Query('status') status?: string,
+    @Query('category') category?: string,
+    @Query('contentType') contentType?: string,
+    @Query('limit') limit: number = 20,
+    @Query('cursor') cursor?: string,
+  ): Promise<ListReportsResponse> {
+    const statusEnum = status?.toUpperCase() as ReportStatus | undefined;
+    const categoryEnum = category?.toUpperCase() as ReportCategory | undefined;
+    const contentTypeEnum = contentType?.toLowerCase() as ReportContentType | undefined;
+
+    return this.reportService.getReports({
+      status: statusEnum,
+      category: categoryEnum,
+      contentType: contentTypeEnum,
+      limit,
+      cursor,
+    });
+  }
+
+  @Get('reports/stats')
+  async getReportStats(): Promise<ReportStatsResponse> {
+    return this.reportService.getReportStats();
+  }
+
+  @Get('reports/pending')
+  async getPendingReports(@Query('limit') limit: number = 20): Promise<ReportResponse[]> {
+    return this.reportService.getPendingReports(limit);
+  }
+
+  @Get('reports/:reportId')
+  async getReport(@Param('reportId') reportId: string): Promise<ReportResponse> {
+    return this.reportService.getReportById(reportId);
+  }
+
+  @Post('reports/:reportId/status')
+  @UseGuards(JwtAuthGuard)
+  async updateReportStatus(
+    @Param('reportId') reportId: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() request: UpdateReportStatusRequest,
+  ): Promise<ReportResponse> {
+    if (!request.status) {
+      throw new BadRequestException('status is required');
+    }
+
+    const validStatuses: ReportStatus[] = ['PENDING', 'REVIEWING', 'RESOLVED', 'DISMISSED'];
+    if (!validStatuses.includes(request.status)) {
+      throw new BadRequestException(`status must be one of: ${validStatuses.join(', ')}`);
+    }
+
+    // Require resolution for terminal statuses
+    if ((request.status === 'RESOLVED' || request.status === 'DISMISSED') && !request.resolution) {
+      throw new BadRequestException('resolution is required when status is RESOLVED or DISMISSED');
+    }
+
+    return this.reportService.updateReportStatus(reportId, request, user.sub);
+  }
+
+  @Get('content/:contentType/:contentId/reports')
+  async getContentReports(
+    @Param('contentType') contentType: string,
+    @Param('contentId') contentId: string,
+  ): Promise<ReportResponse[]> {
+    const validContentTypes: ReportContentType[] = ['topic', 'response', 'user'];
+    if (!validContentTypes.includes(contentType as ReportContentType)) {
+      throw new BadRequestException(`contentType must be one of: ${validContentTypes.join(', ')}`);
+    }
+
+    return this.reportService.getReportsByContent(contentType, contentId);
   }
 }

--- a/services/moderation-service/src/dto/index.ts
+++ b/services/moderation-service/src/dto/index.ts
@@ -28,3 +28,16 @@ export type {
   PendingAppealResponse,
   ListAppealResponse,
 } from './appeal.dto.js';
+
+export type {
+  ReportContentType,
+  ReportCategory,
+  ReportStatus,
+  CreateReportRequest,
+  UpdateReportStatusRequest,
+  ReportFiltersDto,
+  ReporterInfo,
+  ReportResponse,
+  ListReportsResponse,
+  ReportStatsResponse,
+} from './report.dto.js';

--- a/services/moderation-service/src/dto/report.dto.ts
+++ b/services/moderation-service/src/dto/report.dto.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Report DTOs
+ * Data Transfer Objects for content report requests and responses
+ */
+
+/**
+ * Valid content types that can be reported
+ */
+export type ReportContentType = 'topic' | 'response' | 'user';
+
+/**
+ * Report categories matching Prisma enum
+ */
+export type ReportCategory =
+  | 'SPAM'
+  | 'HARASSMENT'
+  | 'MISINFORMATION'
+  | 'HATE_SPEECH'
+  | 'VIOLENCE'
+  | 'COPYRIGHT'
+  | 'OTHER';
+
+/**
+ * Report status matching Prisma enum
+ */
+export type ReportStatus = 'PENDING' | 'REVIEWING' | 'RESOLVED' | 'DISMISSED';
+
+/**
+ * Request to create a new content report
+ */
+export interface CreateReportRequest {
+  /** Type of content being reported */
+  contentType: ReportContentType;
+  /** ID of the content being reported */
+  contentId: string;
+  /** Category of the report */
+  category: ReportCategory;
+  /** Optional detailed description */
+  description?: string;
+}
+
+/**
+ * Request to update a report's status
+ */
+export interface UpdateReportStatusRequest {
+  /** New status for the report */
+  status: ReportStatus;
+  /** Optional resolution notes (required for RESOLVED/DISMISSED) */
+  resolution?: string;
+}
+
+/**
+ * Query parameters for filtering reports
+ */
+export interface ReportFiltersDto {
+  /** Filter by status */
+  status?: ReportStatus;
+  /** Filter by category */
+  category?: ReportCategory;
+  /** Filter by content type */
+  contentType?: ReportContentType;
+  /** Filter reports created after this date */
+  createdAfter?: Date;
+  /** Filter reports created before this date */
+  createdBefore?: Date;
+  /** Maximum number of items to return */
+  limit?: number;
+  /** Cursor for pagination */
+  cursor?: string;
+}
+
+/**
+ * Reporter information in response
+ */
+export interface ReporterInfo {
+  id: string;
+  displayName: string | null;
+}
+
+/**
+ * Moderator information in response
+ */
+export interface ModeratorInfo {
+  id: string;
+  displayName: string | null;
+}
+
+/**
+ * Response containing report details
+ */
+export interface ReportResponse {
+  id: string;
+  reporterId: string;
+  reporter: ReporterInfo | null;
+  contentType: string;
+  contentId: string;
+  category: string;
+  description: string | null;
+  status: string;
+  moderatorId: string | null;
+  moderator: ModeratorInfo | null;
+  resolution: string | null;
+  createdAt: string;
+  updatedAt: string;
+  resolvedAt: string | null;
+}
+
+/**
+ * Paginated response for listing reports
+ */
+export interface ListReportsResponse {
+  reports: ReportResponse[];
+  nextCursor: string | null;
+  totalCount: number;
+}
+
+/**
+ * Report statistics
+ */
+export interface ReportStatsResponse {
+  /** Total reports by status */
+  byStatus: Record<ReportStatus, number>;
+  /** Total reports by category */
+  byCategory: Record<ReportCategory, number>;
+  /** Total pending reports */
+  totalPending: number;
+  /** Average resolution time in minutes (last 30 days) */
+  avgResolutionTimeMinutes: number;
+  /** Oldest pending report age in ISO 8601 duration */
+  oldestPendingAge: string;
+}

--- a/services/moderation-service/src/services/__tests__/report.service.test.ts
+++ b/services/moderation-service/src/services/__tests__/report.service.test.ts
@@ -1,0 +1,516 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ReportService } from '../report.service.js';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import type { ReportStatus, ReportCategory } from '@prisma/client';
+
+describe('ReportService', () => {
+  let service: ReportService;
+  let prismaService: any;
+  let queueService: any;
+
+  const mockReporter = { id: 'user-456', displayName: 'Test User' };
+  const mockModerator = { id: 'mod-789', displayName: 'Test Moderator' };
+
+  const mockReport = {
+    id: 'report-123',
+    reporterId: 'user-456',
+    contentType: 'response',
+    contentId: 'content-789',
+    category: 'HARASSMENT' as ReportCategory,
+    description: 'Offensive comment',
+    status: 'PENDING' as ReportStatus,
+    moderatorId: null,
+    resolution: null,
+    createdAt: new Date('2025-01-15T10:00:00Z'),
+    updatedAt: new Date('2025-01-15T10:00:00Z'),
+    resolvedAt: null,
+    reporter: mockReporter,
+    moderator: null,
+  };
+
+  beforeEach(() => {
+    prismaService = {
+      report: {
+        create: vi.fn(),
+        findUnique: vi.fn(),
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        update: vi.fn(),
+        count: vi.fn(),
+        groupBy: vi.fn(),
+      },
+    };
+
+    queueService = {
+      publishEvent: vi.fn().mockResolvedValue('message-id'),
+    };
+
+    service = new ReportService(prismaService, queueService);
+  });
+
+  describe('createReport', () => {
+    it('should create a report successfully', async () => {
+      prismaService.report.findFirst.mockResolvedValue(null); // No existing report
+      prismaService.report.create.mockResolvedValue(mockReport);
+
+      const result = await service.createReport(
+        {
+          contentType: 'response',
+          contentId: 'content-789',
+          category: 'HARASSMENT',
+          description: 'Offensive comment',
+        },
+        'user-456',
+      );
+
+      expect(prismaService.report.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          reporterId: 'user-456',
+          contentType: 'response',
+          contentId: 'content-789',
+          category: 'HARASSMENT',
+          description: 'Offensive comment',
+          status: 'PENDING',
+        }),
+        include: {
+          reporter: { select: { id: true, displayName: true } },
+          moderator: { select: { id: true, displayName: true } },
+        },
+      });
+      expect(result.id).toBe('report-123');
+    });
+
+    it('should publish report.created event after creating report', async () => {
+      prismaService.report.findFirst.mockResolvedValue(null);
+      prismaService.report.create.mockResolvedValue(mockReport);
+
+      await service.createReport(
+        {
+          contentType: 'response',
+          contentId: 'content-789',
+          category: 'HARASSMENT',
+          description: 'Offensive comment',
+        },
+        'user-456',
+      );
+
+      expect(queueService.publishEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'report.created',
+          payload: expect.objectContaining({
+            reportId: 'report-123',
+            reporterId: 'user-456',
+            contentType: 'response',
+            category: 'HARASSMENT',
+          }),
+        }),
+      );
+    });
+
+    it('should still return report if event publishing fails', async () => {
+      prismaService.report.findFirst.mockResolvedValue(null);
+      prismaService.report.create.mockResolvedValue(mockReport);
+      queueService.publishEvent.mockRejectedValue(new Error('Queue unavailable'));
+
+      const result = await service.createReport(
+        {
+          contentType: 'response',
+          contentId: 'content-789',
+          category: 'HARASSMENT',
+        },
+        'user-456',
+      );
+
+      // Report should still be returned even though event publishing failed
+      expect(result.id).toBe('report-123');
+    });
+
+    it('should reject invalid content type', async () => {
+      await expect(
+        service.createReport(
+          {
+            contentType: 'invalid' as any,
+            contentId: 'content-789',
+            category: 'SPAM',
+          },
+          'user-456',
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject invalid category', async () => {
+      await expect(
+        service.createReport(
+          {
+            contentType: 'response',
+            contentId: 'content-789',
+            category: 'INVALID' as any,
+          },
+          'user-456',
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject duplicate pending report from same user', async () => {
+      prismaService.report.findFirst.mockResolvedValue(mockReport);
+
+      await expect(
+        service.createReport(
+          {
+            contentType: 'response',
+            contentId: 'content-789',
+            category: 'HARASSMENT',
+          },
+          'user-456',
+        ),
+      ).rejects.toThrow('You have already submitted a pending report for this content');
+    });
+  });
+
+  describe('getReportById', () => {
+    it('should return a report by ID', async () => {
+      prismaService.report.findUnique.mockResolvedValue(mockReport);
+
+      const result = await service.getReportById('report-123');
+
+      expect(prismaService.report.findUnique).toHaveBeenCalledWith({
+        where: { id: 'report-123' },
+        include: {
+          reporter: { select: { id: true, displayName: true } },
+          moderator: { select: { id: true, displayName: true } },
+        },
+      });
+      expect(result.id).toBe('report-123');
+    });
+
+    it('should throw NotFoundException if report not found', async () => {
+      prismaService.report.findUnique.mockResolvedValue(null);
+
+      await expect(service.getReportById('nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getReports', () => {
+    it('should list reports with pagination', async () => {
+      const reports = [mockReport, { ...mockReport, id: 'report-124' }];
+      prismaService.report.findMany.mockResolvedValue(reports);
+      prismaService.report.count.mockResolvedValue(2);
+
+      const result = await service.getReports({ limit: 20 });
+
+      expect(prismaService.report.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {},
+          orderBy: { createdAt: 'desc' },
+          take: 21,
+        }),
+      );
+      expect(result.reports).toHaveLength(2);
+      expect(result.nextCursor).toBeNull();
+      expect(result.totalCount).toBe(2);
+    });
+
+    it('should filter by status', async () => {
+      prismaService.report.findMany.mockResolvedValue([mockReport]);
+      prismaService.report.count.mockResolvedValue(1);
+
+      await service.getReports({ status: 'PENDING' });
+
+      expect(prismaService.report.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { status: 'PENDING' },
+        }),
+      );
+    });
+
+    it('should filter by category', async () => {
+      prismaService.report.findMany.mockResolvedValue([]);
+      prismaService.report.count.mockResolvedValue(0);
+
+      await service.getReports({ category: 'SPAM' });
+
+      expect(prismaService.report.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { category: 'SPAM' },
+        }),
+      );
+    });
+
+    it('should filter by content type', async () => {
+      prismaService.report.findMany.mockResolvedValue([]);
+      prismaService.report.count.mockResolvedValue(0);
+
+      await service.getReports({ contentType: 'topic' });
+
+      expect(prismaService.report.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { contentType: 'topic' },
+        }),
+      );
+    });
+
+    it('should support date range filtering', async () => {
+      prismaService.report.findMany.mockResolvedValue([]);
+      prismaService.report.count.mockResolvedValue(0);
+
+      const createdAfter = new Date('2025-01-01');
+      const createdBefore = new Date('2025-01-31');
+
+      await service.getReports({ createdAfter, createdBefore });
+
+      expect(prismaService.report.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            createdAt: { gte: createdAfter, lte: createdBefore },
+          },
+        }),
+      );
+    });
+
+    it('should indicate when there is a next page', async () => {
+      const reports = Array.from({ length: 21 }, (_, i) => ({
+        ...mockReport,
+        id: `report-${i}`,
+      }));
+      prismaService.report.findMany.mockResolvedValue(reports);
+      prismaService.report.count.mockResolvedValue(21);
+
+      const result = await service.getReports({ limit: 20 });
+
+      expect(result.reports).toHaveLength(20);
+      expect(result.nextCursor).toBe('report-19');
+    });
+  });
+
+  describe('getReportsByContent', () => {
+    it('should return reports for a specific content', async () => {
+      prismaService.report.findMany.mockResolvedValue([mockReport]);
+
+      const result = await service.getReportsByContent('response', 'content-789');
+
+      expect(prismaService.report.findMany).toHaveBeenCalledWith({
+        where: {
+          contentType: 'response',
+          contentId: 'content-789',
+        },
+        orderBy: { createdAt: 'desc' },
+        include: {
+          reporter: { select: { id: true, displayName: true } },
+          moderator: { select: { id: true, displayName: true } },
+        },
+      });
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('updateReportStatus', () => {
+    it('should update report status to REVIEWING', async () => {
+      const updatedReport = { ...mockReport, status: 'REVIEWING', moderator: mockModerator };
+      prismaService.report.findUnique.mockResolvedValue(mockReport);
+      prismaService.report.update.mockResolvedValue(updatedReport);
+
+      const result = await service.updateReportStatus(
+        'report-123',
+        { status: 'REVIEWING' },
+        'mod-789',
+      );
+
+      expect(prismaService.report.update).toHaveBeenCalledWith({
+        where: { id: 'report-123' },
+        data: expect.objectContaining({
+          status: 'REVIEWING',
+          moderator: { connect: { id: 'mod-789' } },
+        }),
+        include: {
+          reporter: { select: { id: true, displayName: true } },
+          moderator: { select: { id: true, displayName: true } },
+        },
+      });
+      expect(result.status).toBe('REVIEWING');
+    });
+
+    it('should require resolution for RESOLVED status', async () => {
+      prismaService.report.findUnique.mockResolvedValue(mockReport);
+
+      await expect(
+        service.updateReportStatus('report-123', { status: 'RESOLVED' }, 'mod-789'),
+      ).rejects.toThrow('resolution is required when status is RESOLVED or DISMISSED');
+    });
+
+    it('should require resolution for DISMISSED status', async () => {
+      prismaService.report.findUnique.mockResolvedValue(mockReport);
+
+      await expect(
+        service.updateReportStatus('report-123', { status: 'DISMISSED' }, 'mod-789'),
+      ).rejects.toThrow('resolution is required when status is RESOLVED or DISMISSED');
+    });
+
+    it('should set resolvedAt for RESOLVED status', async () => {
+      const now = new Date();
+      vi.useFakeTimers().setSystemTime(now);
+
+      const updatedReport = {
+        ...mockReport,
+        status: 'RESOLVED',
+        resolution: 'Issue addressed',
+        resolvedAt: now,
+        moderator: mockModerator,
+      };
+      prismaService.report.findUnique.mockResolvedValue(mockReport);
+      prismaService.report.update.mockResolvedValue(updatedReport);
+
+      await service.updateReportStatus(
+        'report-123',
+        { status: 'RESOLVED', resolution: 'Issue addressed' },
+        'mod-789',
+      );
+
+      expect(prismaService.report.update).toHaveBeenCalledWith({
+        where: { id: 'report-123' },
+        data: expect.objectContaining({
+          status: 'RESOLVED',
+          resolution: 'Issue addressed',
+          resolvedAt: now,
+        }),
+        include: expect.anything(),
+      });
+
+      vi.useRealTimers();
+    });
+
+    it('should throw NotFoundException if report not found', async () => {
+      prismaService.report.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.updateReportStatus('nonexistent', { status: 'REVIEWING' }, 'mod-789'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should reject invalid status', async () => {
+      prismaService.report.findUnique.mockResolvedValue(mockReport);
+
+      await expect(
+        service.updateReportStatus('report-123', { status: 'INVALID' as any }, 'mod-789'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should publish report.status.changed event after updating status', async () => {
+      const updatedReport = { ...mockReport, status: 'REVIEWING', moderator: mockModerator };
+      prismaService.report.findUnique.mockResolvedValue(mockReport);
+      prismaService.report.update.mockResolvedValue(updatedReport);
+
+      await service.updateReportStatus('report-123', { status: 'REVIEWING' }, 'mod-789');
+
+      expect(queueService.publishEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'report.status.changed',
+          payload: expect.objectContaining({
+            reportId: 'report-123',
+            previousStatus: 'PENDING',
+            newStatus: 'REVIEWING',
+            moderatorId: 'mod-789',
+          }),
+        }),
+      );
+    });
+
+    it('should still return updated report if event publishing fails', async () => {
+      const updatedReport = { ...mockReport, status: 'REVIEWING', moderator: mockModerator };
+      prismaService.report.findUnique.mockResolvedValue(mockReport);
+      prismaService.report.update.mockResolvedValue(updatedReport);
+      queueService.publishEvent.mockRejectedValue(new Error('Queue unavailable'));
+
+      const result = await service.updateReportStatus(
+        'report-123',
+        { status: 'REVIEWING' },
+        'mod-789',
+      );
+
+      // Status update should still be returned even though event publishing failed
+      expect(result.status).toBe('REVIEWING');
+    });
+  });
+
+  describe('getReportStats', () => {
+    it('should return aggregated statistics', async () => {
+      prismaService.report.groupBy
+        .mockResolvedValueOnce([
+          { status: 'PENDING', _count: { status: 5 } },
+          { status: 'REVIEWING', _count: { status: 3 } },
+          { status: 'RESOLVED', _count: { status: 10 } },
+        ])
+        .mockResolvedValueOnce([
+          { category: 'SPAM', _count: { category: 8 } },
+          { category: 'HARASSMENT', _count: { category: 6 } },
+        ]);
+
+      prismaService.report.findMany.mockResolvedValue([]);
+      prismaService.report.findFirst.mockResolvedValue(null);
+
+      const result = await service.getReportStats();
+
+      expect(result.byStatus.PENDING).toBe(5);
+      expect(result.byStatus.REVIEWING).toBe(3);
+      expect(result.byStatus.RESOLVED).toBe(10);
+      expect(result.byCategory.SPAM).toBe(8);
+      expect(result.byCategory.HARASSMENT).toBe(6);
+      expect(result.totalPending).toBe(8); // PENDING + REVIEWING
+    });
+
+    it('should calculate average resolution time', async () => {
+      prismaService.report.groupBy.mockResolvedValue([]);
+
+      const baseTime = new Date('2025-01-15T10:00:00Z');
+      const resolvedReports = [
+        { createdAt: baseTime, resolvedAt: new Date(baseTime.getTime() + 60 * 60 * 1000) }, // 1 hour
+        { createdAt: baseTime, resolvedAt: new Date(baseTime.getTime() + 30 * 60 * 1000) }, // 30 minutes
+      ];
+      prismaService.report.findMany.mockResolvedValue(resolvedReports);
+      prismaService.report.findFirst.mockResolvedValue(null);
+
+      const result = await service.getReportStats();
+
+      // Average should be 45 minutes
+      expect(result.avgResolutionTimeMinutes).toBe(45);
+    });
+  });
+
+  describe('countPendingReports', () => {
+    it('should count pending reports', async () => {
+      prismaService.report.count.mockResolvedValue(15);
+
+      const result = await service.countPendingReports();
+
+      expect(prismaService.report.count).toHaveBeenCalledWith({
+        where: { status: 'PENDING' },
+      });
+      expect(result).toBe(15);
+    });
+  });
+
+  describe('getPendingReports', () => {
+    it('should get pending reports ordered by creation time', async () => {
+      prismaService.report.findMany.mockResolvedValue([mockReport]);
+
+      const result = await service.getPendingReports(20);
+
+      expect(prismaService.report.findMany).toHaveBeenCalledWith({
+        where: { status: 'PENDING' },
+        orderBy: { createdAt: 'asc' },
+        take: 20,
+        include: {
+          reporter: { select: { id: true, displayName: true } },
+          moderator: { select: { id: true, displayName: true } },
+        },
+      });
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/services/moderation-service/src/services/moderation-queue.service.ts
+++ b/services/moderation-service/src/services/moderation-queue.service.ts
@@ -76,11 +76,10 @@ export class ModerationQueueService {
       items.push(...appeals);
     }
 
-    // Reports will be added once the Report model is implemented
-    // if (!type || type === 'report') {
-    //   const reports = await this.getPendingReports(priority, pageSize, cursor);
-    //   items.push(...reports);
-    // }
+    if (!type || type === 'report') {
+      const reports = await this.getPendingReports(priority, pageSize, cursor);
+      items.push(...reports);
+    }
 
     // Sort items by priority and creation time
     const sortedItems = this.sortQueueItems(items).slice(0, pageSize);
@@ -93,9 +92,9 @@ export class ModerationQueueService {
     if (!type || type === 'appeal') {
       totalCount += await this.countPendingAppeals();
     }
-    // if (!type || type === 'report') {
-    //   totalCount += await this.countPendingReports();
-    // }
+    if (!type || type === 'report') {
+      totalCount += await this.countPendingReports();
+    }
 
     return {
       items: sortedItems,
@@ -107,17 +106,17 @@ export class ModerationQueueService {
    * Get queue statistics including counts and resolution metrics
    */
   async getQueueStats(): Promise<QueueStats> {
-    const [pendingActions, pendingAppeals, metrics] = await Promise.all([
+    const [pendingActions, pendingAppeals, pendingReports, metrics] = await Promise.all([
       this.countPendingActions(),
       this.countPendingAppeals(),
-      // this.countPendingReports(), // TODO: add when Report model is implemented
+      this.countPendingReports(),
       this.calculateMetrics(),
     ]);
 
     return {
       pendingActions,
       pendingAppeals,
-      pendingReports: 0, // TODO: update when Report model is implemented
+      pendingReports,
       avgResolutionTimeMinutes: metrics.avgResolutionTimeMinutes,
       oldestItemAge: metrics.oldestItemAge,
     };
@@ -180,32 +179,31 @@ export class ModerationQueueService {
     }));
   }
 
-  // /**
-  //  * Get pending reports (from users)
-  //  * TODO: Implement when Report model is added to Prisma schema
-  //  */
-  // private async getPendingReports(
-  //   priority?: string,
-  //   limit: number = 20,
-  //   cursor?: string,
-  // ): Promise<QueueItem[]> {
-  //   const reports = await this.prisma.report.findMany({
-  //     where: {
-  //       status: 'PENDING',
-  //     },
-  //     orderBy: [{ createdAt: 'asc' }],
-  //     take: limit,
-  //     ...(cursor && { skip: 1, cursor: { id: cursor } }),
-  //   });
-  //
-  //   return reports.map((report) => ({
-  //     type: 'report' as const,
-  //     id: report.id,
-  //     priority: this.calculateReportPriority(report),
-  //     waitTime: this.calculateWaitTime(report.createdAt),
-  //     summary: `Report: ${report.reason.substring(0, 30)}...`,
-  //   }));
-  // }
+  /**
+   * Get pending reports (from users)
+   */
+  private async getPendingReports(
+    _priority?: string,
+    limit: number = 20,
+    cursor?: string,
+  ): Promise<QueueItem[]> {
+    const reports = await this.prisma.report.findMany({
+      where: {
+        status: 'PENDING',
+      },
+      orderBy: [{ createdAt: 'asc' }],
+      take: limit,
+      ...(cursor && { skip: 1, cursor: { id: cursor } }),
+    });
+
+    return reports.map((report) => ({
+      type: 'report' as const,
+      id: report.id,
+      priority: this.calculateReportPriority(report),
+      waitTime: this.calculateWaitTime(report.createdAt),
+      summary: `Report: ${report.category} on ${report.contentType} ${report.contentId.substring(0, 8)}`,
+    }));
+  }
 
   /**
    * Count pending moderation actions
@@ -229,15 +227,14 @@ export class ModerationQueueService {
     });
   }
 
-  // /**
-  //  * Count pending reports
-  //  * TODO: Implement when Report model is added
-  //  */
-  // private async countPendingReports(): Promise<number> {
-  //   return this.prisma.report.count({
-  //     where: { status: 'PENDING' },
-  //   });
-  // }
+  /**
+   * Count pending reports
+   */
+  private async countPendingReports(): Promise<number> {
+    return this.prisma.report.count({
+      where: { status: 'PENDING' },
+    });
+  }
 
   /**
    * Calculate priority for a moderation action
@@ -268,19 +265,25 @@ export class ModerationQueueService {
     return 'normal';
   }
 
-  // /**
-  //  * Calculate priority for a report
-  //  * TODO: Use when Report model is implemented
-  //  */
-  // private calculateReportPriority(report: any): 'high' | 'normal' | 'low' {
-  //   // High priority: reports of severe violations
-  //   if (report.reason && report.reason.toLowerCase().includes('violence')) {
-  //     return 'high';
-  //   }
-  //
-  //   // Normal priority: default
-  //   return 'normal';
-  // }
+  /**
+   * Calculate priority for a report
+   */
+  private calculateReportPriority(report: any): 'high' | 'normal' | 'low' {
+    // High priority: severe violation categories
+    const highPriorityCategories = ['VIOLENCE', 'HATE_SPEECH', 'HARASSMENT'];
+    if (highPriorityCategories.includes(report.category)) {
+      return 'high';
+    }
+
+    // Normal priority: moderate violations
+    const normalPriorityCategories = ['MISINFORMATION', 'COPYRIGHT'];
+    if (normalPriorityCategories.includes(report.category)) {
+      return 'normal';
+    }
+
+    // Low priority: spam and other
+    return 'low';
+  }
 
   /**
    * Calculate wait time as ISO 8601 duration
@@ -384,13 +387,12 @@ export class ModerationQueueService {
       orderBy: { createdAt: 'asc' },
     });
 
-    // TODO: Add oldestReport once Report model is implemented
-    // const oldestReport = await this.prisma.report.findFirst({
-    //   where: { status: 'PENDING' },
-    //   orderBy: { createdAt: 'asc' },
-    // });
+    const oldestReport = await this.prisma.report.findFirst({
+      where: { status: 'PENDING' },
+      orderBy: { createdAt: 'asc' },
+    });
 
-    const oldestItems = [oldestAction, oldestAppeal].filter(Boolean);
+    const oldestItems = [oldestAction, oldestAppeal, oldestReport].filter(Boolean);
     if (oldestItems.length > 0) {
       const oldest = oldestItems.reduce((min, item) => {
         return (min?.createdAt || new Date()).getTime() > (item?.createdAt || new Date()).getTime()

--- a/services/moderation-service/src/services/moderation.module.ts
+++ b/services/moderation-service/src/services/moderation.module.ts
@@ -15,6 +15,7 @@ import { SafetyReportService } from './safety-report.service.js';
 import { EvidencePreservationService } from './evidence-preservation.service.js';
 import { NCMECReportingService } from './ncmec-reporting.service.js';
 import { ComplianceReportService } from './compliance-report.service.js';
+import { ReportService } from './report.service.js';
 import { PrismaModule } from '../prisma/prisma.module.js';
 import { QueueModule } from '../queue/queue.module.js';
 
@@ -31,6 +32,7 @@ import { QueueModule } from '../queue/queue.module.js';
     EvidencePreservationService,
     NCMECReportingService,
     ComplianceReportService,
+    ReportService,
   ],
   exports: [
     ContentScreeningService,
@@ -43,6 +45,7 @@ import { QueueModule } from '../queue/queue.module.js';
     EvidencePreservationService,
     NCMECReportingService,
     ComplianceReportService,
+    ReportService,
   ],
 })
 export class ModerationModule {}

--- a/services/moderation-service/src/services/report.service.ts
+++ b/services/moderation-service/src/services/report.service.ts
@@ -1,0 +1,537 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { QueueService } from '../queue/queue.service.js';
+import type { Report, ReportStatus, ReportCategory, Prisma } from '@prisma/client';
+import type {
+  CreateReportRequest,
+  UpdateReportStatusRequest,
+  ReportFiltersDto,
+  ReportResponse,
+  ListReportsResponse,
+  ReportStatsResponse,
+} from '../dto/report.dto.js';
+import type {
+  ReportCreatedEvent,
+  ReportStatusChangedEvent,
+} from '@reason-bridge/event-schemas/moderation';
+
+/**
+ * ReportService handles content reporting functionality.
+ *
+ * Responsibilities:
+ * - Create reports for flagged content
+ * - Retrieve reports with filtering and pagination
+ * - Update report status and resolution
+ * - Generate report statistics
+ * - Publish events for real-time notifications
+ */
+@Injectable()
+export class ReportService {
+  private readonly logger = new Logger(ReportService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly queueService: QueueService,
+  ) {}
+
+  /**
+   * Create a new content report
+   *
+   * @param data - Report creation data
+   * @param reporterId - ID of the user submitting the report
+   * @returns The created report
+   */
+  async createReport(data: CreateReportRequest, reporterId: string): Promise<ReportResponse> {
+    // Validate content type
+    const validContentTypes = ['topic', 'response', 'user'];
+    if (!validContentTypes.includes(data.contentType)) {
+      throw new BadRequestException(`contentType must be one of: ${validContentTypes.join(', ')}`);
+    }
+
+    // Validate category
+    const validCategories: ReportCategory[] = [
+      'SPAM',
+      'HARASSMENT',
+      'MISINFORMATION',
+      'HATE_SPEECH',
+      'VIOLENCE',
+      'COPYRIGHT',
+      'OTHER',
+    ];
+    if (!validCategories.includes(data.category as ReportCategory)) {
+      throw new BadRequestException(`category must be one of: ${validCategories.join(', ')}`);
+    }
+
+    // Check for duplicate pending report from same user on same content
+    const existingReport = await this.prisma.report.findFirst({
+      where: {
+        reporterId,
+        contentType: data.contentType,
+        contentId: data.contentId,
+        status: 'PENDING',
+      },
+    });
+
+    if (existingReport) {
+      throw new BadRequestException('You have already submitted a pending report for this content');
+    }
+
+    const report = await this.prisma.report.create({
+      data: {
+        reporterId,
+        contentType: data.contentType,
+        contentId: data.contentId,
+        category: data.category as ReportCategory,
+        description: data.description,
+        status: 'PENDING',
+      },
+      include: {
+        reporter: {
+          select: { id: true, displayName: true },
+        },
+        moderator: {
+          select: { id: true, displayName: true },
+        },
+      },
+    });
+
+    // Publish report.created event for real-time notifications
+    try {
+      const event: ReportCreatedEvent = {
+        id: report.id,
+        type: 'report.created',
+        timestamp: report.createdAt.toISOString(),
+        version: 1,
+        payload: {
+          reportId: report.id,
+          reporterId: report.reporterId,
+          contentType: report.contentType as 'topic' | 'response' | 'user',
+          contentId: report.contentId,
+          category: report.category,
+          createdAt: report.createdAt.toISOString(),
+        },
+        metadata: {
+          source: 'moderation-service',
+          userId: report.reporterId,
+        },
+      };
+
+      await this.queueService.publishEvent(event);
+      this.logger.log(
+        `Published report.created event for report ${report.id} (category: ${report.category})`,
+      );
+    } catch (error) {
+      // Log error but don't fail the request - report is still created
+      this.logger.error(
+        `Failed to publish report.created event: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    return this.mapReportToResponse(report);
+  }
+
+  /**
+   * Get a single report by ID
+   *
+   * @param reportId - The report ID
+   * @returns The report details
+   * @throws NotFoundException if report doesn't exist
+   */
+  async getReportById(reportId: string): Promise<ReportResponse> {
+    const report = await this.prisma.report.findUnique({
+      where: { id: reportId },
+      include: {
+        reporter: {
+          select: { id: true, displayName: true },
+        },
+        moderator: {
+          select: { id: true, displayName: true },
+        },
+      },
+    });
+
+    if (!report) {
+      throw new NotFoundException(`Report with ID ${reportId} not found`);
+    }
+
+    return this.mapReportToResponse(report);
+  }
+
+  /**
+   * Get reports with filtering and pagination
+   *
+   * @param filters - Filter options
+   * @returns Paginated list of reports
+   */
+  async getReports(filters: ReportFiltersDto = {}): Promise<ListReportsResponse> {
+    const {
+      status,
+      category,
+      contentType,
+      createdAfter,
+      createdBefore,
+      limit = 20,
+      cursor,
+    } = filters;
+
+    const where: Prisma.ReportWhereInput = {};
+
+    if (status) {
+      where.status = status as ReportStatus;
+    }
+
+    if (category) {
+      where.category = category as ReportCategory;
+    }
+
+    if (contentType) {
+      where.contentType = contentType;
+    }
+
+    if (createdAfter || createdBefore) {
+      where.createdAt = {};
+      if (createdAfter) {
+        where.createdAt.gte = createdAfter;
+      }
+      if (createdBefore) {
+        where.createdAt.lte = createdBefore;
+      }
+    }
+
+    const [reports, totalCount] = await Promise.all([
+      this.prisma.report.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        take: limit + 1, // Fetch one extra to check for next page
+        ...(cursor && { skip: 1, cursor: { id: cursor } }),
+        include: {
+          reporter: {
+            select: { id: true, displayName: true },
+          },
+          moderator: {
+            select: { id: true, displayName: true },
+          },
+        },
+      }),
+      this.prisma.report.count({ where }),
+    ]);
+
+    const hasNextPage = reports.length > limit;
+    const items = hasNextPage ? reports.slice(0, limit) : reports;
+    const lastItem = items[items.length - 1];
+    const nextCursor = hasNextPage && lastItem ? lastItem.id : null;
+
+    return {
+      reports: items.map((report) => this.mapReportToResponse(report)),
+      nextCursor,
+      totalCount,
+    };
+  }
+
+  /**
+   * Get reports for a specific piece of content
+   *
+   * @param contentType - Type of content
+   * @param contentId - ID of the content
+   * @returns List of reports for the content
+   */
+  async getReportsByContent(contentType: string, contentId: string): Promise<ReportResponse[]> {
+    const reports = await this.prisma.report.findMany({
+      where: {
+        contentType,
+        contentId,
+      },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        reporter: {
+          select: { id: true, displayName: true },
+        },
+        moderator: {
+          select: { id: true, displayName: true },
+        },
+      },
+    });
+
+    return reports.map((report) => this.mapReportToResponse(report));
+  }
+
+  /**
+   * Update a report's status
+   *
+   * @param reportId - The report ID
+   * @param data - Status update data
+   * @param moderatorId - ID of the moderator making the update
+   * @returns The updated report
+   */
+  async updateReportStatus(
+    reportId: string,
+    data: UpdateReportStatusRequest,
+    moderatorId: string,
+  ): Promise<ReportResponse> {
+    // Validate status
+    const validStatuses: ReportStatus[] = ['PENDING', 'REVIEWING', 'RESOLVED', 'DISMISSED'];
+    if (!validStatuses.includes(data.status as ReportStatus)) {
+      throw new BadRequestException(`status must be one of: ${validStatuses.join(', ')}`);
+    }
+
+    // Check if report exists
+    const existingReport = await this.prisma.report.findUnique({
+      where: { id: reportId },
+    });
+
+    if (!existingReport) {
+      throw new NotFoundException(`Report with ID ${reportId} not found`);
+    }
+
+    // Require resolution for RESOLVED or DISMISSED status
+    if ((data.status === 'RESOLVED' || data.status === 'DISMISSED') && !data.resolution) {
+      throw new BadRequestException('resolution is required when status is RESOLVED or DISMISSED');
+    }
+
+    const updateData: Prisma.ReportUpdateInput = {
+      status: data.status as ReportStatus,
+      moderator: { connect: { id: moderatorId } },
+    };
+
+    if (data.resolution) {
+      updateData.resolution = data.resolution;
+    }
+
+    // Set resolvedAt for terminal statuses
+    if (data.status === 'RESOLVED' || data.status === 'DISMISSED') {
+      updateData.resolvedAt = new Date();
+    }
+
+    const previousStatus = existingReport.status;
+
+    const report = await this.prisma.report.update({
+      where: { id: reportId },
+      data: updateData,
+      include: {
+        reporter: {
+          select: { id: true, displayName: true },
+        },
+        moderator: {
+          select: { id: true, displayName: true },
+        },
+      },
+    });
+
+    // Publish report.status.changed event for real-time notifications
+    try {
+      const event: ReportStatusChangedEvent = {
+        id: `${report.id}-status-${Date.now()}`,
+        type: 'report.status.changed',
+        timestamp: new Date().toISOString(),
+        version: 1,
+        payload: {
+          reportId: report.id,
+          previousStatus: previousStatus,
+          newStatus: report.status,
+          moderatorId,
+          resolution: data.resolution,
+          changedAt: new Date().toISOString(),
+        },
+        metadata: {
+          source: 'moderation-service',
+          userId: moderatorId,
+        },
+      };
+
+      await this.queueService.publishEvent(event);
+      this.logger.log(
+        `Published report.status.changed event for report ${report.id} (${previousStatus} -> ${report.status})`,
+      );
+    } catch (error) {
+      // Log error but don't fail the request - status update is still saved
+      this.logger.error(
+        `Failed to publish report.status.changed event: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    return this.mapReportToResponse(report);
+  }
+
+  /**
+   * Get report statistics
+   *
+   * @returns Statistics about reports
+   */
+  async getReportStats(): Promise<ReportStatsResponse> {
+    // Get counts by status
+    const statusCounts = await this.prisma.report.groupBy({
+      by: ['status'],
+      _count: { status: true },
+    });
+
+    const byStatus: Record<ReportStatus, number> = {
+      PENDING: 0,
+      REVIEWING: 0,
+      RESOLVED: 0,
+      DISMISSED: 0,
+    };
+
+    statusCounts.forEach((item) => {
+      byStatus[item.status] = item._count.status;
+    });
+
+    // Get counts by category
+    const categoryCounts = await this.prisma.report.groupBy({
+      by: ['category'],
+      _count: { category: true },
+    });
+
+    const byCategory: Record<ReportCategory, number> = {
+      SPAM: 0,
+      HARASSMENT: 0,
+      MISINFORMATION: 0,
+      HATE_SPEECH: 0,
+      VIOLENCE: 0,
+      COPYRIGHT: 0,
+      OTHER: 0,
+    };
+
+    categoryCounts.forEach((item) => {
+      byCategory[item.category] = item._count.category;
+    });
+
+    // Calculate average resolution time (last 30 days)
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const resolvedReports = await this.prisma.report.findMany({
+      where: {
+        status: { in: ['RESOLVED', 'DISMISSED'] },
+        resolvedAt: { not: null },
+        createdAt: { gte: thirtyDaysAgo },
+      },
+      select: {
+        createdAt: true,
+        resolvedAt: true,
+      },
+    });
+
+    let avgResolutionTimeMinutes = 0;
+    if (resolvedReports.length > 0) {
+      const totalMs = resolvedReports.reduce((sum, report) => {
+        const resolutionMs = report.resolvedAt!.getTime() - report.createdAt.getTime();
+        return sum + resolutionMs;
+      }, 0);
+      avgResolutionTimeMinutes = Math.floor(totalMs / resolvedReports.length / 60 / 1000);
+    }
+
+    // Get oldest pending report age
+    const oldestPending = await this.prisma.report.findFirst({
+      where: { status: 'PENDING' },
+      orderBy: { createdAt: 'asc' },
+      select: { createdAt: true },
+    });
+
+    let oldestPendingAge = 'PT0S';
+    if (oldestPending) {
+      oldestPendingAge = this.calculateDuration(oldestPending.createdAt);
+    }
+
+    return {
+      byStatus,
+      byCategory,
+      totalPending: byStatus.PENDING + byStatus.REVIEWING,
+      avgResolutionTimeMinutes,
+      oldestPendingAge,
+    };
+  }
+
+  /**
+   * Count pending reports
+   *
+   * @returns Number of pending reports
+   */
+  async countPendingReports(): Promise<number> {
+    return this.prisma.report.count({
+      where: { status: 'PENDING' },
+    });
+  }
+
+  /**
+   * Get pending reports for the moderation queue
+   *
+   * @param limit - Maximum number to return
+   * @param cursor - Pagination cursor
+   * @returns List of pending reports
+   */
+  async getPendingReports(limit: number = 20, cursor?: string): Promise<ReportResponse[]> {
+    const reports = await this.prisma.report.findMany({
+      where: { status: 'PENDING' },
+      orderBy: { createdAt: 'asc' },
+      take: limit,
+      ...(cursor && { skip: 1, cursor: { id: cursor } }),
+      include: {
+        reporter: {
+          select: { id: true, displayName: true },
+        },
+        moderator: {
+          select: { id: true, displayName: true },
+        },
+      },
+    });
+
+    return reports.map((report) => this.mapReportToResponse(report));
+  }
+
+  /**
+   * Calculate ISO 8601 duration from a date to now
+   */
+  private calculateDuration(fromDate: Date): string {
+    const now = new Date();
+    const diffMs = now.getTime() - fromDate.getTime();
+    const diffSeconds = Math.floor(diffMs / 1000);
+    const diffMinutes = Math.floor(diffSeconds / 60);
+    const diffHours = Math.floor(diffMinutes / 60);
+    const diffDays = Math.floor(diffHours / 24);
+
+    if (diffDays > 0) {
+      return `P${diffDays}D`;
+    }
+    if (diffHours > 0) {
+      return `PT${diffHours}H`;
+    }
+    if (diffMinutes > 0) {
+      return `PT${diffMinutes}M`;
+    }
+    return `PT${diffSeconds}S`;
+  }
+
+  /**
+   * Map a Prisma Report to a ReportResponse
+   */
+  private mapReportToResponse(
+    report: Report & {
+      reporter: { id: string; displayName: string | null } | null;
+      moderator: { id: string; displayName: string | null } | null;
+    },
+  ): ReportResponse {
+    return {
+      id: report.id,
+      reporterId: report.reporterId,
+      reporter: report.reporter
+        ? { id: report.reporter.id, displayName: report.reporter.displayName }
+        : null,
+      contentType: report.contentType,
+      contentId: report.contentId,
+      category: report.category,
+      description: report.description,
+      status: report.status,
+      moderatorId: report.moderatorId,
+      moderator: report.moderator
+        ? { id: report.moderator.id, displayName: report.moderator.displayName }
+        : null,
+      resolution: report.resolution,
+      createdAt: report.createdAt.toISOString(),
+      updatedAt: report.updatedAt.toISOString(),
+      resolvedAt: report.resolvedAt?.toISOString() ?? null,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Add complete content reporting system with Prisma Report model and ReportStatus/ReportCategory enums
- Implement ReportService with CRUD operations and event publishing (report.created, report.status.changed)
- Add 7 new API endpoints for report management (create, list, update status, get stats, etc.)
- Update frontend useFlagContent hook to use new /moderation/reports endpoint with category mapping

## Test plan
- [x] 27 unit tests for ReportService covering all methods
- [x] 258 total tests passing in moderation-service
- [x] Frontend type check passes
- [ ] Manual verification: Create report via FlagContentModal
- [ ] Manual verification: View reports in moderation queue

Closes #1046

🤖 Generated with [Claude Code](https://claude.com/claude-code)