### PR TITLE
chore(deps): add @nestjs/schedule for cron jobs (#1045)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1029,6 +1029,9 @@ importers:
       '@nestjs/platform-fastify':
         specifier: ^11.1.17
         version: 11.1.17(@fastify/static@9.0.0)(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)
+      '@nestjs/schedule':
+        specifier: ^6.1.1
+        version: 6.1.1(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)
       '@nestjs/swagger':
         specifier: ^11.2.6
         version: 11.2.6(@fastify/static@9.0.0)(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
@@ -1123,6 +1126,9 @@ importers:
       '@nestjs/platform-socket.io':
         specifier: ^11.1.17
         version: 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/websockets@11.1.17)(rxjs@7.8.2)
+      '@nestjs/schedule':
+        specifier: ^6.1.1
+        version: 6.1.1(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)
       '@nestjs/swagger':
         specifier: ^11.2.6
         version: 11.2.6(@fastify/static@9.0.0)(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
@@ -2975,7 +2981,6 @@ packages:
   '@pact-foundation/pact-core@19.1.0':
     resolution: {integrity: sha512-2jyns+jkgLZK79ovM3aMSYHaMyu6dWmwOQjykj0GUhs37G5jXPffSsmBR1fm//KSf244OvuyELrAsWC+FnUHgg==}
     engines: {node: '>=20'}
-    cpu: [x64, ia32, arm64]
     os: [darwin, linux, win32]
 
   '@pact-foundation/pact@16.3.0':

--- a/services/moderation-service/package.json
+++ b/services/moderation-service/package.json
@@ -26,6 +26,7 @@
     "@nestjs/core": "^11.1.17",
     "@nestjs/platform-fastify": "^11.1.17",
     "@nestjs/swagger": "^11.2.6",
+    "@nestjs/schedule": "^6.1.1",
     "axios": "^1.13.6",
     "@prisma/adapter-pg": "^7.5.0",
     "@prisma/client": "7.5.0",

--- a/services/moderation-service/src/jobs/jobs.module.ts
+++ b/services/moderation-service/src/jobs/jobs.module.ts
@@ -4,6 +4,7 @@
  */
 
 import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import { PrismaModule } from '../prisma/prisma.module.js';
 import { SlaMonitorJob } from './sla-monitor.job.js';
 
@@ -13,19 +14,9 @@ import { SlaMonitorJob } from './sla-monitor.job.js';
  * @remarks
  * Contains cron jobs that run on a schedule:
  * - SlaMonitorJob: SLA compliance checks every 5 minutes
- *
- * TODO: Enable @nestjs/schedule when dependency is added:
- * ```typescript
- * import { ScheduleModule } from '@nestjs/schedule';
- *
- * @Module({
- *   imports: [ScheduleModule.forRoot(), PrismaModule],
- *   ...
- * })
- * ```
  */
 @Module({
-  imports: [PrismaModule],
+  imports: [ScheduleModule.forRoot(), PrismaModule],
   providers: [SlaMonitorJob],
   exports: [SlaMonitorJob],
 })

--- a/services/moderation-service/src/jobs/sla-monitor.job.ts
+++ b/services/moderation-service/src/jobs/sla-monitor.job.ts
@@ -4,11 +4,9 @@
  */
 
 import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
 import { PrismaService } from '../prisma/prisma.service.js';
 import type { ReviewPriority, ChildReviewStatus } from '@prisma/client';
-
-// TODO: Enable @nestjs/schedule when dependency is added
-// import { Cron } from '@nestjs/schedule';
 
 /**
  * SLA time limits in minutes for each priority level.
@@ -144,7 +142,7 @@ export class SlaMonitorJob {
    *
    * @returns Result of the compliance check including counts and actions taken
    */
-  // @Cron('*/5 * * * *')
+  @Cron('*/5 * * * *')
   async checkSlaCompliance(): Promise<SlaComplianceResult> {
     this.logger.log('Starting SLA compliance check...');
     const checkedAt = new Date();

--- a/services/notification-service/package.json
+++ b/services/notification-service/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-socket.io": "^11.1.17",
     "@nestjs/swagger": "^11.2.6",
     "@nestjs/websockets": "^11.1.17",
+    "@nestjs/schedule": "^6.1.1",
     "@prisma/adapter-pg": "^7.5.0",
     "@prisma/client": "7.5.0",
     "@nestjs/jwt": "^11.0.0",

--- a/services/notification-service/src/jobs/jobs.module.ts
+++ b/services/notification-service/src/jobs/jobs.module.ts
@@ -4,6 +4,7 @@
  */
 
 import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import { PrismaModule } from '../prisma/prisma.module.js';
 import { EmailModule } from '../email/email.module.js';
 import { ParentDigestJob } from './parent-digest.job.js';
@@ -14,19 +15,9 @@ import { ParentDigestJob } from './parent-digest.job.js';
  * @remarks
  * Contains cron jobs that run on a schedule:
  * - ParentDigestJob: Weekly digest emails to parents (Sunday 9 AM UTC)
- *
- * TODO: Enable @nestjs/schedule when dependency is added:
- * ```typescript
- * import { ScheduleModule } from '@nestjs/schedule';
- *
- * @Module({
- *   imports: [ScheduleModule.forRoot(), PrismaModule, EmailModule],
- *   ...
- * })
- * ```
  */
 @Module({
-  imports: [PrismaModule, EmailModule],
+  imports: [ScheduleModule.forRoot(), PrismaModule, EmailModule],
   providers: [ParentDigestJob],
   exports: [ParentDigestJob],
 })

--- a/services/notification-service/src/jobs/parent-digest.job.ts
+++ b/services/notification-service/src/jobs/parent-digest.job.ts
@@ -4,12 +4,10 @@
  */
 
 import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { EmailService } from '../email/email.service.js';
 import { generateParentDigestEmail } from '../templates/index.js';
-
-// TODO: Enable @nestjs/schedule when dependency is added
-// import { Cron } from '@nestjs/schedule';
 
 /**
  * Data required for a child's activity summary in the parent digest.
@@ -82,7 +80,7 @@ export class ParentDigestJob {
    * - Month: * (any)
    * - Day of week: 0 (Sunday)
    */
-  // @Cron('0 9 * * 0')
+  @Cron('0 9 * * 0')
   async handleCron(): Promise<void> {
     this.logger.log('Starting weekly parent digest job...');
 

--- a/services/user-service/src/app.module.ts
+++ b/services/user-service/src/app.module.ts
@@ -6,6 +6,7 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { PrismaModule } from './prisma/prisma.module.js';
 import { CacheModule } from './cache/cache.module.js';
@@ -25,6 +26,8 @@ import { DemoModule } from './demo/demo.module.js';
       // Look for .env files in order: local service config, then root monorepo config
       envFilePath: ['.env.local', '.env', '../../.env.local', '../../.env'],
     }),
+    // Enable scheduled jobs for compliance features
+    ScheduleModule.forRoot(),
     // Rate limiting for brute force protection
     // Use higher limits in test mode to allow E2E tests to run without throttling
     ThrottlerModule.forRoot([

--- a/services/user-service/src/compliance/age-reverification.job.ts
+++ b/services/user-service/src/compliance/age-reverification.job.ts
@@ -4,11 +4,8 @@
  */
 
 import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
 import { PrismaService } from '../prisma/prisma.service.js';
-
-// TODO: Add @Cron decorator when @nestjs/schedule is installed
-// import { Cron, CronExpression } from '@nestjs/schedule';
-// @Cron(CronExpression.EVERY_DAY_AT_3AM)
 
 /**
  * Scheduled job for annual age re-verification of minor users
@@ -44,6 +41,7 @@ export class AgeReverificationJob {
    * 2. Flags them for re-verification (requiresAgeReverification = true)
    * 3. Users will be prompted to re-verify on their next login
    */
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
   async handleCron(): Promise<void> {
     this.logger.log('Starting age re-verification check...');
 

--- a/services/user-service/src/compliance/data-deletion.job.ts
+++ b/services/user-service/src/compliance/data-deletion.job.ts
@@ -4,11 +4,8 @@
  */
 
 import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
 import { DataDeletionService } from './data-deletion.service.js';
-
-// TODO: Add @Cron decorator when @nestjs/schedule is installed
-// import { Cron, CronExpression } from '@nestjs/schedule';
-// @Cron(CronExpression.EVERY_HOUR)
 
 /**
  * Scheduled job for processing data deletion requests after 48-hour grace period
@@ -53,6 +50,7 @@ export class DataDeletionJob {
    * The 48-hour grace period is enforced by the DataDeletionService.createDeletionRequest()
    * method which sets scheduledFor = requestedAt + 48 hours.
    */
+  @Cron(CronExpression.EVERY_HOUR)
   async handleCron(): Promise<void> {
     this.logger.log('Starting data deletion processing job...');
 


### PR DESCRIPTION
## Summary
- Add `@nestjs/schedule` dependency to notification-service and moderation-service
- Import `ScheduleModule.forRoot()` in jobs modules and user-service app module
- Enable `@Cron` decorators on all job handler methods

## Jobs Enabled
| Service | Job | Schedule |
|---------|-----|----------|
| notification-service | ParentDigestJob | Weekly (Sunday 9 AM UTC) |
| moderation-service | SlaMonitorJob | Every 5 minutes |
| user-service | AgeReverificationJob | Daily at 3 AM |
| user-service | DataDeletionJob | Every hour |

## Test plan
- [x] notification-service tests pass (99 tests)
- [x] moderation-service tests pass (258 tests)
- [x] user-service tests pass (847 tests)
- [x] TypeScript compilation succeeds for all services

Closes #1045

🤖 Generated with [Claude Code](https://claude.com/claude-code)