### PR TITLE
feat(responses): implement link previews for shared URLs

### DIFF
--- a/frontend/src/components/responses/LinkPreviewCard.tsx
+++ b/frontend/src/components/responses/LinkPreviewCard.tsx
@@ -1,0 +1,202 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { ExternalLink, Image as ImageIcon, Globe } from 'lucide-react';
+
+/**
+ * Link preview metadata structure
+ */
+export interface LinkPreviewData {
+  url: string;
+  title: string | null;
+  description: string | null;
+  image: string | null;
+  siteName: string | null;
+  favicon: string | null;
+  type: string | null;
+}
+
+export interface LinkPreviewCardProps {
+  /** Preview metadata to display */
+  preview: LinkPreviewData;
+
+  /** Whether the card is in a loading state */
+  isLoading?: boolean;
+
+  /** Compact mode for inline display */
+  compact?: boolean;
+
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * LinkPreviewCard Component
+ *
+ * Displays rich Open Graph metadata for shared URLs in responses.
+ * Shows title, description, image preview, and site favicon.
+ *
+ * Features:
+ * - Responsive layout (image left on desktop, stacked on mobile)
+ * - Dark mode support
+ * - Graceful fallback for missing metadata
+ * - External link indicator
+ * - Compact mode for inline display
+ *
+ * @example
+ * ```tsx
+ * <LinkPreviewCard
+ *   preview={{
+ *     url: "https://example.com/article",
+ *     title: "Article Title",
+ *     description: "A brief description...",
+ *     image: "https://example.com/og-image.jpg",
+ *     siteName: "Example.com",
+ *     favicon: "https://example.com/favicon.ico",
+ *     type: "article"
+ *   }}
+ * />
+ * ```
+ */
+const LinkPreviewCard: React.FC<LinkPreviewCardProps> = ({
+  preview,
+  isLoading = false,
+  compact = false,
+  className = '',
+}) => {
+  const [imageError, setImageError] = React.useState(false);
+  const [faviconError, setFaviconError] = React.useState(false);
+
+  // Extract domain from URL for display
+  const domain = React.useMemo(() => {
+    try {
+      return new URL(preview.url).hostname.replace(/^www\./, '');
+    } catch {
+      return preview.siteName || 'Link';
+    }
+  }, [preview.url, preview.siteName]);
+
+  // Loading skeleton
+  if (isLoading) {
+    return (
+      <div
+        className={`rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 overflow-hidden animate-pulse ${className}`}
+        aria-label="Loading link preview"
+      >
+        <div className={`flex ${compact ? 'flex-row' : 'flex-col sm:flex-row'}`}>
+          {/* Image skeleton */}
+          <div
+            className={`bg-gray-200 dark:bg-gray-700 ${compact ? 'w-16 h-16' : 'w-full sm:w-32 h-24 sm:h-full'}`}
+          />
+          {/* Content skeleton */}
+          <div className="flex-1 p-3 space-y-2">
+            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4" />
+            <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-full" />
+            <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-1/2" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Determine if we should show the image
+  const showImage = preview.image && !imageError;
+
+  return (
+    <a
+      href={preview.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`
+        group block rounded-lg border border-gray-200 dark:border-gray-700
+        bg-white dark:bg-gray-800 overflow-hidden
+        hover:border-primary-300 dark:hover:border-primary-600
+        hover:shadow-md dark:hover:shadow-gray-900/30
+        transition-all duration-200
+        ${className}
+      `}
+      aria-label={`Open ${preview.title || domain} in new tab`}
+    >
+      <div className={`flex ${compact ? 'flex-row' : 'flex-col sm:flex-row'}`}>
+        {/* Image section */}
+        {showImage ? (
+          <div
+            className={`
+              relative shrink-0 bg-gray-100 dark:bg-gray-700
+              ${compact ? 'w-16 h-16' : 'w-full sm:w-40 h-40 sm:h-auto'}
+            `}
+          >
+            <img
+              src={preview.image!}
+              alt=""
+              className="w-full h-full object-cover"
+              onError={() => setImageError(true)}
+              loading="lazy"
+            />
+          </div>
+        ) : (
+          // Placeholder when no image
+          <div
+            className={`
+              shrink-0 bg-gray-100 dark:bg-gray-700
+              flex items-center justify-center
+              ${compact ? 'w-16 h-16' : 'w-full sm:w-40 h-24 sm:h-auto min-h-[80px]'}
+            `}
+          >
+            <ImageIcon className="w-8 h-8 text-gray-400 dark:text-gray-500" />
+          </div>
+        )}
+
+        {/* Content section */}
+        <div className={`flex-1 ${compact ? 'p-2' : 'p-3 sm:p-4'} min-w-0`}>
+          {/* Site info */}
+          <div className="flex items-center gap-2 mb-1">
+            {preview.favicon && !faviconError ? (
+              <img
+                src={preview.favicon}
+                alt=""
+                className="w-4 h-4 rounded-sm"
+                onError={() => setFaviconError(true)}
+              />
+            ) : (
+              <Globe className="w-4 h-4 text-gray-400" />
+            )}
+            <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
+              {preview.siteName || domain}
+            </span>
+          </div>
+
+          {/* Title */}
+          <h4
+            className={`
+              font-medium text-gray-900 dark:text-gray-100
+              group-hover:text-primary-600 dark:group-hover:text-primary-400
+              transition-colors
+              ${compact ? 'text-sm line-clamp-1' : 'text-base line-clamp-2'}
+            `}
+          >
+            {preview.title || domain}
+          </h4>
+
+          {/* Description */}
+          {preview.description && !compact && (
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-300 line-clamp-2">
+              {preview.description}
+            </p>
+          )}
+
+          {/* External link indicator */}
+          <div className="mt-2 flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
+            <ExternalLink className="w-3 h-3" />
+            <span className="truncate">{domain}</span>
+          </div>
+        </div>
+      </div>
+    </a>
+  );
+};
+
+export default LinkPreviewCard;

--- a/frontend/src/components/responses/ResponseItem.tsx
+++ b/frontend/src/components/responses/ResponseItem.tsx
@@ -39,6 +39,8 @@ import { useAuthContext } from '../../contexts/AuthContext';
 import { useRequireAuth } from '../../hooks/useRequireAuth';
 import { apiClient } from '../../lib/api';
 import { InlineTrustBadge } from '../users';
+import { useLinkPreviews } from '../../hooks/useLinkPreviews';
+import { extractUrls } from '../../services/linkPreviewService';
 import ResponseComposer from './ResponseComposer';
 import { LightweightReplyComposer } from './LightweightReplyComposer';
 import ReactionBar from './ReactionBar';
@@ -49,6 +51,7 @@ import VoteButtons from './VoteButtons';
 import ResponseMenu from './ResponseMenu';
 import DeleteConfirmDialog from './DeleteConfirmDialog';
 import ReportDialog, { type ReportReason } from './ReportDialog';
+import LinkPreviewCard from './LinkPreviewCard';
 
 export interface ResponseItemProps {
   response: ResponseDetail;
@@ -132,6 +135,13 @@ export function ResponseItem({
     isPending: isVotePending,
     isLoading: isVoteLoading,
   } = useVotes(response.id);
+
+  // Link previews for URLs in content
+  const contentUrls = useMemo(() => extractUrls(response.content), [response.content]);
+  const { previews, isLoading: isPreviewsLoading } = useLinkPreviews(response.content, {
+    enabled: contentUrls.length > 0,
+    maxUrls: 3, // Limit to 3 previews per response
+  });
 
   // Response menu state
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -403,6 +413,38 @@ export function ResponseItem({
                     </li>
                   ))}
                 </ul>
+              </div>
+            )}
+
+            {/* Link Previews for URLs in content */}
+            {contentUrls.length > 0 && (
+              <div
+                className={`space-y-2 ${compact ? 'mt-2' : 'mt-3'} ${
+                  !isGroupStart && compact ? 'ml-8' : ''
+                }`}
+              >
+                {contentUrls.map((url) => {
+                  const preview = previews.get(url);
+                  if (!preview && !isPreviewsLoading) return null;
+                  return (
+                    <LinkPreviewCard
+                      key={url}
+                      preview={
+                        preview || {
+                          url,
+                          title: null,
+                          description: null,
+                          image: null,
+                          siteName: null,
+                          favicon: null,
+                          type: null,
+                        }
+                      }
+                      isLoading={isPreviewsLoading}
+                      compact={compact}
+                    />
+                  );
+                })}
               </div>
             )}
 

--- a/frontend/src/hooks/useLinkPreviews.ts
+++ b/frontend/src/hooks/useLinkPreviews.ts
@@ -1,0 +1,166 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * useLinkPreviews - React Query hook for fetching link preview metadata
+ *
+ * Detects URLs in content and fetches Open Graph metadata for display.
+ * Results are cached both server-side (Redis) and client-side (React Query).
+ */
+
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  linkPreviewService,
+  extractUrls,
+  type LinkPreviewData,
+  type LinkPreviewError,
+} from '../services/linkPreviewService';
+
+/**
+ * Options for useLinkPreviews hook
+ */
+export interface UseLinkPreviewsOptions {
+  /** Whether to enable fetching (default: true) */
+  enabled?: boolean;
+  /** Stale time in milliseconds (default: 5 minutes) */
+  staleTime?: number;
+  /** Maximum number of URLs to fetch (default: 5) */
+  maxUrls?: number;
+}
+
+/**
+ * Result of useLinkPreviews hook
+ */
+export interface UseLinkPreviewsResult {
+  /** Map of URL to preview data */
+  previews: Map<string, LinkPreviewData>;
+  /** URLs that are currently loading */
+  loadingUrls: Set<string>;
+  /** URLs that failed to load */
+  errorUrls: Map<string, string>;
+  /** Whether any previews are loading */
+  isLoading: boolean;
+  /** Whether any previews failed */
+  isError: boolean;
+  /** Get preview for a specific URL */
+  getPreview: (url: string) => LinkPreviewData | undefined;
+  /** Check if URL is loading */
+  isUrlLoading: (url: string) => boolean;
+  /** Get error for a specific URL */
+  getError: (url: string) => string | undefined;
+}
+
+/**
+ * Hook for fetching link previews for URLs in content
+ *
+ * @param content - Text content to scan for URLs
+ * @param options - Optional configuration
+ * @returns Object with preview data and loading states
+ *
+ * @remarks
+ * **Features:**
+ * - Automatic URL detection in content
+ * - Batch fetching for efficiency
+ * - Server-side caching (24 hours)
+ * - Client-side caching (5 minutes)
+ * - Error handling per-URL
+ *
+ * @example
+ * ```tsx
+ * const { previews, isLoading, getPreview } = useLinkPreviews(response.content);
+ *
+ * // Render preview cards for detected URLs
+ * {urls.map(url => {
+ *   const preview = getPreview(url);
+ *   if (preview) {
+ *     return <LinkPreviewCard key={url} preview={preview} />;
+ *   }
+ *   return null;
+ * })}
+ * ```
+ */
+export function useLinkPreviews(
+  content: string,
+  options: UseLinkPreviewsOptions = {},
+): UseLinkPreviewsResult {
+  const { enabled = true, staleTime = 5 * 60 * 1000, maxUrls = 5 } = options;
+
+  // Extract URLs from content
+  const urls = useMemo(() => {
+    if (!content || !enabled) return [];
+    const extracted = extractUrls(content);
+    return extracted.slice(0, maxUrls);
+  }, [content, enabled, maxUrls]);
+
+  // Create a stable query key from sorted URLs
+  const queryKey = useMemo(() => ['link-previews', [...urls].sort().join(',')], [urls]);
+
+  // Fetch previews for all URLs
+  const { data, isLoading, isError } = useQuery({
+    queryKey,
+    queryFn: async () => {
+      if (urls.length === 0) {
+        return {};
+      }
+      return linkPreviewService.getPreviewsBatch(urls);
+    },
+    enabled: enabled && urls.length > 0,
+    staleTime,
+    // Don't refetch on window focus - previews don't change often
+    refetchOnWindowFocus: false,
+    // Retry once on failure
+    retry: 1,
+  });
+
+  // Process results into maps
+  const { previews, errorUrls, loadingUrls } = useMemo(() => {
+    const previewsMap = new Map<string, LinkPreviewData>();
+    const errorsMap = new Map<string, string>();
+    const loadingSet = new Set<string>();
+
+    if (isLoading) {
+      // All URLs are loading
+      urls.forEach((url) => loadingSet.add(url));
+    } else if (data) {
+      // Process results
+      for (const [url, result] of Object.entries(data)) {
+        if ('error' in result) {
+          errorsMap.set(url, (result as LinkPreviewError).error);
+        } else {
+          previewsMap.set(url, result as LinkPreviewData);
+        }
+      }
+    }
+
+    return { previews: previewsMap, errorUrls: errorsMap, loadingUrls: loadingSet };
+  }, [data, isLoading, urls]);
+
+  // Helper functions
+  const getPreview = (url: string): LinkPreviewData | undefined => {
+    return previews.get(url);
+  };
+
+  const isUrlLoading = (url: string): boolean => {
+    return loadingUrls.has(url);
+  };
+
+  const getError = (url: string): string | undefined => {
+    return errorUrls.get(url);
+  };
+
+  return {
+    previews,
+    loadingUrls,
+    errorUrls,
+    isLoading,
+    isError,
+    getPreview,
+    isUrlLoading,
+    getError,
+  };
+}
+
+export default useLinkPreviews;

--- a/frontend/src/services/linkPreviewService.ts
+++ b/frontend/src/services/linkPreviewService.ts
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Link Preview Service
+ *
+ * Fetches Open Graph metadata for URLs via the backend API.
+ * Results are cached server-side for 24 hours.
+ */
+
+const API_BASE_URL = import.meta.env['VITE_API_URL'] || 'http://localhost:3000';
+
+/**
+ * Link preview metadata
+ */
+export interface LinkPreviewData {
+  /** Original URL */
+  url: string;
+  /** Page title (from og:title or <title>) */
+  title: string | null;
+  /** Page description (from og:description or meta) */
+  description: string | null;
+  /** Preview image URL (from og:image) */
+  image: string | null;
+  /** Site name (from og:site_name) */
+  siteName: string | null;
+  /** Favicon URL */
+  favicon: string | null;
+  /** Content type (article, video, etc.) */
+  type: string | null;
+  /** Whether served from cache */
+  cached: boolean;
+  /** When metadata was fetched */
+  fetchedAt: string;
+}
+
+/**
+ * Error response from link preview API
+ */
+export interface LinkPreviewError {
+  error: string;
+  url: string;
+  code: 'INVALID_URL' | 'FETCH_FAILED' | 'TIMEOUT' | 'BLOCKED' | 'RATE_LIMITED';
+}
+
+/**
+ * Link Preview Service
+ */
+class LinkPreviewService {
+  /**
+   * Get authentication headers for API requests
+   */
+  private getAuthHeaders(): HeadersInit {
+    const token = localStorage.getItem('authToken') || sessionStorage.getItem('authToken');
+    return {
+      'Content-Type': 'application/json',
+      ...(token && { Authorization: `Bearer ${token}` }),
+    };
+  }
+
+  /**
+   * Fetch preview metadata for a single URL
+   *
+   * @param url - URL to fetch metadata for
+   * @returns Link preview data
+   * @throws Error if fetch fails
+   */
+  async getPreview(url: string): Promise<LinkPreviewData> {
+    const response = await fetch(`${API_BASE_URL}/link-previews`, {
+      method: 'POST',
+      headers: this.getAuthHeaders(),
+      body: JSON.stringify({ url }),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.message || 'Failed to fetch link preview');
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Fetch preview metadata for multiple URLs
+   *
+   * @param urls - Array of URLs to fetch
+   * @returns Map of URL to preview data or error
+   */
+  async getPreviewsBatch(
+    urls: string[],
+  ): Promise<Record<string, LinkPreviewData | LinkPreviewError>> {
+    const response = await fetch(`${API_BASE_URL}/link-previews/batch`, {
+      method: 'POST',
+      headers: this.getAuthHeaders(),
+      body: JSON.stringify({ urls }),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.message || 'Failed to fetch link previews');
+    }
+
+    return response.json();
+  }
+}
+
+export const linkPreviewService = new LinkPreviewService();
+
+/**
+ * URL detection regex for finding links in text content
+ * Matches http/https URLs with optional paths and query strings
+ */
+export const URL_PATTERN =
+  /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*)/gi;
+
+/**
+ * Extract URLs from text content
+ *
+ * @param content - Text content to scan for URLs
+ * @returns Array of unique URLs found
+ */
+export function extractUrls(content: string): string[] {
+  const matches = content.match(URL_PATTERN);
+  if (!matches) return [];
+
+  // Return unique URLs only
+  return [...new Set(matches)];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -868,6 +868,9 @@ importers:
       jwks-rsa:
         specifier: 4.0.1
         version: 4.0.1
+      open-graph-scraper:
+        specifier: '6'
+        version: 6.11.0
       pdfkit:
         specifier: 0.18.0
         version: 0.18.0
@@ -4819,6 +4822,9 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
@@ -4950,6 +4956,13 @@ packages:
 
   check-types@11.2.3:
     resolution: {integrity: sha512-+67P1GkJRaxQD6PKK0Et9DhwQB+vGg3PM5+aavopCpZT1lj9jeqfvpgTLAWErNj8qApkkmXlu/Ug74kmhagkXg==}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
 
   chevrotain@10.5.0:
     resolution: {integrity: sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==}
@@ -5145,9 +5158,16 @@ packages:
   crypt@0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -5298,8 +5318,21 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dotenv-expand@12.0.3:
     resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
@@ -5353,6 +5386,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -5371,8 +5407,16 @@ packages:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   environment@1.1.0:
@@ -6070,6 +6114,9 @@ packages:
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -6097,6 +6144,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -7209,6 +7260,9 @@ packages:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
   nypm@0.6.5:
     resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
     engines: {node: '>=18'}
@@ -7282,6 +7336,10 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  open-graph-scraper@6.11.0:
+    resolution: {integrity: sha512-KkO3qMMzJj9KYGtCl19dRtncb+RuBiG/P9BgukcAG4p2w9wSAWTE90vL6/xqth1K9ThkYF/+xfTGrVvU79TJtQ==}
+    engines: {node: '>=20.0.0'}
+
   openai@6.31.0:
     resolution: {integrity: sha512-iqEn3QY1NnVrDOynUWA2Fjs04gzZ0m7fbwR9xZVFmcN1cqQwslMQM2sjQBNkTVFK/rrSvV78SXiBgU+Pyqz1Aw==}
     hasBin: true
@@ -7344,6 +7402,15 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
@@ -8967,6 +9034,15 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -13022,6 +13098,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolbase@1.0.0: {}
+
   bowser@2.14.1: {}
 
   brace-expansion@1.1.12:
@@ -13168,6 +13246,29 @@ snapshots:
   check-error@2.1.3: {}
 
   check-types@11.2.3: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.24.3
+      whatwg-mimetype: 4.0.0
 
   chevrotain@10.5.0:
     dependencies:
@@ -13341,10 +13442,20 @@ snapshots:
 
   crypt@0.0.2: {}
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
+
+  css-what@6.2.2: {}
 
   css.escape@1.5.1: {}
 
@@ -13466,9 +13577,27 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
   dompurify@3.3.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dotenv-expand@12.0.3:
     dependencies:
@@ -13511,6 +13640,11 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
@@ -13550,7 +13684,11 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  entities@4.5.0: {}
+
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   environment@1.1.0: {}
 
@@ -14571,6 +14709,13 @@ snapshots:
 
   html-url-attributes@3.0.1: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -14601,6 +14746,10 @@ snapshots:
   human-signals@5.0.0: {}
 
   husky@9.1.7: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.2:
     dependencies:
@@ -15927,6 +16076,10 @@ snapshots:
     dependencies:
       path-key: 4.0.0
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   nypm@0.6.5:
     dependencies:
       citty: 0.2.1
@@ -16005,6 +16158,13 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  open-graph-scraper@6.11.0:
+    dependencies:
+      chardet: 2.1.1
+      cheerio: 1.2.0
+      iconv-lite: 0.7.2
+      undici: 7.24.3
+
   openai@6.31.0(ws@8.18.3)(zod@4.3.6):
     optionalDependencies:
       ws: 8.18.3
@@ -16079,6 +16239,19 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parse5@8.0.0:
     dependencies:
@@ -17946,6 +18119,12 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-mimetype@5.0.0: {}
 

--- a/services/discussion-service/package.json
+++ b/services/discussion-service/package.json
@@ -18,13 +18,13 @@
     "test:cov": "vitest run --coverage"
   },
   "dependencies": {
-    "@nestjs/config": "^4.0.3",
-    "@nestjs/jwt": "11.0.2",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^5.2.5",
     "@nestjs/cache-manager": "3.1.0",
     "@nestjs/common": "^11.1.17",
+    "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.1.17",
+    "@nestjs/jwt": "11.0.2",
     "@nestjs/platform-fastify": "^11.1.17",
     "@nestjs/platform-socket.io": "^11.1.17",
     "@nestjs/swagger": "^11.2.6",
@@ -42,6 +42,7 @@
     "class-validator": "^0.15.1",
     "fastify": "^5.8.2",
     "jwks-rsa": "4.0.1",
+    "open-graph-scraper": "6",
     "pdfkit": "0.18.0",
     "pg": "^8.20.0",
     "prom-client": "^15.1.3",

--- a/services/discussion-service/src/app.module.ts
+++ b/services/discussion-service/src/app.module.ts
@@ -24,6 +24,7 @@ import { BookmarksModule } from './bookmarks/bookmarks.module.js';
 import { ReadStateModule } from './read-state/read-state.module.js';
 import { GatewaysModule } from './gateways/index.js';
 import { SearchModule } from './search/search.module.js';
+import { LinkPreviewModule } from './link-preview/link-preview.module.js';
 
 /**
  * T009 [P] - Main application module with rate limiting configuration
@@ -86,6 +87,8 @@ import { SearchModule } from './search/search.module.js';
     GatewaysModule,
     // Feature #1040: Unified full-text search
     SearchModule,
+    // Feature #1042: Link preview metadata fetching
+    LinkPreviewModule,
   ],
   controllers: [],
   providers: [],

--- a/services/discussion-service/src/link-preview/dto/link-preview.dto.ts
+++ b/services/discussion-service/src/link-preview/dto/link-preview.dto.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IsUrl, IsNotEmpty, IsString } from 'class-validator';
+
+/**
+ * Request DTO for fetching link preview metadata
+ */
+export class GetLinkPreviewDto {
+  @IsUrl({}, { message: 'Must be a valid URL' })
+  @IsNotEmpty()
+  @IsString()
+  url!: string;
+}
+
+/**
+ * Response DTO containing link preview metadata
+ */
+export interface LinkPreviewResponseDto {
+  /** Original URL that was fetched */
+  url: string;
+
+  /** Page title (from og:title or <title>) */
+  title: string | null;
+
+  /** Page description (from og:description or meta description) */
+  description: string | null;
+
+  /** Preview image URL (from og:image) */
+  image: string | null;
+
+  /** Site name (from og:site_name) */
+  siteName: string | null;
+
+  /** Favicon URL */
+  favicon: string | null;
+
+  /** Content type (article, video, etc.) */
+  type: string | null;
+
+  /** Whether this result was served from cache */
+  cached: boolean;
+
+  /** Timestamp when metadata was fetched */
+  fetchedAt: string;
+}
+
+/**
+ * Error response for link preview failures
+ */
+export interface LinkPreviewErrorDto {
+  /** Error message */
+  error: string;
+
+  /** Original URL that failed */
+  url: string;
+
+  /** Error code for client handling */
+  code: 'INVALID_URL' | 'FETCH_FAILED' | 'TIMEOUT' | 'BLOCKED' | 'RATE_LIMITED';
+}

--- a/services/discussion-service/src/link-preview/index.ts
+++ b/services/discussion-service/src/link-preview/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './link-preview.module.js';
+export * from './link-preview.service.js';
+export * from './link-preview.controller.js';
+export * from './dto/link-preview.dto.js';

--- a/services/discussion-service/src/link-preview/link-preview.controller.ts
+++ b/services/discussion-service/src/link-preview/link-preview.controller.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Controller,
+  Post,
+  Body,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  BadRequestException,
+} from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard.js';
+import { LinkPreviewService } from './link-preview.service.js';
+import { GetLinkPreviewDto } from './dto/link-preview.dto.js';
+import type { LinkPreviewResponseDto, LinkPreviewErrorDto } from './dto/link-preview.dto.js';
+
+/**
+ * Link Preview Controller
+ *
+ * Provides API endpoint for fetching Open Graph metadata for URLs.
+ * Rate limited to prevent abuse when used for arbitrary URL fetching.
+ *
+ * Security:
+ * - Requires authentication
+ * - SSRF protection via validation
+ * - Rate limiting (10 requests per minute)
+ */
+@ApiTags('link-preview')
+@Controller('link-previews')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class LinkPreviewController {
+  constructor(private readonly linkPreviewService: LinkPreviewService) {}
+
+  /**
+   * Fetch Open Graph metadata for a URL
+   *
+   * Returns cached data if available, otherwise fetches from the URL.
+   * Validates URL for SSRF threats before fetching.
+   */
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { limit: 10, ttl: 60000 } }) // 10 requests per minute
+  @ApiOperation({
+    summary: 'Get link preview metadata',
+    description: 'Fetches Open Graph metadata for a URL. Results are cached for 24 hours.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Link preview metadata retrieved successfully',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid URL or URL blocked by security validation',
+  })
+  @ApiResponse({
+    status: 429,
+    description: 'Rate limit exceeded',
+  })
+  async getPreview(@Body() dto: GetLinkPreviewDto): Promise<LinkPreviewResponseDto> {
+    const result = await this.linkPreviewService.getPreview(dto.url);
+
+    if (!result.success) {
+      throw new BadRequestException(result.error);
+    }
+
+    return result.data;
+  }
+
+  /**
+   * Batch fetch previews for multiple URLs
+   *
+   * Useful for pre-fetching all links when loading a response.
+   * Limited to 10 URLs per request.
+   */
+  @Post('batch')
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { limit: 5, ttl: 60000 } }) // 5 batch requests per minute
+  @ApiOperation({
+    summary: 'Get link previews for multiple URLs',
+    description: 'Batch fetches Open Graph metadata for up to 10 URLs.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Link preview metadata for requested URLs',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid request or too many URLs',
+  })
+  async getPreviewsBatch(
+    @Body() body: { urls: string[] },
+  ): Promise<Record<string, LinkPreviewResponseDto | LinkPreviewErrorDto>> {
+    const MAX_URLS = 10;
+
+    if (!body.urls || !Array.isArray(body.urls)) {
+      throw new BadRequestException('urls must be an array');
+    }
+
+    if (body.urls.length > MAX_URLS) {
+      throw new BadRequestException(`Maximum ${MAX_URLS} URLs per request`);
+    }
+
+    const results = await this.linkPreviewService.getPreviewsBatch(body.urls);
+    return Object.fromEntries(results);
+  }
+}

--- a/services/discussion-service/src/link-preview/link-preview.module.ts
+++ b/services/discussion-service/src/link-preview/link-preview.module.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Module } from '@nestjs/common';
+import { LinkPreviewController } from './link-preview.controller.js';
+import { LinkPreviewService } from './link-preview.service.js';
+import { AuthModule } from '../auth/index.js';
+
+/**
+ * Link Preview Module
+ *
+ * Provides functionality for fetching and caching Open Graph metadata
+ * for URLs shared in discussion responses.
+ *
+ * Features:
+ * - Server-side URL fetching (avoids CORS issues)
+ * - Redis caching with 24-hour TTL
+ * - SSRF protection via URL validation
+ * - Rate limiting to prevent abuse
+ *
+ * Endpoints:
+ * - POST /link-previews - Fetch metadata for single URL
+ * - POST /link-previews/batch - Fetch metadata for multiple URLs
+ */
+@Module({
+  imports: [AuthModule],
+  controllers: [LinkPreviewController],
+  providers: [LinkPreviewService],
+  exports: [LinkPreviewService],
+})
+export class LinkPreviewModule {}

--- a/services/discussion-service/src/link-preview/link-preview.service.ts
+++ b/services/discussion-service/src/link-preview/link-preview.service.ts
@@ -1,0 +1,237 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Injectable, Logger, Inject } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
+import ogs from 'open-graph-scraper';
+import { validateCitationUrl, isSafeUrl } from '../utils/ssrf-validator.js';
+import type { LinkPreviewResponseDto, LinkPreviewErrorDto } from './dto/link-preview.dto.js';
+
+/**
+ * Open Graph result object type (subset of what ogs returns)
+ */
+interface OgResult {
+  ogTitle?: string;
+  ogDescription?: string;
+  ogImage?: Array<{ url: string }> | { url: string };
+  ogSiteName?: string;
+  ogType?: string;
+  dcTitle?: string;
+  dcDescription?: string;
+  favicon?: string;
+  error?: string;
+  success?: boolean;
+}
+
+/**
+ * Cache TTL for link previews (24 hours)
+ * Metadata changes infrequently, so longer TTL is appropriate
+ */
+const LINK_PREVIEW_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+
+/**
+ * Request timeout for fetching link metadata (10 seconds)
+ */
+const FETCH_TIMEOUT_MS = 10000;
+
+/**
+ * Link Preview Service
+ *
+ * Fetches and caches Open Graph metadata for URLs shared in responses.
+ * Uses multi-layer security validation via SSRF validator before fetching.
+ *
+ * Features:
+ * - SSRF protection (private IP blocking, DNS rebinding prevention)
+ * - Redis caching with 24-hour TTL
+ * - Graceful fallback for missing metadata
+ * - Timeout protection against slow sites
+ */
+@Injectable()
+export class LinkPreviewService {
+  private readonly logger = new Logger(LinkPreviewService.name);
+
+  constructor(@Inject(CACHE_MANAGER) private readonly cacheManager: Cache) {}
+
+  /**
+   * Generate cache key for a URL
+   */
+  private getCacheKey(url: string): string {
+    // Normalize URL for consistent cache hits
+    const normalized = url.toLowerCase().replace(/\/$/, '');
+    return `link-preview:${normalized}`;
+  }
+
+  /**
+   * Fetch link preview metadata for a URL
+   *
+   * @param url - URL to fetch metadata for
+   * @returns Link preview metadata or error
+   */
+  async getPreview(
+    url: string,
+  ): Promise<
+    { success: true; data: LinkPreviewResponseDto } | { success: false; error: LinkPreviewErrorDto }
+  > {
+    // Step 1: Check cache first
+    const cacheKey = this.getCacheKey(url);
+    try {
+      const cached = await this.cacheManager.get<LinkPreviewResponseDto>(cacheKey);
+      if (cached) {
+        this.logger.debug(`Cache hit for ${url}`);
+        return { success: true, data: { ...cached, cached: true } };
+      }
+    } catch (cacheError) {
+      this.logger.warn(`Cache read error for ${url}: ${cacheError}`);
+      // Continue without cache
+    }
+
+    // Step 2: Validate URL for SSRF threats
+    const validation = await validateCitationUrl(url);
+    if (!isSafeUrl(validation)) {
+      this.logger.warn(`URL blocked by SSRF validator: ${url} - ${validation.error}`);
+      return {
+        success: false,
+        error: {
+          url,
+          error: validation.error || 'URL validation failed',
+          code: 'BLOCKED',
+        },
+      };
+    }
+
+    // Step 3: Fetch Open Graph metadata
+    try {
+      const { result, error } = await ogs({
+        url: validation.normalizedUrl,
+        timeout: FETCH_TIMEOUT_MS,
+        fetchOptions: {
+          headers: {
+            'User-Agent': 'ReasonBridge-LinkPreview/1.0 (+https://reasonbridge.com)',
+          },
+        },
+      });
+
+      if (error || !result.success) {
+        this.logger.warn(`Failed to fetch OG data for ${url}: ${result.error || 'Unknown error'}`);
+        return {
+          success: false,
+          error: {
+            url,
+            error: 'Failed to fetch link metadata',
+            code: 'FETCH_FAILED',
+          },
+        };
+      }
+
+      // Step 4: Build response with fallbacks
+      const preview: LinkPreviewResponseDto = {
+        url: validation.normalizedUrl,
+        title: result.ogTitle || result.dcTitle || null,
+        description: result.ogDescription || result.dcDescription || null,
+        image: this.extractImageUrl(result),
+        siteName: result.ogSiteName || this.extractSiteName(url),
+        favicon: result.favicon || this.buildFaviconUrl(url),
+        type: result.ogType || null,
+        cached: false,
+        fetchedAt: new Date().toISOString(),
+      };
+
+      // Step 5: Cache the result
+      try {
+        await this.cacheManager.set(cacheKey, preview, LINK_PREVIEW_CACHE_TTL);
+        this.logger.debug(`Cached preview for ${url}`);
+      } catch (cacheError) {
+        this.logger.warn(`Cache write error for ${url}: ${cacheError}`);
+        // Continue without caching
+      }
+
+      return { success: true, data: preview };
+    } catch (fetchError) {
+      const isTimeout =
+        fetchError instanceof Error &&
+        (fetchError.message.includes('timeout') || fetchError.message.includes('ETIMEDOUT'));
+
+      this.logger.error(`Error fetching preview for ${url}: ${fetchError}`);
+      return {
+        success: false,
+        error: {
+          url,
+          error: isTimeout ? 'Request timed out' : 'Failed to fetch link metadata',
+          code: isTimeout ? 'TIMEOUT' : 'FETCH_FAILED',
+        },
+      };
+    }
+  }
+
+  /**
+   * Extract the best image URL from OG result
+   */
+  private extractImageUrl(result: OgResult): string | null {
+    if (result.ogImage && Array.isArray(result.ogImage) && result.ogImage.length > 0) {
+      return result.ogImage[0]?.url || null;
+    }
+    if (result.ogImage && typeof result.ogImage === 'object' && 'url' in result.ogImage) {
+      return (result.ogImage as { url: string }).url;
+    }
+    return null;
+  }
+
+  /**
+   * Extract site name from URL hostname
+   */
+  private extractSiteName(url: string): string | null {
+    try {
+      const hostname = new URL(url).hostname;
+      // Remove www. prefix and return domain
+      return hostname.replace(/^www\./, '');
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Build favicon URL from domain
+   */
+  private buildFaviconUrl(url: string): string | null {
+    try {
+      const origin = new URL(url).origin;
+      return `${origin}/favicon.ico`;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Batch fetch previews for multiple URLs
+   * Useful for pre-fetching all links in a response
+   *
+   * @param urls - Array of URLs to fetch
+   * @returns Map of URL to preview result
+   */
+  async getPreviewsBatch(
+    urls: string[],
+  ): Promise<Map<string, LinkPreviewResponseDto | LinkPreviewErrorDto>> {
+    const results = new Map<string, LinkPreviewResponseDto | LinkPreviewErrorDto>();
+
+    // Limit concurrent fetches to prevent overwhelming external servers
+    const BATCH_SIZE = 5;
+    for (let i = 0; i < urls.length; i += BATCH_SIZE) {
+      const batch = urls.slice(i, i + BATCH_SIZE);
+      const batchResults = await Promise.all(
+        batch.map(async (url) => {
+          const result = await this.getPreview(url);
+          return { url, result };
+        }),
+      );
+
+      for (const { url, result } of batchResults) {
+        results.set(url, result.success ? result.data : result.error);
+      }
+    }
+
+    return results;
+  }
+}


### PR DESCRIPTION
## Summary
- Add server-side link preview fetching with Open Graph metadata extraction
- Redis caching with 24-hour TTL reduces external requests
- SSRF protection via existing URL validator (private IP blocking, DNS rebinding prevention)
- Rate limiting prevents abuse (10 single/min, 5 batch/min)
- Frontend LinkPreviewCard component with responsive layout and dark mode support
- Auto-detect up to 3 URLs per response for preview display

## Technical Details

**Backend (discussion-service):**
- `LinkPreviewModule` with controller, service, and DTOs
- Uses `open-graph-scraper` library for metadata extraction
- Batch endpoint for efficient multi-URL fetching

**Frontend:**
- `LinkPreviewCard` - Displays title, description, image, favicon
- `useLinkPreviews` - React Query hook with 5-min client cache
- `linkPreviewService` - API client for preview endpoints
- Integration in `ResponseItem.tsx` below citations

## Test plan
- [x] All 5371 tests pass
- [ ] Verify previews appear for responses with URLs
- [ ] Test Web Share API fallback to clipboard
- [ ] Verify rate limiting blocks excessive requests
- [ ] Test caching behavior (check Redis TTL)

Closes #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)