### PR TITLE
feat(mobile): add swipe gestures for responses and pull-to-refresh

### DIFF
--- a/frontend/src/components/responses/SwipeableResponseWrapper.tsx
+++ b/frontend/src/components/responses/SwipeableResponseWrapper.tsx
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { MessageSquare, Bookmark } from 'lucide-react';
+import { useSwipeActions, type SwipeState } from '../../hooks/useSwipeActions';
+
+export interface SwipeableResponseWrapperProps {
+  /** Response ID for actions */
+  responseId: string;
+  /** Callback when swipe-right triggers reply */
+  onReply?: () => void;
+  /** Child content to wrap */
+  children: React.ReactNode;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Get transform style based on swipe state
+ */
+function getSwipeTransform(swipeState: SwipeState): React.CSSProperties {
+  if (!swipeState.isActive || swipeState.progress === 0) {
+    return {};
+  }
+
+  // Maximum transform distance (in pixels)
+  const maxTransform = 60;
+  const transform = swipeState.progress * maxTransform;
+
+  return {
+    transform: `translateX(${swipeState.direction === 'right' ? transform : -transform}px)`,
+    transition: swipeState.progress < 1 ? 'none' : 'transform 200ms ease-out',
+  };
+}
+
+/**
+ * SwipeableResponseWrapper Component
+ *
+ * Wraps response content with swipe gesture handling and visual feedback.
+ * Shows action indicators (reply icon on right, bookmark on left) during swipe.
+ *
+ * @remarks
+ * - Only active on mobile viewports
+ * - Swipe right → Reply action
+ * - Swipe left → Toggle bookmark
+ * - Visual feedback shows progress during swipe
+ *
+ * @example
+ * ```tsx
+ * <SwipeableResponseWrapper
+ *   responseId={response.id}
+ *   onReply={() => setShowReplyForm(true)}
+ * >
+ *   <ResponseItem response={response} />
+ * </SwipeableResponseWrapper>
+ * ```
+ */
+const SwipeableResponseWrapper: React.FC<SwipeableResponseWrapperProps> = ({
+  responseId,
+  onReply,
+  children,
+  className = '',
+}) => {
+  const { swipeHandlers, swipeState } = useSwipeActions({
+    responseId,
+    onReply,
+  });
+
+  const isSwipingRight = swipeState.direction === 'right' && swipeState.isActive;
+  const isSwipingLeft = swipeState.direction === 'left' && swipeState.isActive;
+
+  return (
+    <div className={`relative overflow-hidden ${className}`} {...swipeHandlers}>
+      {/* Left action indicator (appears when swiping right → Reply) */}
+      <div
+        className={`
+          absolute left-0 top-0 bottom-0 flex items-center justify-center
+          w-16 bg-primary-500 dark:bg-primary-600
+          transition-opacity duration-150
+          ${isSwipingRight ? 'opacity-100' : 'opacity-0'}
+        `}
+        style={{ opacity: isSwipingRight ? swipeState.progress : 0 }}
+        aria-hidden="true"
+      >
+        <MessageSquare
+          className="w-6 h-6 text-white"
+          style={{
+            transform: `scale(${0.5 + swipeState.progress * 0.5})`,
+            transition: 'transform 100ms ease-out',
+          }}
+        />
+      </div>
+
+      {/* Right action indicator (appears when swiping left → Bookmark) */}
+      <div
+        className={`
+          absolute right-0 top-0 bottom-0 flex items-center justify-center
+          w-16 bg-amber-500 dark:bg-amber-600
+          transition-opacity duration-150
+          ${isSwipingLeft ? 'opacity-100' : 'opacity-0'}
+        `}
+        style={{ opacity: isSwipingLeft ? swipeState.progress : 0 }}
+        aria-hidden="true"
+      >
+        <Bookmark
+          className="w-6 h-6 text-white"
+          style={{
+            transform: `scale(${0.5 + swipeState.progress * 0.5})`,
+            transition: 'transform 100ms ease-out',
+          }}
+        />
+      </div>
+
+      {/* Main content with transform during swipe */}
+      <div className="relative bg-white dark:bg-gray-800" style={getSwipeTransform(swipeState)}>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default SwipeableResponseWrapper;

--- a/frontend/src/components/ui/PullToRefreshContainer.tsx
+++ b/frontend/src/components/ui/PullToRefreshContainer.tsx
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { RefreshCw, ArrowDown } from 'lucide-react';
+import { usePullToRefresh, type PullToRefreshState } from '../../hooks/usePullToRefresh';
+
+export interface PullToRefreshContainerProps {
+  /** Callback when refresh is triggered */
+  onRefresh: () => Promise<void>;
+  /** Child content */
+  children: React.ReactNode;
+  /** Additional CSS classes for container */
+  className?: string;
+  /** Whether pull-to-refresh is enabled */
+  enabled?: boolean;
+}
+
+/**
+ * Indicator component for pull-to-refresh state
+ */
+const PullToRefreshIndicator: React.FC<{ state: PullToRefreshState }> = ({ state }) => {
+  const { isPulling, isRefreshing, progress, canRelease, pullDistance } = state;
+
+  if (!isPulling && !isRefreshing && pullDistance === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="absolute top-0 left-0 right-0 flex items-center justify-center overflow-hidden bg-gray-50 dark:bg-gray-900 z-10"
+      style={{
+        height: pullDistance,
+        transition: isPulling ? 'none' : 'height 200ms ease-out',
+      }}
+    >
+      <div
+        className="flex flex-col items-center justify-center gap-1"
+        style={{
+          opacity: Math.min(progress * 1.5, 1),
+          transform: `scale(${0.5 + progress * 0.5})`,
+          transition: isPulling ? 'none' : 'all 200ms ease-out',
+        }}
+      >
+        {isRefreshing ? (
+          <>
+            <RefreshCw className="w-6 h-6 text-primary-500 animate-spin" />
+            <span className="text-xs text-gray-500 dark:text-gray-400">Refreshing...</span>
+          </>
+        ) : canRelease ? (
+          <>
+            <RefreshCw
+              className="w-6 h-6 text-primary-500"
+              style={{ transform: `rotate(${progress * 180}deg)` }}
+            />
+            <span className="text-xs text-primary-500 font-medium">Release to refresh</span>
+          </>
+        ) : (
+          <>
+            <ArrowDown
+              className="w-6 h-6 text-gray-400 dark:text-gray-500"
+              style={{ transform: `rotate(${progress * 180}deg)` }}
+            />
+            <span className="text-xs text-gray-500 dark:text-gray-400">Pull to refresh</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * PullToRefreshContainer Component
+ *
+ * Wraps content with pull-to-refresh functionality on mobile devices.
+ * Shows visual indicator during pull and triggers refresh on release.
+ *
+ * @remarks
+ * - Only active on mobile viewports by default
+ * - Shows progress indicator during pull
+ * - Animates smoothly on release
+ * - Shows spinner during refresh
+ *
+ * @example
+ * ```tsx
+ * <PullToRefreshContainer onRefresh={async () => await refetchTopics()}>
+ *   <TopicList topics={topics} />
+ * </PullToRefreshContainer>
+ * ```
+ */
+const PullToRefreshContainer: React.FC<PullToRefreshContainerProps> = ({
+  onRefresh,
+  children,
+  className = '',
+  enabled,
+}) => {
+  const { state, containerRef, handlers } = usePullToRefresh({
+    onRefresh,
+    enabled,
+  });
+
+  return (
+    <div ref={containerRef} className={`relative overflow-auto ${className}`} {...handlers}>
+      <PullToRefreshIndicator state={state} />
+      <div
+        style={{
+          transform: `translateY(${state.pullDistance}px)`,
+          transition: state.isPulling ? 'none' : 'transform 200ms ease-out',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default PullToRefreshContainer;

--- a/frontend/src/hooks/usePullToRefresh.ts
+++ b/frontend/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,223 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * usePullToRefresh - Hook for pull-to-refresh gesture on mobile
+ *
+ * Enables pull-down gesture at the top of scrollable content
+ * to trigger a refresh action.
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { useIsMobileViewport } from './useMediaQuery';
+
+/**
+ * Pull-to-refresh state
+ */
+export interface PullToRefreshState {
+  /** Whether currently pulling */
+  isPulling: boolean;
+  /** Pull distance in pixels */
+  pullDistance: number;
+  /** Pull progress (0-1) */
+  progress: number;
+  /** Whether refresh has been triggered */
+  isRefreshing: boolean;
+  /** Whether pull threshold has been reached */
+  canRelease: boolean;
+}
+
+/**
+ * Options for usePullToRefresh hook
+ */
+export interface UsePullToRefreshOptions {
+  /** Callback when refresh is triggered */
+  onRefresh: () => Promise<void>;
+  /** Pull distance required to trigger refresh (default: 80px) */
+  threshold?: number;
+  /** Maximum pull distance (default: 120px) */
+  maxPullDistance?: number;
+  /** Whether pull-to-refresh is enabled (default: auto-detects mobile) */
+  enabled?: boolean;
+}
+
+/**
+ * Result of usePullToRefresh hook
+ */
+export interface UsePullToRefreshResult {
+  /** Current pull state */
+  state: PullToRefreshState;
+  /** Ref to attach to scrollable container */
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  /** Touch event handlers */
+  handlers: {
+    onTouchStart: (e: React.TouchEvent) => void;
+    onTouchMove: (e: React.TouchEvent) => void;
+    onTouchEnd: () => void;
+  };
+}
+
+/**
+ * Hook for implementing pull-to-refresh gesture
+ *
+ * @param options - Configuration options
+ * @returns State and handlers for pull-to-refresh
+ *
+ * @example
+ * ```tsx
+ * const { state, containerRef, handlers } = usePullToRefresh({
+ *   onRefresh: async () => {
+ *     await refetchTopics();
+ *   },
+ * });
+ *
+ * <div ref={containerRef} {...handlers}>
+ *   <PullToRefreshIndicator state={state} />
+ *   <TopicList />
+ * </div>
+ * ```
+ */
+export function usePullToRefresh(options: UsePullToRefreshOptions): UsePullToRefreshResult {
+  const { onRefresh, threshold = 80, maxPullDistance = 120, enabled } = options;
+
+  const isMobileViewport = useIsMobileViewport();
+  const isEnabled = enabled ?? isMobileViewport;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const startY = useRef<number>(0);
+  const currentY = useRef<number>(0);
+
+  const [state, setState] = useState<PullToRefreshState>({
+    isPulling: false,
+    pullDistance: 0,
+    progress: 0,
+    isRefreshing: false,
+    canRelease: false,
+  });
+
+  // Handle touch start
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (!isEnabled || state.isRefreshing) return;
+
+      const container = containerRef.current;
+      if (!container) return;
+
+      // Only enable pull-to-refresh when scrolled to top
+      if (container.scrollTop > 0) return;
+
+      const touch = e.touches[0];
+      if (touch) {
+        startY.current = touch.clientY;
+        currentY.current = touch.clientY;
+      }
+    },
+    [isEnabled, state.isRefreshing],
+  );
+
+  // Handle touch move
+  const onTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (!isEnabled || state.isRefreshing || startY.current === 0) return;
+
+      const touch = e.touches[0];
+      if (!touch) return;
+
+      currentY.current = touch.clientY;
+      const deltaY = currentY.current - startY.current;
+
+      // Only handle downward pull
+      if (deltaY <= 0) {
+        setState((prev) => ({
+          ...prev,
+          isPulling: false,
+          pullDistance: 0,
+          progress: 0,
+          canRelease: false,
+        }));
+        return;
+      }
+
+      // Apply resistance to pull (gets harder as you pull further)
+      const resistance = 0.5;
+      const pullDistance = Math.min(deltaY * resistance, maxPullDistance);
+      const progress = Math.min(pullDistance / threshold, 1);
+      const canRelease = pullDistance >= threshold;
+
+      setState({
+        isPulling: true,
+        pullDistance,
+        progress,
+        isRefreshing: false,
+        canRelease,
+      });
+
+      // Prevent default scroll behavior when pulling
+      if (pullDistance > 0) {
+        e.preventDefault();
+      }
+    },
+    [isEnabled, state.isRefreshing, threshold, maxPullDistance],
+  );
+
+  // Handle touch end
+  const onTouchEnd = useCallback(async () => {
+    if (!isEnabled || !state.isPulling) return;
+
+    startY.current = 0;
+    currentY.current = 0;
+
+    if (state.canRelease) {
+      // Trigger refresh
+      setState((prev) => ({
+        ...prev,
+        isPulling: false,
+        isRefreshing: true,
+        pullDistance: threshold, // Keep indicator visible during refresh
+      }));
+
+      try {
+        await onRefresh();
+      } finally {
+        setState({
+          isPulling: false,
+          pullDistance: 0,
+          progress: 0,
+          isRefreshing: false,
+          canRelease: false,
+        });
+      }
+    } else {
+      // Cancel pull
+      setState({
+        isPulling: false,
+        pullDistance: 0,
+        progress: 0,
+        isRefreshing: false,
+        canRelease: false,
+      });
+    }
+  }, [isEnabled, state.isPulling, state.canRelease, threshold, onRefresh]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      startY.current = 0;
+      currentY.current = 0;
+    };
+  }, []);
+
+  return {
+    state,
+    containerRef,
+    handlers: {
+      onTouchStart,
+      onTouchMove,
+      onTouchEnd,
+    },
+  };
+}
+
+export default usePullToRefresh;

--- a/frontend/src/hooks/useSwipeActions.ts
+++ b/frontend/src/hooks/useSwipeActions.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * useSwipeActions - Hook for handling swipe gestures on responses
+ *
+ * Provides swipe action handlers for mobile devices:
+ * - Swipe right → Reply to response
+ * - Swipe left → Toggle bookmark
+ *
+ * @remarks
+ * Only enables swipe gestures on mobile viewports to avoid conflicts
+ * with desktop interactions like text selection.
+ */
+
+import { useCallback, useState } from 'react';
+import { useSwipeable } from 'react-swipeable';
+import type { SwipeEventData } from 'react-swipeable';
+import { useToast } from '../contexts/ToastContext';
+import { useIsMobileViewport } from './useMediaQuery';
+import { useBookmarkStatus } from './useBookmarks';
+import { useRequireAuth } from './useRequireAuth';
+
+/**
+ * Swipe direction for visual feedback
+ */
+export type SwipeDirection = 'left' | 'right' | null;
+
+/**
+ * Swipe action state
+ */
+export interface SwipeState {
+  /** Current swipe direction */
+  direction: SwipeDirection;
+  /** Swipe progress (0-1) for visual feedback */
+  progress: number;
+  /** Whether a swipe action is active */
+  isActive: boolean;
+}
+
+/**
+ * Options for useSwipeActions hook
+ */
+export interface UseSwipeActionsOptions {
+  /** Response ID for bookmark actions */
+  responseId: string;
+  /** Callback when swipe-right triggers reply */
+  onReply?: () => void;
+  /** Minimum swipe distance to trigger action (default: 80px) */
+  threshold?: number;
+  /** Whether swipe gestures are enabled (default: auto-detects mobile) */
+  enabled?: boolean;
+}
+
+/**
+ * Result of useSwipeActions hook
+ */
+export interface UseSwipeActionsResult {
+  /** Swipeable handlers to spread on container element */
+  swipeHandlers: ReturnType<typeof useSwipeable>;
+  /** Current swipe state for visual feedback */
+  swipeState: SwipeState;
+  /** Reset swipe state (call after action completes) */
+  resetSwipe: () => void;
+}
+
+/**
+ * Hook for handling swipe gestures on response items
+ *
+ * @param options - Configuration options
+ * @returns Swipe handlers and state for visual feedback
+ *
+ * @example
+ * ```tsx
+ * const { swipeHandlers, swipeState } = useSwipeActions({
+ *   responseId: response.id,
+ *   onReply: () => setShowReplyForm(true),
+ * });
+ *
+ * <div {...swipeHandlers} className={getSwipeClasses(swipeState)}>
+ *   <ResponseContent />
+ * </div>
+ * ```
+ */
+export function useSwipeActions(options: UseSwipeActionsOptions): UseSwipeActionsResult {
+  const { responseId, onReply, threshold = 80, enabled } = options;
+
+  const isMobileViewport = useIsMobileViewport();
+  const { requireAuth } = useRequireAuth();
+  const toast = useToast();
+  const {
+    isBookmarked,
+    toggleBookmark,
+    isPending: isBookmarkPending,
+  } = useBookmarkStatus(responseId);
+
+  // Swipe state for visual feedback
+  const [swipeState, setSwipeState] = useState<SwipeState>({
+    direction: null,
+    progress: 0,
+    isActive: false,
+  });
+
+  // Reset swipe state
+  const resetSwipe = useCallback(() => {
+    setSwipeState({ direction: null, progress: 0, isActive: false });
+  }, []);
+
+  // Handle swipe right → Reply
+  const handleSwipeRight = useCallback(() => {
+    if (onReply) {
+      requireAuth(() => {
+        onReply();
+        toast.info('Replying to response');
+      });
+    }
+    resetSwipe();
+  }, [onReply, requireAuth, toast, resetSwipe]);
+
+  // Handle swipe left → Toggle bookmark
+  const handleSwipeLeft = useCallback(() => {
+    if (isBookmarkPending) return;
+
+    requireAuth(() => {
+      toggleBookmark();
+      toast.success(isBookmarked ? 'Bookmark removed' : 'Bookmarked!');
+    });
+    resetSwipe();
+  }, [isBookmarked, isBookmarkPending, toggleBookmark, requireAuth, toast, resetSwipe]);
+
+  // Track swipe progress for visual feedback
+  const handleSwiping = useCallback(
+    (eventData: SwipeEventData) => {
+      const { deltaX, dir } = eventData;
+      const absX = Math.abs(deltaX);
+      const progress = Math.min(absX / threshold, 1);
+
+      if (dir === 'Left' || dir === 'Right') {
+        setSwipeState({
+          direction: dir.toLowerCase() as SwipeDirection,
+          progress,
+          isActive: true,
+        });
+      }
+    },
+    [threshold],
+  );
+
+  // Determine if swipe is enabled
+  const isSwipeEnabled = enabled ?? isMobileViewport;
+
+  // Configure swipeable
+  const swipeHandlers = useSwipeable({
+    onSwipedRight: isSwipeEnabled ? handleSwipeRight : undefined,
+    onSwipedLeft: isSwipeEnabled ? handleSwipeLeft : undefined,
+    onSwiping: isSwipeEnabled ? handleSwiping : undefined,
+    onSwiped: resetSwipe,
+    trackMouse: false, // Touch only - don't interfere with mouse
+    trackTouch: true,
+    delta: threshold, // Minimum distance to trigger
+    preventScrollOnSwipe: true, // Prevent vertical scroll during horizontal swipe
+  });
+
+  return {
+    swipeHandlers: isSwipeEnabled ? swipeHandlers : ({} as ReturnType<typeof useSwipeable>),
+    swipeState,
+    resetSwipe,
+  };
+}
+
+export default useSwipeActions;


### PR DESCRIPTION
## Summary
- Add swipe gesture support for mobile devices using existing `react-swipeable` library
- Swipe right on responses to reply, swipe left to toggle bookmark
- Pull-to-refresh functionality for topic lists
- Visual feedback during gestures with smooth animations

## Components Added

| Component | Purpose |
|-----------|---------|
| `useSwipeActions` | Hook for swipe gesture handling with state |
| `SwipeableResponseWrapper` | Wrapper with visual action indicators |
| `usePullToRefresh` | Hook for pull-down refresh gesture |
| `PullToRefreshContainer` | Container with refresh indicator UI |

## Features
- **Mobile-only**: Gestures only activate on mobile viewports (< 768px)
- **Visual feedback**: Action icons appear during swipe with progress scaling
- **Auth-aware**: Actions require authentication via `useRequireAuth`
- **Toast notifications**: Success/info feedback after actions
- **Smooth animations**: Transform-based animations during and after gestures

## Test plan
- [x] All 5371 tests pass
- [ ] Test swipe-right to reply on mobile device
- [ ] Test swipe-left to bookmark on mobile device  
- [ ] Test pull-to-refresh on topic list
- [ ] Verify gestures don't interfere with scrolling
- [ ] Test on iOS Safari and Android Chrome

Closes #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)