### PR TITLE
feat(avatars): wire avatar URLs through discussion service DTOs

### DIFF
--- a/services/discussion-service/src/discussions/discussions.service.ts
+++ b/services/discussion-service/src/discussions/discussions.service.ts
@@ -28,6 +28,7 @@ import {
   createPaginationMeta,
   PaginatedResponseDto,
 } from '../dto/pagination.dto.js';
+import { getGravatarUrl } from '../dto/user-summary.dto.js';
 
 export interface ListDiscussionsQuery extends PaginationQueryDto {
   topicId?: string;
@@ -59,7 +60,14 @@ export class DiscussionsService {
     // FR-001: Verify user is verified (emailVerified === true)
     const user = await this.prisma.user.findUnique({
       where: { id: userId },
-      select: { id: true, displayName: true, emailVerified: true, verificationLevel: true },
+      select: {
+        id: true,
+        displayName: true,
+        avatarUrl: true,
+        email: true,
+        emailVerified: true,
+        verificationLevel: true,
+      },
     });
 
     if (!user) {
@@ -170,13 +178,25 @@ export class DiscussionsService {
         where: { id: discussion.id },
         include: {
           creator: {
-            select: { id: true, displayName: true, verificationLevel: true },
+            select: {
+              id: true,
+              displayName: true,
+              avatarUrl: true,
+              email: true,
+              verificationLevel: true,
+            },
           },
           responses: {
             where: { deletedAt: null },
             include: {
               author: {
-                select: { id: true, displayName: true, verificationLevel: true },
+                select: {
+                  id: true,
+                  displayName: true,
+                  avatarUrl: true,
+                  email: true,
+                  verificationLevel: true,
+                },
               },
               citations: true,
             },
@@ -213,6 +233,8 @@ export class DiscussionsService {
         author: {
           id: response.author.id,
           displayName: response.author.displayName,
+          avatarUrl: response.author.avatarUrl ?? getGravatarUrl(response.author.email),
+          verificationLevel: response.author.verificationLevel,
         },
         parentResponseId: response.parentId,
         citations: response.citations.map((citation) => ({
@@ -271,7 +293,13 @@ export class DiscussionsService {
         where,
         include: {
           creator: {
-            select: { id: true, displayName: true, verificationLevel: true },
+            select: {
+              id: true,
+              displayName: true,
+              avatarUrl: true,
+              email: true,
+              verificationLevel: true,
+            },
           },
         },
         orderBy: {

--- a/services/discussion-service/src/dto/user-summary.dto.ts
+++ b/services/discussion-service/src/dto/user-summary.dto.ts
@@ -10,6 +10,7 @@
  * without exposing sensitive fields
  */
 
+import { createHash } from 'crypto';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 /**
@@ -55,12 +56,32 @@ export class UserSummaryDto {
 export function mapToUserSummary(user: {
   id: string;
   displayName: string | null;
+  avatarUrl?: string | null;
+  email?: string | null;
   verificationLevel: string;
 }): UserSummaryDto {
   return {
     id: user.id,
     displayName: user.displayName,
-    avatarUrl: null, // TODO: Add avatar support when implemented
+    avatarUrl: user.avatarUrl ?? getGravatarUrl(user.email),
     verificationLevel: user.verificationLevel as any,
   };
+}
+
+/**
+ * Generate Gravatar URL from email address
+ * Uses MD5 hash of lowercase email per Gravatar specification
+ * @param email - User email address
+ * @param size - Avatar size in pixels (default 80)
+ * @returns Gravatar URL or null if no email provided
+ */
+export function getGravatarUrl(email?: string | null, size = 80): string | null {
+  if (!email) return null;
+
+  // Gravatar expects lowercase, trimmed email
+  const normalizedEmail = email.toLowerCase().trim();
+  const hash = createHash('md5').update(normalizedEmail).digest('hex');
+
+  // Use 'identicon' as default for users without Gravatar accounts
+  return `https://www.gravatar.com/avatar/${hash}?s=${size}&d=identicon`;
 }

--- a/services/discussion-service/src/responses/dto/response.dto.ts
+++ b/services/discussion-service/src/responses/dto/response.dto.ts
@@ -15,7 +15,9 @@ export interface CitedSourceDto {
 
 export interface UserSummaryDto {
   id: string;
-  displayName: string;
+  displayName: string | null;
+  avatarUrl?: string | null;
+  verificationLevel?: 'BASIC' | 'ENHANCED' | 'VERIFIED_HUMAN';
 }
 
 export interface ResponsePropositionDto {

--- a/services/discussion-service/src/responses/responses.service.ts
+++ b/services/discussion-service/src/responses/responses.service.ts
@@ -18,6 +18,7 @@ import { CreateResponseDto } from './dto/create-response.dto.js';
 import { UpdateResponseDto } from './dto/update-response.dto.js';
 import { ResponseDetailDto } from './dto/response-detail.dto.js';
 import type { ResponseDto, CitedSourceDto, UserSummaryDto } from './dto/response.dto.js';
+import { getGravatarUrl } from '../dto/user-summary.dto.js';
 import { DiscussionLogger } from '../utils/logger.js';
 import { validateCitationUrl } from '../utils/ssrf-validator.js';
 
@@ -79,6 +80,9 @@ export class ResponsesService {
           select: {
             id: true,
             displayName: true,
+            avatarUrl: true,
+            email: true,
+            verificationLevel: true,
           },
         },
         propositions: {
@@ -193,6 +197,9 @@ export class ResponsesService {
           select: {
             id: true,
             displayName: true,
+            avatarUrl: true,
+            email: true,
+            verificationLevel: true,
           },
         },
       },
@@ -254,6 +261,9 @@ export class ResponsesService {
           select: {
             id: true,
             displayName: true,
+            avatarUrl: true,
+            email: true,
+            verificationLevel: true,
           },
         },
         propositions: {
@@ -374,6 +384,9 @@ export class ResponsesService {
           select: {
             id: true,
             displayName: true,
+            avatarUrl: true,
+            email: true,
+            verificationLevel: true,
           },
         },
         propositions: {
@@ -452,6 +465,8 @@ export class ResponsesService {
       ? {
           id: response.author.id,
           displayName: response.author.displayName,
+          avatarUrl: response.author.avatarUrl ?? getGravatarUrl(response.author.email),
+          verificationLevel: response.author.verificationLevel,
         }
       : undefined;
 
@@ -663,7 +678,13 @@ export class ResponsesService {
         where: { id: response.id },
         include: {
           author: {
-            select: { id: true, displayName: true, verificationLevel: true },
+            select: {
+              id: true,
+              displayName: true,
+              avatarUrl: true,
+              email: true,
+              verificationLevel: true,
+            },
           },
           citations: true,
         },
@@ -692,6 +713,7 @@ export class ResponsesService {
       author: {
         id: result.author.id,
         displayName: result.author.displayName,
+        avatarUrl: result.author.avatarUrl ?? getGravatarUrl(result.author.email),
         verificationLevel: result.author.verificationLevel,
       },
       parentResponseId: result.parentId,
@@ -914,7 +936,13 @@ export class ResponsesService {
       },
       include: {
         author: {
-          select: { id: true, displayName: true, verificationLevel: true },
+          select: {
+            id: true,
+            displayName: true,
+            avatarUrl: true,
+            email: true,
+            verificationLevel: true,
+          },
         },
         citations: true,
         _count: {
@@ -932,6 +960,7 @@ export class ResponsesService {
       author: {
         id: response.author.id,
         displayName: response.author.displayName,
+        avatarUrl: response.author.avatarUrl ?? getGravatarUrl(response.author.email),
         verificationLevel: response.author.verificationLevel,
       },
       parentResponseId: response.parentId,


### PR DESCRIPTION
## Summary
- Wire `avatarUrl` through discussion service API responses
- Add Gravatar fallback for users without custom avatars
- Update all author/user select queries to include avatar fields

## Changes
- **user-summary.dto.ts**: Add `getGravatarUrl()` helper using MD5 hash per Gravatar spec
- **response.dto.ts**: Add `avatarUrl` and `verificationLevel` to `UserSummaryDto`
- **responses.service.ts**: Select `avatarUrl` and `email` in Prisma queries, include in response mappings
- **discussions.service.ts**: Same updates for discussion responses

## How it works
1. When fetching responses/discussions, the service now selects `avatarUrl` and `email` from the author
2. If `avatarUrl` exists (user uploaded avatar to S3), it's used directly
3. If no avatar, `getGravatarUrl()` generates a Gravatar URL using MD5 hash of email
4. Gravatar returns an identicon for users without Gravatar accounts

## Test plan
- [x] TypeScript compilation passes
- [x] All 502 discussion-service unit tests pass
- [x] Pre-commit hooks pass
- [ ] CI pipeline validates full test suite

Resolves #1053

🤖 Generated with [Claude Code](https://claude.ai/code)