### PR TITLE
fix(auth): remove duplicate 'Don't have an account?' text on login page

### DIFF
--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -133,7 +133,7 @@ function LoginForm({ onSubmit, isLoading = false, error, className = '' }: Login
           <p className="text-sm text-center text-gray-600 dark:text-gray-300">
             Don&apos;t have an account?{' '}
             <Link
-              to="/register"
+              to="/signup"
               className="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 font-medium"
             >
               Create one

--- a/frontend/src/pages/Auth/LoginPage.tsx
+++ b/frontend/src/pages/Auth/LoginPage.tsx
@@ -40,21 +40,8 @@ function LoginPage() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full">
-        {/* Login Form - includes its own Sign In heading */}
+        {/* Login Form - includes "Don't have an account?" link */}
         <LoginForm onSubmit={handleSubmit} isLoading={isLoading} error={error} />
-
-        {/* Footer Links */}
-        <div className="mt-6 text-center">
-          <p className="text-sm text-gray-600 dark:text-gray-300">
-            Don&apos;t have an account?{' '}
-            <Link
-              to="/signup"
-              className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 font-medium"
-            >
-              Create one
-            </Link>
-          </p>
-        </div>
 
         {/* Back to Home */}
         <div className="mt-4 text-center">


### PR DESCRIPTION
## Summary

- **Bug fixed**: The login page displayed "Don't have an account? Create one" text twice
- **Issue**: The two instances linked to different routes (`/register` vs `/signup`)
- **Solution**: Removed duplicate from LoginPage wrapper, standardized on `/signup` route

## Before

The login page showed:
1. "Don't have an account? Create one" inside the card (→ /register)
2. "Don't have an account? Create one" below the card (→ /signup)
3. "Back to Home" link

## After

The login page shows:
1. "Don't have an account? Create one" inside the card (→ /signup)
2. "Back to Home" link

## Files Changed

- `frontend/src/pages/Auth/LoginPage.tsx` - Removed duplicate footer section
- `frontend/src/components/auth/LoginForm.tsx` - Changed link from `/register` to `/signup`

## Test plan

- [x] TypeScript compiles
- [x] ESLint passes
- [x] Pre-commit hooks pass
- [x] Visual verification shows single "Create one" link
- [ ] E2E login tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)