### PR TITLE
feat(ui): add retry buttons to error states

### DIFF
--- a/frontend/src/components/layouts/MobileDrawer.tsx
+++ b/frontend/src/components/layouts/MobileDrawer.tsx
@@ -58,7 +58,7 @@ export function MobileDrawer() {
     [sidebarMode, isMobileOpen],
   );
 
-  const { data, isLoading, error } = useTopics(topicsParams);
+  const { data, isLoading, error, refetch } = useTopics(topicsParams);
 
   const topics = useMemo(() => data?.data || [], [data?.data]);
   const errorMessage = error ? 'Failed to load topics' : null;
@@ -248,6 +248,7 @@ export function MobileDrawer() {
                 unreadMap={unreadMap}
                 isLoading={isLoading}
                 error={errorMessage}
+                onRetry={() => refetch()}
                 height={typeof window !== 'undefined' ? window.innerHeight - 180 : 400}
                 onTopicSelect={handleTopicSelect}
               />

--- a/frontend/src/components/layouts/Sidebar.tsx
+++ b/frontend/src/components/layouts/Sidebar.tsx
@@ -56,7 +56,7 @@ export function Sidebar() {
     [sidebarMode],
   );
 
-  const { data, isLoading, error } = useTopics(topicsParams);
+  const { data, isLoading, error, refetch } = useTopics(topicsParams);
 
   const topics = useMemo(() => data?.data || [], [data?.data]);
   const errorMessage = error ? 'Failed to load topics' : null;
@@ -130,6 +130,7 @@ export function Sidebar() {
               unreadMap={unreadMap}
               isLoading={isLoading}
               error={errorMessage}
+              onRetry={() => refetch()}
               height={typeof window !== 'undefined' ? window.innerHeight - 120 : 600}
             />
           </div>

--- a/frontend/src/components/topics/TopicNavigationContent.tsx
+++ b/frontend/src/components/topics/TopicNavigationContent.tsx
@@ -25,6 +25,8 @@ export interface TopicNavigationContentProps {
   height?: number;
   /** Optional callback when a topic is selected */
   onTopicSelect?: (topicId: string) => void;
+  /** Optional callback to retry loading topics */
+  onRetry?: () => void;
   /** CSS class name */
   className?: string;
 }
@@ -62,6 +64,7 @@ export function TopicNavigationContent({
   error = null,
   height = 400,
   onTopicSelect,
+  onRetry,
   className = '',
 }: TopicNavigationContentProps) {
   const { activeTopicId, navigateToTopic } = useTopicNavigation();
@@ -122,10 +125,18 @@ export function TopicNavigationContent({
       <div className="flex-1 overflow-hidden">
         {error && (
           <div
-            className="mx-3 my-2 p-2 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg"
+            className="mx-3 my-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg"
             role="alert"
           >
-            <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
+            <p className="text-sm text-red-800 dark:text-red-200 mb-2">{error}</p>
+            {onRetry && (
+              <button
+                onClick={onRetry}
+                className="text-xs px-3 py-1.5 text-white bg-primary-600 hover:bg-primary-700 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500"
+              >
+                Try Again
+              </button>
+            )}
           </div>
         )}
 

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useAuthRedirect } from '../hooks/useAuthRedirect';
 import { useLoginModal } from '../contexts/LoginModalContext';
@@ -48,32 +48,32 @@ export const LandingPage: React.FC = () => {
   // Redirect authenticated users to /topics?welcome=true
   useAuthRedirect();
 
+  // Fetch topics function - extracted for retry capability
+  const fetchTopics = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetch('/api/topics?limit=5&sortBy=participantCount&sortOrder=desc');
+      if (!response.ok) {
+        throw new Error('Failed to fetch topics');
+      }
+      const data: TopicsResponse = await response.json();
+      setTopics(data.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load topics');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
   // Fetch topics for landing page display (only if not authenticated)
   useEffect(() => {
     // Skip fetch if user is authenticated - they'll be redirected anyway
     if (isAuthenticatedSync) {
       return;
     }
-
-    const fetchTopics = async () => {
-      try {
-        setLoading(true);
-        const response = await fetch('/api/topics?limit=5&sortBy=participantCount&sortOrder=desc');
-        if (!response.ok) {
-          throw new Error('Failed to fetch topics');
-        }
-        const data: TopicsResponse = await response.json();
-        setTopics(data.data);
-        setError(null);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load topics');
-      } finally {
-        setLoading(false);
-      }
-    };
-
     fetchTopics();
-  }, [isAuthenticatedSync]);
+  }, [isAuthenticatedSync, fetchTopics]);
 
   // Prevent landing page flash by returning loading state for authenticated users
   // The useAuthRedirect hook will handle the actual redirect via useEffect
@@ -342,8 +342,16 @@ export const LandingPage: React.FC = () => {
             )}
 
             {error && (
-              <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-center">
-                <p className="text-red-700 dark:text-red-400">Unable to load topics: {error}</p>
+              <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6 text-center">
+                <p className="text-red-700 dark:text-red-400 mb-4">
+                  Unable to load topics: {error}
+                </p>
+                <button
+                  onClick={fetchTopics}
+                  className="px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500"
+                >
+                  Try Again
+                </button>
               </div>
             )}
 

--- a/frontend/src/pages/Topics/TopicsPage.tsx
+++ b/frontend/src/pages/Topics/TopicsPage.tsx
@@ -12,6 +12,7 @@ import { useAuthContext } from '../../contexts/AuthContext';
 import { useRequireAuth } from '../../hooks/useRequireAuth';
 import Card from '../../components/ui/Card';
 import Button from '../../components/ui/Button';
+import ErrorState from '../../components/ui/ErrorState';
 import {
   TopicCard,
   TopicFilterUI,
@@ -52,7 +53,7 @@ function TopicsPage() {
     canonical: `${window.location.origin}/topics`,
   });
 
-  const { data, isLoading, error } = useFilteredTopics(filters);
+  const { data, isLoading, error, refetch } = useFilteredTopics(filters);
   const showSkeleton = useDelayedLoading(isLoading);
 
   // Check for welcome param and dismissed state
@@ -86,14 +87,12 @@ function TopicsPage() {
   if (error) {
     return (
       <div className="max-w-6xl mx-auto">
-        <Card variant="elevated" padding="lg">
-          <div className="text-center text-fallacy-DEFAULT dark:text-red-400">
-            <h2 className="text-xl font-semibold mb-2">Error Loading Topics</h2>
-            <p className="text-gray-600 dark:text-gray-300">
-              {error instanceof Error ? error.message : 'Failed to load topics'}
-            </p>
-          </div>
-        </Card>
+        <ErrorState
+          title="Error Loading Topics"
+          message={error instanceof Error ? error.message : 'Failed to load topics'}
+          onRetry={() => refetch()}
+          retryLabel="Try Again"
+        />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Add retry capability to error states across the application
- TopicsPage: Use ErrorState component with onRetry prop
- LandingPage: Extract fetchTopics with useCallback for retry capability
- TopicNavigationContent: Add optional onRetry prop to interface
- Sidebar/MobileDrawer: Pass refetch callback to TopicNavigationContent

## Test plan
- [ ] Navigate to /topics with backend down - verify retry button appears
- [ ] Click retry button - verify it attempts to reload
- [ ] Navigate to landing page with API error - verify retry button works
- [ ] Test sidebar topic list error state with retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)