### PR TITLE
fix(contract): add retry logic to ai-service consumer pact tests

### DIFF
--- a/services/api-gateway/tests/contract/ai-service.consumer.pact.ts
+++ b/services/api-gateway/tests/contract/ai-service.consumer.pact.ts
@@ -33,21 +33,38 @@ const provider = new PactV4({
 });
 
 /**
- * Helper function to make HTTP requests to the mock server
+ * Helper function to make HTTP requests to the mock server with retry logic.
+ * Retries help handle transient network issues in CI environments.
  */
 async function fetchFromProvider(
   baseUrl: string,
   endpoint: string,
   options: RequestInit = {},
+  retries = 2,
 ): Promise<Response> {
   const url = `${baseUrl}${endpoint}`;
-  return fetch(url, {
-    headers: {
-      'Content-Type': 'application/json',
-      ...options.headers,
-    },
-    ...options,
-  });
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const response = await fetch(url, {
+        headers: {
+          'Content-Type': 'application/json',
+          ...options.headers,
+        },
+        ...options,
+      });
+      return response;
+    } catch (error) {
+      lastError = error as Error;
+      if (attempt < retries) {
+        // Wait before retry (50ms, 100ms)
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+      }
+    }
+  }
+
+  throw lastError;
 }
 
 describe('AI Service Consumer Contract Tests', () => {


### PR DESCRIPTION
## Summary
- Add retry logic with exponential backoff to the `fetchFromProvider` helper in AI service contract tests
- Addresses intermittent CI failures where the mock server request is not received

## Root Cause Analysis
Build #437 on main failed with:
```
AI Service Consumer Contract Tests > Feedback Endpoints (Bias Analysis) > should dismiss feedback with reason
Mock server failed with the following mismatches: The following request was expected but not received
```

Investigation findings:
- Test passes 100% locally (10+ consecutive runs)
- Test passed in build #436 (before our changes)
- The failure had 13ms execution time (suspiciously fast)
- No code changes to contract tests were made in the failing commit (PR #1078)

This is a transient CI environmental issue where network/timing causes the mock server request to occasionally fail.

## Changes
The fix adds:
- Up to 2 retries on fetch failure with 50ms, 100ms delays between retries
- Proper error propagation if all retries fail
- Consistent with existing pattern in `user-service.consumer.pact.ts`

## Test Plan
- [x] Contract tests pass locally (verified 10 consecutive runs)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)