### PR TITLE
chore(e2e): remove redundant .skip from AI feedback tests (#1083)

### DIFF
--- a/frontend/e2e/ai-feedback-accuracy.spec.ts
+++ b/frontend/e2e/ai-feedback-accuracy.spec.ts
@@ -111,9 +111,9 @@ async function typeAndWaitForFeedback(
   }
 }
 
-// SKIPPED: Requires AWS Bedrock credentials (not available in CI)
+// NOTE: Requires AWS Bedrock credentials (automatically skipped in CI via @ai tag grep filter)
 // Run manually with: E2E_DOCKER=true PLAYWRIGHT_BASE_URL=http://localhost:9080 AWS_REGION=us-east-1 npx playwright test ai-feedback-accuracy.spec.ts
-test.describe.skip('AI Feedback Accuracy - Nuanced Tone Detection @ai', () => {
+test.describe('AI Feedback Accuracy - Nuanced Tone Detection @ai', () => {
   test.beforeEach(async ({ page }) => {
     await loginAsAlice(page);
     await navigateToTopicComposer(page);


### PR DESCRIPTION
## Summary

- Removed explicit `.skip` from the 'AI Feedback Accuracy - Nuanced Tone Detection' test suite
- The `@ai` tag mechanism already handles CI skipping via grep pattern in playwright.config.ts

## Context

The test file had inconsistent skip mechanisms:
- **Before**: First test suite used BOTH `.skip` AND `@ai` tag (redundant)
- **After**: All test suites use only `@ai` tag for CI filtering

This change:
1. Matches the pattern used by other `@ai` test suites in the same file
2. Allows tests to run locally when AWS Bedrock credentials are available
3. Maintains CI skipping via the existing grep filter: `grep: process.env.CI ? /^(?!.*@ai)/ : undefined`

## Test plan

- [x] `npx playwright test frontend/e2e/ai-feedback-accuracy.spec.ts --list` shows 12 tests (none explicitly skipped)
- [x] Pre-commit hooks pass
- [x] CI will still skip these tests via `@ai` tag grep filter

Closes #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)