### PR TITLE
fix(e2e): enable auth redirect tests and fix route registry (#1084)

### DIFF
--- a/frontend/e2e/helpers/route-registry.ts
+++ b/frontend/e2e/helpers/route-registry.ts
@@ -1,4 +1,9 @@
 /**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
  * Route Registry for Navigation Crawl E2E Tests
  *
  * Single source of truth for all application routes.
@@ -90,17 +95,18 @@ export const ROUTE_REGISTRY: RouteDefinition[] = [
   {
     path: '/simulator',
     name: 'Discussion Simulator',
-    requiresAuth: false,
+    requiresAuth: true, // Uses ProtectedRoute wrapper
     isDynamic: false,
   },
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Profile Routes - User profiles
+  // Note: /profile doesn't use ProtectedRoute wrapper - it handles missing auth itself
   // ═══════════════════════════════════════════════════════════════════════════
   {
     path: '/profile',
     name: 'My Profile',
-    requiresAuth: true,
+    requiresAuth: false, // No ProtectedRoute wrapper - page handles unauthenticated state
     isDynamic: false,
   },
   {

--- a/frontend/e2e/navigation-crawl.spec.ts
+++ b/frontend/e2e/navigation-crawl.spec.ts
@@ -125,15 +125,18 @@ test.describe('Navigation Crawl - Full Coverage', () => {
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Auth Redirect Tests - Protected routes should redirect when unauthenticated
-  // Note: Skip for now as the application may not enforce auth redirects on all routes.
-  // Enable when auth guards are implemented on protected routes.
+  // These tests verify that routes wrapped with ProtectedRoute redirect to landing page
+  // Skip in E2E Docker mode - mock validation doesn't work with real backend
   // ═══════════════════════════════════════════════════════════════════════════
 
-  test.describe.skip('Auth Redirects', () => {
+  test.describe('Auth Redirects', () => {
+    // Skip in E2E Docker mode - redirect detection requires controlled environment
+    test.skip(isE2EDocker, 'Auth redirects require controlled environment - skip in E2E Docker');
+
     const authRoutes = getAuthenticatedRoutes();
 
     for (const route of authRoutes) {
-      test(`${route.name} (${resolvePath(route)}) redirects to login when unauthenticated`, async ({
+      test(`${route.name} (${resolvePath(route)}) redirects to landing when unauthenticated`, async ({
         page,
       }) => {
         const errorCollector = new ErrorCollector(page);
@@ -142,9 +145,9 @@ test.describe('Navigation Crawl - Full Coverage', () => {
         const validator = new PageValidator(page, errorCollector);
         const result = await validator.validateRoute(route);
 
-        // Should redirect to login
-        expect(result.redirectedTo, 'Expected redirect to login page').toBeDefined();
-        expect(result.redirectedTo).toContain('/login');
+        // Should redirect to landing page (ProtectedRoute redirects to '/')
+        expect(result.redirectedTo, 'Expected redirect to landing page').toBeDefined();
+        expect(result.redirectedTo).toBe('/');
 
         // No uncaught errors during redirect
         const uncaughtErrors = result.errors.filter((e) => e.type === 'uncaught');


### PR DESCRIPTION
## Summary

- Enabled the previously skipped `Auth Redirects` test suite
- Fixed route registry to accurately reflect actual ProtectedRoute usage
- Added missing SPDX license header to route-registry.ts

## Route Registry Corrections

| Route | Before | After | Reason |
|-------|--------|-------|--------|
| `/profile` | requiresAuth: true | requiresAuth: false | Not wrapped with ProtectedRoute - page handles unauthenticated state itself |
| `/simulator` | requiresAuth: false | requiresAuth: true | Wrapped with ProtectedRoute in routes/index.tsx |

## Auth Redirect Tests

Previously skipped with comment "Skip for now as the application may not enforce auth redirects on all routes".

**Fixed issues:**
1. Test expected redirect to `/login` but ProtectedRoute redirects to `/` (landing page)
2. Added conditional skip for E2E Docker mode (redirect detection requires controlled environment)

## Test plan

- [x] `npx playwright test frontend/e2e/navigation-crawl.spec.ts --list` shows 22 tests including Auth Redirects
- [x] Pre-commit hooks pass

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)