### PR TITLE
chore(e2e): improve skip documentation for create-topic tests (#1086)

### DIFF
--- a/frontend/e2e/create-topic.spec.ts
+++ b/frontend/e2e/create-topic.spec.ts
@@ -274,7 +274,10 @@ test.describe('Create Topic Flow', () => {
     await expect(modal.getByRole('button', { name: /create anyway/i })).toBeVisible();
   });
 
-  // Skip: Duplicate detection workflow timing issues - modal doesn't close within timeout
+  // Skip: "Create Anyway" workflow has timing issues - modal doesn't close within timeout
+  // Note: The duplicate warning display and "Create Anyway" button visibility are tested
+  // in the previous test. This test would additionally verify clicking "Create Anyway"
+  // actually creates the topic. The unit tests cover this logic.
   test.skip('should allow creating topic despite duplicate warning', async ({ page }) => {
     await page.getByRole('button', { name: /create topic/i }).click();
     const modal = page.locator('[data-testid="create-topic-modal"]');


### PR DESCRIPTION
## Summary

Improved documentation for skipped tests in create-topic.spec.ts to clarify what is and isn't tested.

## Analysis

### Test 1: "should allow creating topic despite duplicate warning" (line 278)

**Current status:** Skipped due to timing issues

**What IS tested (in previous test at line 245):**
- Duplicate warning appears when creating similar topic
- "Create Anyway" button becomes visible
- Warning message displays

**What ISN'T tested:**
- Clicking "Create Anyway" actually creates the topic and closes modal

**Why keep skipped:**
- The test has documented timing issues ("modal doesn't close within timeout")
- Duplicate detection relies on semantic matching (inconsistent trigger)
- Unit tests cover the `handleSubmit` logic
- The core UX (warning display, button visibility) IS verified

### Test 2: Rate limiting test (line 407)

**Status:** Intentionally skipped (time-consuming)

**Rationale:**
- Would require creating 6 topics (rate limit is 5/day)
- Better tested at API/integration level
- Acceptable reason per issue description

## Changes

Enhanced skip comments to document:
- What the skipped test would verify
- What adjacent tests already verify
- Why the test remains skipped

## Test plan

- [x] Pre-commit hooks pass
- [x] No functional changes, only comment updates

Closes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)