### PR TITLE
fix(db): drop orphaned response search_vector trigger

### DIFF
--- a/packages/db-models/prisma/migrations/20260322_drop_orphaned_response_search_trigger/migration.sql
+++ b/packages/db-models/prisma/migrations/20260322_drop_orphaned_response_search_trigger/migration.sql
@@ -1,0 +1,9 @@
+-- Fix: Drop orphaned trigger and function for response search_vector
+-- The search_vector column was dropped in migration 20260320232632_add_verification_token_type
+-- but the trigger and function were not removed, causing "record 'new' has no field 'search_vector'" errors
+
+-- Drop the trigger first (depends on the function)
+DROP TRIGGER IF EXISTS trig_update_response_search_vector ON "responses";
+
+-- Drop the orphaned function
+DROP FUNCTION IF EXISTS update_response_search_vector();


### PR DESCRIPTION
## Summary
- Drops the orphaned `trig_update_response_search_vector` trigger
- Drops the unused `update_response_search_vector()` function

## Context
Migration `20260320232632_add_verification_token_type` dropped the `search_vector` column from `responses` but didn't remove the trigger that references it. This causes E2E database seeding to fail with:

```
record "new" has no field "search_vector"
PL/pgSQL assignment "NEW.search_vector := to_tsvector('english', COALESCE(NEW.content, ''))"
```

This is a companion fix to PR #1078 which fixed the same issue for the `discussion_topics` table.

## Test Plan
- [x] Migration SQL syntax verified
- [ ] Jenkins E2E tests pass (db-seed no longer fails)

Fixes #1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)