### PR TITLE
fix(e2e): rewrite merge-topics tests to use seeded data

### DIFF
--- a/frontend/e2e/merge-topics.spec.ts
+++ b/frontend/e2e/merge-topics.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { loginWithDemoAccount } from './helpers/demo-auth';
+import { loginWithDemoAccount, SEEDED_TOPICS } from './helpers/demo-auth';
 
 /**
  * Navigate to topics page with proper waiting for auth state to load
@@ -49,206 +49,126 @@ test.describe('Topic Merging', () => {
     });
 
     test('should successfully merge two topics', async ({ page }) => {
-      // For this test, we'll create two test topics to merge
+      // Use seeded topics instead of creating dynamic ones
+      // This ensures topics exist and are in the availableTopics list
+      const sourceTopic = SEEDED_TOPICS.AI_DISCLOSURE; // Will be merged into target
+      const targetTopic = SEEDED_TOPICS.PRODUCT_AI_DISCLOSURE; // Receives merged content
+
       await navigateToTopicsAndWaitForAuth(page);
 
-      // Create first topic (source)
-      await page.getByRole('button', { name: /create topic/i }).click();
-      let modal = page.getByRole('dialog');
-      await expect(modal).toBeVisible();
-
-      const sourceTitle = `Merge Source Topic ${Date.now()}`;
-      await modal.getByLabel(/title/i).fill(sourceTitle);
-      await modal
-        .getByLabel(/description/i)
-        .fill('This is the source topic that will be merged into the target topic.');
-
-      let tagInput = modal.getByRole('combobox', { name: /tags/i });
-      await tagInput.fill('merge-test');
-      await tagInput.press('Enter');
-
-      await modal.getByRole('button', { name: /create topic/i }).click();
-      await expect(modal).not.toBeVisible({ timeout: 10000 });
-      await page.waitForTimeout(1000);
-
-      // Activate the source topic
-      const activateButton = page.getByRole('button', { name: /activate topic/i });
-      if (await activateButton.isVisible({ timeout: 3000 })) {
-        await activateButton.click();
-        await page.getByRole('button', { name: /^confirm$/i }).click();
-        await page.waitForTimeout(1500);
-      }
-
-      // Go back to topics list
-      await navigateToTopicsAndWaitForAuth(page);
-
-      // Create second topic (target)
-      await page.getByRole('button', { name: /create topic/i }).click();
-      modal = page.getByRole('dialog');
-      await expect(modal).toBeVisible();
-
-      const targetTitle = `Merge Target Topic ${Date.now()}`;
-      await modal.getByLabel(/title/i).fill(targetTitle);
-      await modal
-        .getByLabel(/description/i)
-        .fill('This is the target topic that will receive the merged content.');
-
-      tagInput = modal.getByRole('combobox', { name: /tags/i });
-      await tagInput.fill('merge-test');
-      await tagInput.press('Enter');
-
-      await modal.getByRole('button', { name: /create topic/i }).click();
-      await expect(modal).not.toBeVisible({ timeout: 10000 });
-      await page.waitForTimeout(1000);
-
-      // Activate the target topic
-      const activateButton2 = page.getByRole('button', { name: /activate topic/i });
-      if (await activateButton2.isVisible({ timeout: 3000 })) {
-        await activateButton2.click();
-        await page.getByRole('button', { name: /^confirm$/i }).click();
-        await page.waitForTimeout(1500);
-      }
-
-      // Now attempt to merge
-      // Note: The actual UI for initiating merge may vary
-      // This is a placeholder for the merge workflow
-      await navigateToTopicsAndWaitForAuth(page);
-
-      // Look for merge button or moderator menu
+      // Open merge modal
       const mergeButton = page.getByRole('button', { name: /merge topics/i });
-      if (await mergeButton.isVisible({ timeout: 2000 })) {
-        await mergeButton.click();
+      await expect(mergeButton).toBeVisible({ timeout: 5000 });
+      await mergeButton.click();
 
-        // Should show merge modal
-        modal = page.getByRole('dialog');
-        await expect(modal).toBeVisible();
+      // Wait for merge modal to appear
+      const modal = page.getByRole('dialog');
+      await expect(modal).toBeVisible({ timeout: 5000 });
 
-        // Select source topic
-        // UI may have checkboxes or select dropdowns
-        const sourceCheckbox = modal
-          .locator(`text=${sourceTitle}`)
-          .locator('..')
-          .locator('input[type="checkbox"]');
-        if (await sourceCheckbox.isVisible()) {
-          await sourceCheckbox.check();
-        }
+      // Select source topic by clicking on its row (contains checkbox)
+      // The MergeTopicsModal uses clickable divs with checkboxes
+      const sourceRow = modal.locator(`text=${sourceTopic.title}`).locator('..').locator('..');
+      await expect(sourceRow).toBeVisible({ timeout: 5000 });
+      await sourceRow.click();
 
-        // Select target topic
-        const targetSelect = modal.locator('select');
-        if (await targetSelect.isVisible()) {
-          // Find option with target title
-          await targetSelect.selectOption({ label: targetTitle });
-        }
+      // Verify checkbox is now checked
+      const sourceCheckbox = sourceRow.locator('input[type="checkbox"]');
+      await expect(sourceCheckbox).toBeChecked();
 
-        // Enter merge reason
-        const reasonTextarea = modal.getByLabel(/merge reason/i);
-        if (await reasonTextarea.isVisible()) {
-          await reasonTextarea.fill(
-            'Merging these two topics because they cover the same subject matter and consolidation will improve discussion quality.',
-          );
-        }
+      // Select target topic from dropdown (using topic ID as value)
+      const targetSelect = modal.locator('select#target-topic');
+      await expect(targetSelect).toBeVisible();
+      await targetSelect.selectOption({ value: targetTopic.id });
 
-        // Preview merge
-        const previewButton = modal.getByRole('button', { name: /preview merge/i });
-        if (await previewButton.isVisible()) {
-          await previewButton.click();
+      // Enter merge reason (minimum 20 characters required)
+      const reasonTextarea = modal.locator('textarea#merge-reason');
+      await expect(reasonTextarea).toBeVisible();
+      await reasonTextarea.fill(
+        'These topics cover similar AI disclosure requirements and consolidating them will improve discussion quality and reduce fragmentation.',
+      );
 
-          // Should show confirmation
-          await expect(modal.getByText(/confirm topic merge/i)).toBeVisible();
+      // Click Preview Merge button
+      const previewButton = modal.getByRole('button', { name: /preview merge/i });
+      await expect(previewButton).toBeEnabled({ timeout: 3000 });
+      await previewButton.click();
 
-          // Confirm merge
-          const confirmButton = modal.getByRole('button', { name: /confirm merge/i });
-          await confirmButton.click();
+      // Should show confirmation dialog with "Confirm Topic Merge" title
+      await expect(modal.getByText(/confirm topic merge/i)).toBeVisible({ timeout: 5000 });
 
-          // Wait for merge to complete
-          await page.waitForTimeout(2000);
+      // Verify merge summary shows source and target
+      await expect(modal.getByText(/source topics.*will be archived/i)).toBeVisible();
+      await expect(modal.getByText(/target topic.*receives all content/i)).toBeVisible();
 
-          // Should redirect or show success
-          await expect(modal).not.toBeVisible({ timeout: 10000 });
-        } else {
-          test.skip(true, 'Merge UI differs from expected');
-        }
-      } else {
-        test.skip(true, 'Merge feature not accessible in current UI');
-      }
+      // Click Confirm Merge to execute
+      const confirmButton = modal.getByRole('button', { name: /confirm merge/i });
+      await expect(confirmButton).toBeVisible();
+      await confirmButton.click();
+
+      // Wait for merge to complete and modal to close
+      await expect(modal).not.toBeVisible({ timeout: 15000 });
     });
 
     test('should show validation error for missing merge reason', async ({ page }) => {
       await navigateToTopicsAndWaitForAuth(page);
 
-      // Look for merge button
+      // Open merge modal
       const mergeButton = page.getByRole('button', { name: /merge topics/i });
-      if (await mergeButton.isVisible({ timeout: 2000 })) {
-        await mergeButton.click();
+      await expect(mergeButton).toBeVisible({ timeout: 5000 });
+      await mergeButton.click();
 
-        const modal = page.getByRole('dialog');
-        await expect(modal).toBeVisible();
+      const modal = page.getByRole('dialog');
+      await expect(modal).toBeVisible({ timeout: 5000 });
 
-        // Try to preview without filling merge reason
-        const previewButton = modal.getByRole('button', { name: /preview merge/i });
+      // Select a source topic
+      const sourceTopic = SEEDED_TOPICS.CONGESTION_PRICING;
+      const sourceRow = modal.locator(`text=${sourceTopic.title}`).locator('..').locator('..');
+      await expect(sourceRow).toBeVisible({ timeout: 5000 });
+      await sourceRow.click();
 
-        // Preview button might be disabled or clicking might show error
-        if (await previewButton.isVisible()) {
-          const isDisabled = await previewButton.isDisabled();
-          if (!isDisabled) {
-            await previewButton.click();
-            // Should show validation error
-            await expect(modal.getByText(/merge reason/i)).toBeVisible();
-          } else {
-            // Button is disabled, which is also valid behavior
-            expect(isDisabled).toBeTruthy();
-          }
-        }
-      } else {
-        test.skip(true, 'Merge feature not accessible');
-      }
+      // Select a target topic (using topic ID as value)
+      const targetTopic = SEEDED_TOPICS.AI_DISCLOSURE;
+      const targetSelect = modal.locator('select#target-topic');
+      await targetSelect.selectOption({ value: targetTopic.id });
+
+      // Leave merge reason empty and try to preview
+      // The Preview button should be enabled (form doesn't pre-validate)
+      const previewButton = modal.getByRole('button', { name: /preview merge/i });
+      await expect(previewButton).toBeEnabled();
+      await previewButton.click();
+
+      // Should show validation error for merge reason
+      await expect(modal.getByText(/merge reason must be at least 20 characters/i)).toBeVisible({
+        timeout: 3000,
+      });
     });
 
     test('should prevent merging target topic into itself', async ({ page }) => {
       await navigateToTopicsAndWaitForAuth(page);
 
+      // Open merge modal
       const mergeButton = page.getByRole('button', { name: /merge topics/i });
-      if (await mergeButton.isVisible({ timeout: 2000 })) {
-        await mergeButton.click();
+      await expect(mergeButton).toBeVisible({ timeout: 5000 });
+      await mergeButton.click();
 
-        const modal = page.getByRole('dialog');
-        await expect(modal).toBeVisible();
+      const modal = page.getByRole('dialog');
+      await expect(modal).toBeVisible({ timeout: 5000 });
 
-        // Try to select same topic as both source and target
-        // UI should prevent this or show error
+      // Select a source topic
+      const sourceTopic = SEEDED_TOPICS.CONGESTION_PRICING;
+      const sourceRow = modal.locator(`text=${sourceTopic.title}`).locator('..').locator('..');
+      await expect(sourceRow).toBeVisible({ timeout: 5000 });
+      await sourceRow.click();
 
-        // Select a topic as source
-        const firstCheckbox = modal.locator('input[type="checkbox"]').first();
-        if (await firstCheckbox.isVisible()) {
-          await firstCheckbox.check();
+      // Verify the source topic is NOT available in the target dropdown
+      // (MergeTopicsModal filters out selected sources from target options)
+      const targetSelect = modal.locator('select#target-topic');
+      const targetOptions = await targetSelect.locator('option').allTextContents();
 
-          // Get the associated topic ID/title
-          // Then try to select it as target
-          // The target dropdown should not include it, or an error should show
-
-          const reasonTextarea = modal.getByLabel(/merge reason/i);
-          if (await reasonTextarea.isVisible()) {
-            await reasonTextarea.fill(
-              'This should fail because target and source cannot be the same topic.',
-            );
-          }
-
-          const previewButton = modal.getByRole('button', { name: /preview merge/i });
-          if ((await previewButton.isVisible()) && !(await previewButton.isDisabled())) {
-            // If we can click preview, it should show an error
-            await previewButton.click();
-
-            // Look for error message
-            const errorText = await modal.locator('text=/target.*source/i').count();
-            if (errorText > 0) {
-              // Error message found, test passes
-              expect(errorText).toBeGreaterThan(0);
-            }
-          }
-        }
-      } else {
-        test.skip(true, 'Merge feature not accessible');
-      }
+      // The source topic should NOT appear in the target dropdown
+      const sourceInTargetOptions = targetOptions.some((opt) =>
+        opt.includes(sourceTopic.title.substring(0, 30)),
+      );
+      expect(sourceInTargetOptions).toBe(false);
     });
   });
 
@@ -278,34 +198,35 @@ test.describe('Topic Merging', () => {
   });
 
   test.describe('Post-Merge Verification', () => {
+    // Note: These tests are placeholders until the merge backend returns
+    // sufficient data to verify post-merge state in E2E tests.
+    // The merge feature creates a MergeRecord with 30-day rollback window,
+    // but we'd need to either:
+    // 1. Query the API for merge records
+    // 2. Check the database directly (not ideal for E2E)
+    // 3. Add UI elements that show merge history
+
     test.beforeEach(async ({ page }) => {
       // Login as moderator
       await loginWithDemoAccount(page, 'Mod Martinez');
     });
 
-    test('source topic should show redirect notice after merge', async ({ page }) => {
+    test.skip('source topic should show redirect notice after merge', async ({ page }) => {
+      // TODO: Implement when MergeRecord API returns source topic status
       // This test would verify that after a merge:
       // 1. Source topic is archived
       // 2. Source topic description includes redirect notice
       // 3. Clicking through leads to target topic
-
-      // For now, this is a placeholder since it depends on having completed a merge
-      // In a real test, we'd:
-      // - Perform a merge
-      // - Navigate to the source topic
-      // - Verify it shows "[MERGED]" notice
-      // - Verify status is ARCHIVED
-
-      test.skip(true, 'Requires completed merge operation');
+      await navigateToTopicsAndWaitForAuth(page);
     });
 
-    test('target topic should have increased response count after merge', async ({ page }) => {
+    test.skip('target topic should have increased response count after merge', async ({ page }) => {
+      // TODO: Implement when response count tracking is verified
       // This test would verify that:
       // 1. Target topic response count increases by source topic count
       // 2. All responses are accessible on target topic
       // 3. Participant count is updated
-
-      test.skip(true, 'Requires completed merge operation');
+      await navigateToTopicsAndWaitForAuth(page);
     });
   });
 });


### PR DESCRIPTION
## Summary
Rewrites the merge-topics E2E tests to use seeded topics instead of creating dynamic ones at runtime.

## Problem
Several tests in `merge-topics.spec.ts` were skipping at runtime with messages like:
- "Merge feature not accessible in current UI"
- "Merge UI differs from expected"

**Root cause**: Tests created dynamic topics with `Date.now()` in the title and expected them to appear immediately in the MergeTopicsModal's `availableTopics` list. Without a page refresh, newly created topics weren't available for selection.

## Solution
- Import `SEEDED_TOPICS` from `demo-auth` helper
- Use `AI_DISCLOSURE` and `PRODUCT_AI_DISCLOSURE` as test source/target topics
- Fix selectors to use actual component IDs (`select#target-topic`, `textarea#merge-reason`)
- Use `topic.id` for `selectOption` instead of RegExp label matching (TypeScript fix)
- Convert post-merge verification tests to explicit `test.skip()` with TODO comments

## Test Plan
- [x] TypeScript type-check passes
- [ ] Jenkins E2E tests pass
- [ ] Merge workflow tests no longer skip at runtime

Fixes #1104

🤖 Generated with [Claude Code](https://claude.com/claude-code)