### PR TITLE
feat(header): integrate HelpMenu component into navigation (#1105)

### DIFF
--- a/frontend/e2e/orientation.spec.ts
+++ b/frontend/e2e/orientation.spec.ts
@@ -295,9 +295,7 @@ test.describe('Orientation Flow', () => {
     await expect(page.getByText(/let's take a quick tour/i)).toBeVisible();
   });
 
-  // SKIPPED: HelpMenu component exists at components/onboarding/HelpMenu.tsx
-  // but is not integrated into Header.tsx. Re-enable after HelpMenu is wired into Header.
-  test.describe.skip('Help Menu Integration', () => {
+  test.describe('Help Menu Integration', () => {
     test.beforeEach(async ({ page }) => {
       // Navigate to home page instead of orientation
       await page.goto('/');

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useSidebar } from '../../hooks/useSidebar';
 import { useIsMobileViewport } from '../../hooks/useMediaQuery';
 import { useTheme } from '../../hooks/useTheme';
 import { useLoginModal } from '../../contexts/LoginModalContext';
 import { useAuth } from '../../hooks/useAuth';
 import { NotificationDropdown } from '../notifications/NotificationDropdown';
+import HelpMenu from '../onboarding/HelpMenu';
 import Avatar from '../ui/Avatar';
 
 /**
@@ -24,6 +25,11 @@ export function Header() {
   const { isDark, toggleTheme } = useTheme();
   const { openModal: openLoginModal } = useLoginModal();
   const { user, isLoading } = useAuth();
+  const navigate = useNavigate();
+
+  const handleReopenOrientation = () => {
+    navigate('/orientation');
+  };
 
   return (
     <header
@@ -174,6 +180,9 @@ export function Header() {
               </svg>
             )}
           </button>
+
+          {/* Help menu */}
+          <HelpMenu onReopenOrientation={handleReopenOrientation} />
 
           {/* Notifications dropdown */}
           <NotificationDropdown />

--- a/frontend/src/components/onboarding/HelpMenu.tsx
+++ b/frontend/src/components/onboarding/HelpMenu.tsx
@@ -94,13 +94,13 @@ const HelpMenu: React.FC<HelpMenuProps> = ({ onReopenOrientation }) => {
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 px-3 py-2 text-white hover:bg-primary-700 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-primary-600"
+        className="flex h-11 w-11 items-center justify-center rounded-lg text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
         aria-label="Help menu"
         aria-expanded={isOpen}
         aria-haspopup="true"
       >
         <svg
-          className="h-5 w-5"
+          className="h-6 w-6"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -109,11 +109,10 @@ const HelpMenu: React.FC<HelpMenuProps> = ({ onReopenOrientation }) => {
           <path
             strokeLinecap="round"
             strokeLinejoin="round"
-            strokeWidth={2}
-            d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            strokeWidth={1.5}
+            d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"
           />
         </svg>
-        <span className="text-sm font-medium">Help</span>
       </button>
 
       {/* Dropdown menu */}


### PR DESCRIPTION
## Summary
- Add HelpMenu to Header between theme toggle and notifications
- Update HelpMenu button styling to match Header design (icon-only, gray theme)
- Enable 5 previously skipped E2E tests for Help Menu Integration
- Clicking "View Orientation" navigates to /orientation page

## Test plan
- [ ] Help menu button visible in header navigation
- [ ] Clicking help menu opens dropdown with options
- [ ] "View Orientation" navigates to orientation page
- [ ] Menu closes when clicking outside
- [ ] Menu closes on Escape key

Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)