### PR TITLE
feat(auth): implement token refresh in AuthContext

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -179,12 +179,26 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   /**
    * Handle continue session button
-   * For now, just closes the modal. In future, this could refresh the token.
+   * Refreshes the token to extend the session
    */
-  const handleContinueSession = useCallback(() => {
+  const handleContinueSession = useCallback(async () => {
     setShowSessionModal(false);
-    // TODO: Implement token refresh in future enhancement
-  }, []);
+
+    try {
+      const refreshed = await authService.refreshToken();
+      if (refreshed) {
+        toast.success('Session extended successfully');
+      } else {
+        // Refresh failed, log the user out
+        toast.error('Session could not be extended. Please log in again.');
+        logout();
+      }
+    } catch (error) {
+      console.error('Failed to refresh session:', error);
+      toast.error('Session could not be extended. Please log in again.');
+      logout();
+    }
+  }, [logout, toast]);
 
   /**
    * Handle session expiration logout
@@ -196,15 +210,23 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, [logout]);
 
   /**
-   * Session expiration checking
-   * Check token expiry every minute and show warning 5 minutes before expiry
+   * Proactive token refresh and session expiration checking
+   *
+   * Strategy:
+   * - 10+ minutes before expiry: Do nothing
+   * - 5-10 minutes before expiry: Silently refresh token in background
+   * - 0-5 minutes before expiry: Show warning modal (if refresh failed or user inactive)
+   * - Token expired: Auto-logout
    */
   useEffect(() => {
     if (!user) {
       return; // Not authenticated, no need to check
     }
 
-    const checkTokenExpiry = () => {
+    // Track if we've already attempted a proactive refresh in this window
+    let proactiveRefreshAttempted = false;
+
+    const checkTokenExpiry = async () => {
       const token = authService.getAuthToken();
       if (!token) {
         return;
@@ -212,13 +234,33 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
       const timeLeft = getJWTTimeUntilExpiry(token);
 
-      // Show warning modal 5 minutes (300 seconds) before expiry
+      // Token expired, auto-logout
+      if (timeLeft <= 0) {
+        logout();
+        return;
+      }
+
+      // 5-10 minutes before expiry: Attempt silent background refresh
+      if (timeLeft > 300 && timeLeft <= 600 && !proactiveRefreshAttempted) {
+        proactiveRefreshAttempted = true;
+        try {
+          const refreshed = await authService.refreshToken();
+          if (refreshed) {
+            // Reset the flag since we got a new token
+            proactiveRefreshAttempted = false;
+          }
+          // If refresh failed, we'll show the modal when timeLeft <= 300
+        } catch (error) {
+          console.error('Proactive token refresh failed:', error);
+          // Will show modal when timeLeft <= 300
+        }
+        return;
+      }
+
+      // 0-5 minutes before expiry: Show warning modal
       if (timeLeft > 0 && timeLeft <= 300) {
         setSessionTimeRemaining(Math.floor(timeLeft));
         setShowSessionModal(true);
-      } else if (timeLeft === 0) {
-        // Token expired, auto-logout
-        logout();
       }
     };
 

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -347,7 +347,7 @@ class AuthService {
     // Handle 401 Unauthorized - token expired or invalid
     if (response.status === 401) {
       // Attempt to refresh token
-      const refreshed = await this.refreshAccessToken();
+      const refreshed = await this.refreshAccessTokenInternal();
       if (refreshed) {
         // Retry request with new token
         const newHeaders = {
@@ -372,8 +372,17 @@ class AuthService {
 
   /**
    * Refresh the access token using the refresh token
+   * Public method for explicit token refresh (e.g., session continuation)
+   * @returns true if refresh succeeded, false otherwise
    */
-  private async refreshAccessToken(): Promise<boolean> {
+  async refreshToken(): Promise<boolean> {
+    return this.refreshAccessTokenInternal();
+  }
+
+  /**
+   * Internal method to refresh the access token using the refresh token
+   */
+  private async refreshAccessTokenInternal(): Promise<boolean> {
     const refreshToken = this.getRefreshToken();
     if (!refreshToken) {
       return false;


### PR DESCRIPTION
## Summary
- Add public `refreshToken()` method to authService for explicit token refresh
- Implement `handleContinueSession` to refresh token when user clicks "Continue" in session expiration modal
- Add proactive token refresh 5-10 minutes before expiry (silent background refresh)

## Token Refresh Strategy

| Time Until Expiry | Action |
|-------------------|--------|
| 10+ minutes | No action |
| 5-10 minutes | Silent background refresh attempt |
| 0-5 minutes | Show warning modal with Continue/Logout options |
| Token expired | Auto-logout |

## Changes
- `frontend/src/services/authService.ts`: Added public `refreshToken()` wrapper method
- `frontend/src/contexts/AuthContext.tsx`: Updated `handleContinueSession` to actually refresh token, added proactive refresh logic

## Test plan
- [ ] Frontend tests pass (2441 tests) ✅
- [ ] TypeScript check passes ✅
- [ ] CI pipeline passes
- [ ] Manual testing: Token should auto-refresh silently when 5-10 min from expiry
- [ ] Manual testing: "Continue Session" button should refresh token and show success toast

Closes #1122

🤖 Generated with [Claude Code](https://claude.com/claude-code)