### PR TITLE
feat(verification): integrate SMS provider for phone verification

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1168,6 +1168,9 @@ importers:
       '@willsoto/nestjs-prometheus':
         specifier: ^6.0.2
         version: 6.0.2(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(prom-client@15.1.3)
+      class-validator:
+        specifier: ^0.15.1
+        version: 0.15.1
       fastify:
         specifier: ^5.8.2
         version: 5.8.2

--- a/services/notification-service/package.json
+++ b/services/notification-service/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@aws-sdk/client-ses": "^3.1014.0",
     "@aws-sdk/client-sns": "^3.1014.0",
+    "class-validator": "^0.15.1",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^5.2.5",
     "@nestjs/common": "^11.1.17",

--- a/services/notification-service/src/app.module.ts
+++ b/services/notification-service/src/app.module.ts
@@ -12,6 +12,7 @@ import { GatewaysModule } from './gateways/gateways.module.js';
 import { JobsModule } from './jobs/jobs.module.js';
 import { ServicesModule } from './services/services.module.js';
 import { NotificationModule } from './notifications/notification.module.js';
+import { InternalModule } from './internal/internal.module.js';
 import { MetricsModule } from './observability/index.js';
 
 @Module({
@@ -29,6 +30,7 @@ import { MetricsModule } from './observability/index.js';
     JobsModule,
     ServicesModule,
     NotificationModule,
+    InternalModule,
   ],
   controllers: [],
   providers: [],

--- a/services/notification-service/src/internal/__tests__/internal-sms.controller.test.ts
+++ b/services/notification-service/src/internal/__tests__/internal-sms.controller.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InternalSmsController, SendVerificationCodeDto } from '../internal-sms.controller.js';
+
+describe('InternalSmsController', () => {
+  let controller: InternalSmsController;
+  let mockSmsService: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockSmsService = {
+      sendVerificationCode: vi.fn(),
+    };
+
+    controller = new InternalSmsController(mockSmsService);
+  });
+
+  describe('sendVerificationCode', () => {
+    it('should send verification code successfully', async () => {
+      mockSmsService.sendVerificationCode.mockResolvedValue({
+        success: true,
+        messageId: 'msg-123',
+      });
+
+      const dto: SendVerificationCodeDto = {
+        phoneNumber: '+14155551234',
+        code: '123456',
+      };
+
+      const result = await controller.sendVerificationCode(dto);
+
+      expect(result.success).toBe(true);
+      expect(result.messageId).toBe('msg-123');
+      expect(mockSmsService.sendVerificationCode).toHaveBeenCalledWith('+14155551234', '123456');
+    });
+
+    it('should return error when SMS delivery fails', async () => {
+      mockSmsService.sendVerificationCode.mockResolvedValue({
+        success: false,
+        error: 'Rate limit exceeded',
+      });
+
+      const dto: SendVerificationCodeDto = {
+        phoneNumber: '+14155551234',
+        code: '123456',
+      };
+
+      const result = await controller.sendVerificationCode(dto);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Rate limit exceeded');
+    });
+
+    it('should handle various phone number formats', async () => {
+      mockSmsService.sendVerificationCode.mockResolvedValue({
+        success: true,
+        messageId: 'msg-456',
+      });
+
+      // Test with different valid E.164 formats
+      const phoneNumbers = ['+1234567890', '+447911123456', '+861234567890'];
+
+      for (const phoneNumber of phoneNumbers) {
+        const dto: SendVerificationCodeDto = {
+          phoneNumber,
+          code: '999888',
+        };
+
+        await controller.sendVerificationCode(dto);
+
+        expect(mockSmsService.sendVerificationCode).toHaveBeenCalledWith(phoneNumber, '999888');
+      }
+    });
+
+    it('should pass through error message from SMS service', async () => {
+      mockSmsService.sendVerificationCode.mockResolvedValue({
+        success: false,
+        error: 'Invalid phone number format: +1invalid. Expected E.164 format (e.g., +14155551234)',
+      });
+
+      const dto: SendVerificationCodeDto = {
+        phoneNumber: '+1invalid',
+        code: '123456',
+      };
+
+      const result = await controller.sendVerificationCode(dto);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid phone number format');
+    });
+  });
+});

--- a/services/notification-service/src/internal/index.ts
+++ b/services/notification-service/src/internal/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { InternalModule } from './internal.module.js';
+export { InternalSmsController, SendVerificationCodeDto } from './internal-sms.controller.js';
+export type { SendSmsResponseDto } from './internal-sms.controller.js';

--- a/services/notification-service/src/internal/internal-sms.controller.ts
+++ b/services/notification-service/src/internal/internal-sms.controller.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Controller, Post, Body, HttpCode, HttpStatus, Logger } from '@nestjs/common';
+import { IsString, IsNotEmpty, Matches, MaxLength } from 'class-validator';
+import { SmsService, type SmsResult } from '../services/sms.service.js';
+
+/**
+ * DTO for sending a verification code via SMS
+ */
+export class SendVerificationCodeDto {
+  /**
+   * Phone number in E.164 format (e.g., +14155551234)
+   */
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^\+[1-9]\d{1,14}$/, {
+    message: 'Phone number must be in E.164 format (e.g., +14155551234)',
+  })
+  phoneNumber!: string;
+
+  /**
+   * Verification code to send (typically 6 digits)
+   */
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(10)
+  code!: string;
+}
+
+/**
+ * Response DTO for SMS send result
+ */
+export interface SendSmsResponseDto {
+  success: boolean;
+  messageId?: string;
+  error?: string;
+}
+
+/**
+ * Internal SMS Controller
+ *
+ * Provides internal endpoints for service-to-service SMS operations.
+ * These endpoints are not protected by JWT auth since they're for
+ * internal microservice communication only.
+ *
+ * @remarks
+ * - Endpoints prefixed with /internal are for service-to-service calls
+ * - Should only be accessible within the internal network (not exposed via API gateway)
+ * - Uses fire-and-forget pattern on client side but returns result for error handling
+ */
+@Controller('internal/sms')
+export class InternalSmsController {
+  private readonly logger = new Logger(InternalSmsController.name);
+
+  constructor(private readonly smsService: SmsService) {}
+
+  /**
+   * Send a verification code via SMS
+   *
+   * Called by user-service during phone verification flow.
+   * Uses AWS SNS to deliver the SMS message.
+   *
+   * @param dto - Phone number and verification code
+   * @returns Result with success status and optional messageId
+   */
+  @Post('verification-code')
+  @HttpCode(HttpStatus.OK)
+  async sendVerificationCode(@Body() dto: SendVerificationCodeDto): Promise<SendSmsResponseDto> {
+    this.logger.log(`Sending verification code to ${this.maskPhone(dto.phoneNumber)}`);
+
+    const result: SmsResult = await this.smsService.sendVerificationCode(dto.phoneNumber, dto.code);
+
+    if (!result.success) {
+      this.logger.warn(
+        `Failed to send verification SMS to ${this.maskPhone(dto.phoneNumber)}: ${result.error}`,
+      );
+    }
+
+    return {
+      success: result.success,
+      messageId: result.messageId,
+      error: result.error,
+    };
+  }
+
+  /**
+   * Mask phone number for logging (privacy)
+   */
+  private maskPhone(phoneNumber: string): string {
+    if (phoneNumber.length < 4) return '****';
+    return phoneNumber.substring(0, 3) + '****' + phoneNumber.substring(phoneNumber.length - 2);
+  }
+}

--- a/services/notification-service/src/internal/internal.module.ts
+++ b/services/notification-service/src/internal/internal.module.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Module } from '@nestjs/common';
+import { ServicesModule } from '../services/services.module.js';
+import { InternalSmsController } from './internal-sms.controller.js';
+
+/**
+ * Internal Module
+ *
+ * Provides internal endpoints for service-to-service communication.
+ * These endpoints are not protected by JWT auth since they're
+ * for internal microservice calls only.
+ */
+@Module({
+  imports: [ServicesModule],
+  controllers: [InternalSmsController],
+})
+export class InternalModule {}

--- a/services/user-service/src/clients/__tests__/sms.client.test.ts
+++ b/services/user-service/src/clients/__tests__/sms.client.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SmsClient } from '../sms.client.js';
+
+describe('SmsClient', () => {
+  let client: SmsClient;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalFetch = global.fetch;
+    client = new SmsClient();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('sendVerificationCode', () => {
+    it('should send verification code successfully', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            messageId: 'msg-123',
+          }),
+      }) as any;
+
+      const result = await client.sendVerificationCode('+14155551234', '123456');
+
+      expect(result.success).toBe(true);
+      expect(result.messageId).toBe('msg-123');
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/internal/sms/verification-code'),
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ phoneNumber: '+14155551234', code: '123456' }),
+        }),
+      );
+    });
+
+    it('should return error when fetch returns non-ok response', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('Internal Server Error'),
+      }) as any;
+
+      const result = await client.sendVerificationCode('+14155551234', '123456');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('HTTP 500');
+    });
+
+    it('should return error when SMS service returns failure', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            success: false,
+            error: 'Rate limit exceeded',
+          }),
+      }) as any;
+
+      const result = await client.sendVerificationCode('+14155551234', '123456');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Rate limit exceeded');
+    });
+
+    it('should handle network errors gracefully', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network error')) as any;
+
+      const result = await client.sendVerificationCode('+14155551234', '123456');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Network error');
+    });
+
+    it('should handle timeout errors', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('Request timeout')) as any;
+
+      const result = await client.sendVerificationCode('+14155551234', '123456');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Request timeout');
+    });
+
+    it('should use NOTIFICATION_SERVICE_URL from environment if available', async () => {
+      const originalEnv = process.env['NOTIFICATION_SERVICE_URL'];
+      process.env['NOTIFICATION_SERVICE_URL'] = 'http://custom-notification:8080';
+
+      // Create new client to pick up env var
+      const customClient = new SmsClient();
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true, messageId: 'msg-789' }),
+      }) as any;
+
+      await customClient.sendVerificationCode('+14155551234', '123456');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://custom-notification:8080/internal/sms/verification-code',
+        expect.any(Object),
+      );
+
+      // Restore env var
+      if (originalEnv === undefined) {
+        delete process.env['NOTIFICATION_SERVICE_URL'];
+      } else {
+        process.env['NOTIFICATION_SERVICE_URL'] = originalEnv;
+      }
+    });
+  });
+});

--- a/services/user-service/src/clients/index.ts
+++ b/services/user-service/src/clients/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { SmsClient } from './sms.client.js';
+export type { SmsDeliveryResult } from './sms.client.js';

--- a/services/user-service/src/clients/sms.client.ts
+++ b/services/user-service/src/clients/sms.client.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { getServiceUrl } from '@reason-bridge/common';
+
+/**
+ * Result of an SMS send operation
+ */
+export interface SmsDeliveryResult {
+  success: boolean;
+  messageId?: string;
+  error?: string;
+}
+
+/**
+ * SMS Client for notification-service
+ *
+ * Provides SMS delivery capabilities by calling the notification-service's
+ * internal SMS endpoint. Used primarily for phone verification OTP codes.
+ *
+ * @remarks
+ * - Calls notification-service's /internal/sms/verification-code endpoint
+ * - Returns delivery result for error handling (not fire-and-forget)
+ * - Phone numbers must be in E.164 format (e.g., +14155551234)
+ *
+ * @example
+ * ```typescript
+ * const result = await smsClient.sendVerificationCode('+14155551234', '123456');
+ * if (!result.success) {
+ *   logger.warn(`Failed to send SMS: ${result.error}`);
+ * }
+ * ```
+ */
+@Injectable()
+export class SmsClient {
+  private readonly logger = new Logger(SmsClient.name);
+  private readonly baseUrl: string;
+
+  constructor() {
+    this.baseUrl = process.env['NOTIFICATION_SERVICE_URL'] || getServiceUrl('NOTIFICATION_SERVICE');
+  }
+
+  /**
+   * Send a verification code via SMS
+   *
+   * Calls notification-service to deliver the SMS via AWS SNS.
+   * Returns result to allow caller to handle delivery failures.
+   *
+   * @param phoneNumber - E.164 format phone number
+   * @param code - Verification code to send
+   * @returns Delivery result with success status
+   */
+  async sendVerificationCode(phoneNumber: string, code: string): Promise<SmsDeliveryResult> {
+    const endpoint = `${this.baseUrl}/internal/sms/verification-code`;
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ phoneNumber, code }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        this.logger.warn(
+          `SMS delivery failed for ${this.maskPhone(phoneNumber)}: HTTP ${response.status}`,
+        );
+        return {
+          success: false,
+          error: `HTTP ${response.status}: ${errorText}`,
+        };
+      }
+
+      const result = (await response.json()) as SmsDeliveryResult;
+
+      if (result.success) {
+        this.logger.log(
+          `SMS sent to ${this.maskPhone(phoneNumber)}, messageId: ${result.messageId}`,
+        );
+      } else {
+        this.logger.warn(`SMS delivery failed for ${this.maskPhone(phoneNumber)}: ${result.error}`);
+      }
+
+      return result;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Error sending SMS to ${this.maskPhone(phoneNumber)}: ${errorMessage}`);
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Mask phone number for logging (privacy)
+   */
+  private maskPhone(phoneNumber: string): string {
+    if (phoneNumber.length < 4) return '****';
+    return phoneNumber.substring(0, 3) + '****' + phoneNumber.substring(phoneNumber.length - 2);
+  }
+}

--- a/services/user-service/src/verification/verification.module.ts
+++ b/services/user-service/src/verification/verification.module.ts
@@ -13,6 +13,7 @@ import { VideoVerificationService } from './video-challenge.service.js';
 import { VideoUploadService } from './video-upload.service.js';
 import { OtpService } from './services/otp.service.js';
 import { PhoneValidationService } from './services/phone-validation.service.js';
+import { SmsClient } from '../clients/sms.client.js';
 
 /**
  * Verification Module
@@ -29,6 +30,7 @@ import { PhoneValidationService } from './services/phone-validation.service.js';
     VideoUploadService,
     OtpService,
     PhoneValidationService,
+    SmsClient,
   ],
   exports: [VerificationService, VideoVerificationService, VideoUploadService],
 })

--- a/services/user-service/src/verification/verification.service.ts
+++ b/services/user-service/src/verification/verification.service.ts
@@ -12,6 +12,7 @@ import { randomUUID } from 'crypto';
 import { VerificationType, VerificationStatus } from '@prisma/client';
 import { OtpService } from './services/otp.service.js';
 import { PhoneValidationService } from './services/phone-validation.service.js';
+import { SmsClient } from '../clients/sms.client.js';
 import {
   PhoneVerificationRequestDto,
   PhoneVerificationVerifyDto,
@@ -36,6 +37,7 @@ export class VerificationService {
     private videoVerificationService: VideoVerificationService,
     private otpService: OtpService,
     private phoneValidationService: PhoneValidationService,
+    private smsClient: SmsClient,
   ) {}
 
   /**
@@ -474,11 +476,36 @@ export class VerificationService {
       },
     });
 
-    // TODO: In production, integrate with SMS provider (Twilio, AWS SNS, etc.)
-    // For now, log the OTP to console for development/testing
-    this.logger.log(
-      `[DEV MODE] OTP for ${this.phoneValidationService.maskPhoneNumber(normalizedPhone)}: ${otpCode}`,
-    );
+    // Send OTP via SMS (through notification-service)
+    // In dev/test mode without notification-service, also log to console
+    const isDevMode = process.env['NODE_ENV'] === 'development' || isTestMode;
+
+    if (isDevMode) {
+      this.logger.log(
+        `[DEV MODE] OTP for ${this.phoneValidationService.maskPhoneNumber(normalizedPhone)}: ${otpCode}`,
+      );
+    }
+
+    // Send SMS via notification-service
+    const smsResult = await this.smsClient.sendVerificationCode(normalizedPhone, otpCode);
+
+    if (!smsResult.success) {
+      this.logger.warn(
+        `SMS delivery failed for ${this.phoneValidationService.maskPhoneNumber(normalizedPhone)}: ${smsResult.error}`,
+      );
+      // In production, we might want to throw here, but for now we'll continue
+      // since the OTP was created and can be tested via dev mode logging or test endpoint
+      if (!isDevMode) {
+        // Clean up the verification record if SMS failed in production
+        await this.prisma.verificationRecord.delete({ where: { id: verification.id } });
+        throw new BadRequestException('Failed to send verification code. Please try again later.');
+      }
+    } else {
+      this.logger.log(
+        `OTP sent to ${this.phoneValidationService.maskPhoneNumber(normalizedPhone)}, messageId: ${smsResult.messageId}`,
+      );
+    }
+
     this.logger.log(`OTP expires at: ${expiresAt.toISOString()}`);
 
     return {


### PR DESCRIPTION
## Summary
- Added internal SMS endpoint (`/internal/sms/verification-code`) in notification-service for cross-service SMS delivery
- Created `SmsClient` in user-service to call notification-service's SMS endpoint
- Integrated SMS delivery into `VerificationService.requestPhoneVerification()` 
- Graceful degradation: continues to log OTP in dev/test mode if notification-service is unavailable
- Production mode fails cleanly if SMS delivery fails, cleaning up the verification record

## Technical Details

### New Files
- `services/notification-service/src/internal/internal-sms.controller.ts` - Internal endpoint for SMS delivery
- `services/notification-service/src/internal/internal.module.ts` - Module for internal endpoints
- `services/user-service/src/clients/sms.client.ts` - HTTP client to call notification-service

### Modified Files
- `services/user-service/src/verification/verification.service.ts` - Integrated SMS client
- `services/notification-service/package.json` - Added class-validator dependency

### Architecture
```
user-service                    notification-service
     │                                │
     │ VerificationService            │
     │ requestPhoneVerification()     │
     │         │                      │
     │         ▼                      │
     │    SmsClient ─────HTTP────►   InternalSmsController
     │                                │
     │                                ▼
     │                           SmsService
     │                                │
     │                                ▼
     │                           AWS SNS
```

## Test Plan
- [x] Unit tests for InternalSmsController (4 tests)
- [x] Unit tests for SmsClient (6 tests)
- [x] All existing user-service tests pass (877 tests)
- [x] All existing notification-service tests pass (103 tests)

Closes #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)