### PR TITLE
feat(notifications): notify all topic participants for common ground events

### DIFF
--- a/services/notification-service/src/__tests__/integration/common-ground-handler.integration.test.ts
+++ b/services/notification-service/src/__tests__/integration/common-ground-handler.integration.test.ts
@@ -21,6 +21,7 @@ describe('CommonGroundNotificationHandler Integration Tests', () => {
   let handler: CommonGroundNotificationHandler;
   let gateway: NotificationGateway;
   let mockPrisma: any;
+  let mockDeliveryService: any;
 
   beforeEach(() => {
     const logger = new Logger();
@@ -29,6 +30,16 @@ describe('CommonGroundNotificationHandler Integration Tests', () => {
     mockPrisma = {
       discussionTopic: {
         findUnique: vi.fn().mockResolvedValue(mockTopic),
+      },
+      notification: {
+        create: vi
+          .fn()
+          .mockImplementation(() =>
+            Promise.resolve({ id: `notif-${Math.random().toString(36).slice(2)}` }),
+          ),
+      },
+      response: {
+        findMany: vi.fn().mockResolvedValue([]),
       },
     };
 
@@ -47,8 +58,17 @@ describe('CommonGroundNotificationHandler Integration Tests', () => {
       handleUnsubscribeCommonGround: vi.fn(),
     } as any;
 
+    // Mock delivery service
+    mockDeliveryService = {
+      deliverNotification: vi.fn().mockResolvedValue(undefined),
+    };
+
     // Create handler with injected dependencies
-    handler = new CommonGroundNotificationHandler(mockPrisma as PrismaService, gateway);
+    handler = new CommonGroundNotificationHandler(
+      mockPrisma as PrismaService,
+      gateway,
+      mockDeliveryService,
+    );
   });
 
   afterEach(() => {

--- a/services/notification-service/src/handlers/common-ground-notification.handler.test.ts
+++ b/services/notification-service/src/handlers/common-ground-notification.handler.test.ts
@@ -7,6 +7,14 @@ const createMockPrismaService = () => ({
   },
   notification: {
     createMany: vi.fn().mockResolvedValue({ count: 0 }),
+    create: vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve({ id: `notif-${Math.random().toString(36).slice(2)}` }),
+      ),
+  },
+  response: {
+    findMany: vi.fn().mockResolvedValue([]),
   },
 });
 
@@ -15,16 +23,26 @@ const createMockNotificationGateway = () => ({
   emitCommonGroundUpdated: vi.fn(),
 });
 
+const createMockDeliveryService = () => ({
+  deliverNotification: vi.fn().mockResolvedValue(undefined),
+});
+
 describe('CommonGroundNotificationHandler', () => {
   let handler: CommonGroundNotificationHandler;
   let mockPrisma: ReturnType<typeof createMockPrismaService>;
   let mockGateway: ReturnType<typeof createMockNotificationGateway>;
+  let mockDeliveryService: ReturnType<typeof createMockDeliveryService>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockPrisma = createMockPrismaService();
     mockGateway = createMockNotificationGateway();
-    handler = new CommonGroundNotificationHandler(mockPrisma as any, mockGateway as any);
+    mockDeliveryService = createMockDeliveryService();
+    handler = new CommonGroundNotificationHandler(
+      mockPrisma as any,
+      mockGateway as any,
+      mockDeliveryService as any,
+    );
   });
 
   describe('handleCommonGroundGenerated', () => {
@@ -325,6 +343,93 @@ describe('CommonGroundNotificationHandler', () => {
       );
 
       expect(mockGateway.emitCommonGroundUpdated).toHaveBeenCalled();
+    });
+  });
+
+  describe('participant tracking', () => {
+    const createEvent = (overrides = {}) => ({
+      type: 'common-ground.generated' as const,
+      timestamp: new Date().toISOString(),
+      payload: {
+        topicId: 'topic-1',
+        version: 1,
+        agreementZones: [{ id: 'zone-1', summary: 'Agreement on X' }],
+        misunderstandings: [],
+        genuineDisagreements: [],
+        overallConsensusScore: 0.75,
+        ...overrides,
+      },
+    });
+
+    it('should notify all topic participants including creator', async () => {
+      mockPrisma.discussionTopic.findUnique.mockResolvedValue({
+        id: 'topic-1',
+        title: 'Test Topic',
+        creatorId: 'user-1',
+        participantCount: 3,
+      });
+
+      // Other participants (not the creator)
+      mockPrisma.response.findMany.mockResolvedValue([
+        { authorId: 'user-2' },
+        { authorId: 'user-3' },
+      ]);
+
+      await handler.handleCommonGroundGenerated(createEvent());
+
+      // Should query for participants excluding creator
+      expect(mockPrisma.response.findMany).toHaveBeenCalledWith({
+        where: {
+          topicId: 'topic-1',
+          authorId: { not: 'user-1' },
+        },
+        select: { authorId: true },
+        distinct: ['authorId'],
+      });
+
+      // Should create 3 notifications (1 creator + 2 other participants)
+      expect(mockPrisma.notification.create).toHaveBeenCalledTimes(3);
+    });
+
+    it('should notify only creator when no other participants', async () => {
+      mockPrisma.discussionTopic.findUnique.mockResolvedValue({
+        id: 'topic-1',
+        title: 'Test Topic',
+        creatorId: 'user-1',
+        participantCount: 1,
+      });
+
+      // No other participants
+      mockPrisma.response.findMany.mockResolvedValue([]);
+
+      await handler.handleCommonGroundGenerated(createEvent());
+
+      // Should create 1 notification (just creator)
+      expect(mockPrisma.notification.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('should deliver notifications to all participants', async () => {
+      mockPrisma.discussionTopic.findUnique.mockResolvedValue({
+        id: 'topic-1',
+        title: 'Test Topic',
+        creatorId: 'user-1',
+        participantCount: 2,
+      });
+
+      mockPrisma.response.findMany.mockResolvedValue([{ authorId: 'user-2' }]);
+
+      await handler.handleCommonGroundGenerated(createEvent());
+
+      // Should deliver to both creator and participant
+      expect(mockDeliveryService.deliverNotification).toHaveBeenCalledTimes(2);
+      expect(mockDeliveryService.deliverNotification).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ type: 'common_ground' }),
+      );
+      expect(mockDeliveryService.deliverNotification).toHaveBeenCalledWith(
+        'user-2',
+        expect.objectContaining({ type: 'common_ground' }),
+      );
     });
   });
 });

--- a/services/notification-service/src/handlers/common-ground-notification.handler.ts
+++ b/services/notification-service/src/handlers/common-ground-notification.handler.ts
@@ -62,9 +62,15 @@ export class CommonGroundNotificationHandler {
         overallConsensusScore,
       );
 
-      // TODO: Fetch topic participants when participant tracking is implemented
-      // For now, notify topic creator only
-      const recipientIds = [topic.creatorId];
+      // Get all topic participants (response authors) excluding the creator
+      const otherParticipants = await this.getTopicParticipants(topic.id, topic.creatorId);
+
+      // Include topic creator and all other participants
+      const recipientIds = [topic.creatorId, ...otherParticipants];
+
+      this.logger.debug(
+        `Notifying ${recipientIds.length} participants (1 creator + ${otherParticipants.length} others)`,
+      );
 
       const actionUrl = `/topics/${topic.id}/common-ground`;
 
@@ -150,9 +156,15 @@ export class CommonGroundNotificationHandler {
       const title = `New insights in "${topic.title}"`;
       const body = this.buildUpdatedNotificationBody(changes);
 
-      // TODO: Fetch topic participants when participant tracking is implemented
-      // For now, notify topic creator only
-      const recipientIds = [topic.creatorId];
+      // Get all topic participants (response authors) excluding the creator
+      const otherParticipants = await this.getTopicParticipants(topic.id, topic.creatorId);
+
+      // Include topic creator and all other participants
+      const recipientIds = [topic.creatorId, ...otherParticipants];
+
+      this.logger.debug(
+        `Notifying ${recipientIds.length} participants (1 creator + ${otherParticipants.length} others)`,
+      );
 
       const actionUrl = `/topics/${topic.id}/common-ground`;
 
@@ -206,6 +218,28 @@ export class CommonGroundNotificationHandler {
       );
       throw error;
     }
+  }
+
+  /**
+   * Get all unique participants for a topic by querying response authors
+   * Excludes the topic creator since they're already included
+   *
+   * @param topicId - Topic ID to get participants for
+   * @param excludeUserId - Optional user ID to exclude (typically the topic creator)
+   * @returns Array of unique user IDs who have contributed responses
+   */
+  private async getTopicParticipants(topicId: string, excludeUserId?: string): Promise<string[]> {
+    // Query distinct author IDs from responses for this topic
+    const participants = await this.prisma.response.findMany({
+      where: {
+        topicId,
+        ...(excludeUserId && { authorId: { not: excludeUserId } }),
+      },
+      select: { authorId: true },
+      distinct: ['authorId'],
+    });
+
+    return participants.map((p) => p.authorId);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Implements topic participant tracking for common ground notifications
- Queries distinct response authors to identify all participants who contributed to a topic
- Notifies all participants (creator + responders) when common ground analysis is generated or updated
- Adds comprehensive tests for participant resolution behavior

## Changes
- `getTopicParticipants` method queries `response.findMany` with `distinct: ['authorId']`
- Both `handleCommonGroundGenerated` and `handleCommonGroundUpdated` now notify all participants
- Integration and unit tests updated with participant tracking coverage

## Test plan
- [x] Unit tests for participant tracking (3 new tests in handler.test.ts)
- [x] Integration tests updated with required mocks
- [x] All 129 notification-service tests pass

Resolves #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)