### PR TITLE
feat(profile): add privacy settings and tier level to user profile

### DIFF
--- a/frontend/src/hooks/useUserRank.ts
+++ b/frontend/src/hooks/useUserRank.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * React Query hook for fetching a user's ranking and tier level
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import type { UserRank } from '../types/ranking';
+import { apiClient } from '../lib/api';
+
+/**
+ * Fetches a user's ranking information by their ID
+ * @param userId - The user's UUID
+ * @returns Query result with UserRank data
+ */
+export function useUserRank(userId: string | undefined) {
+  return useQuery({
+    queryKey: ['userRank', userId],
+    queryFn: async () => {
+      if (!userId) {
+        throw new Error('User ID is required');
+      }
+      const response = await apiClient.get<UserRank>(`/users/${userId}/ranking`);
+      return response;
+    },
+    enabled: !!userId,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    // Don't throw on 404 - user may not have a rank yet
+    retry: (failureCount, error) => {
+      // Don't retry on 404 (user has no rank yet)
+      if (error instanceof Error && error.message.includes('404')) {
+        return false;
+      }
+      return failureCount < 3;
+    },
+  });
+}

--- a/frontend/src/pages/Profile/UserProfilePage.tsx
+++ b/frontend/src/pages/Profile/UserProfilePage.tsx
@@ -26,6 +26,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useUser } from '../../lib/useUser';
 import { useDelayedLoading } from '../../hooks/useDelayedLoading';
 import { useCanViewSection } from '../../hooks/useCanViewSection';
+import { useUserRank } from '../../hooks/useUserRank';
 import {
   useProfileContributions,
   useContributionStats,
@@ -46,13 +47,14 @@ import {
   FollowingModal,
 } from '../../components/profile';
 import { UserNotFound } from '../../components/users';
-import type { TierLevel, TopicExpertise } from '../../types/ranking';
+import type { TopicExpertise } from '../../types/ranking';
 import type { ContributionType } from '../../types/contribution';
 import { UserStatus } from '../../types/user';
 
 function UserProfilePage() {
   const { id } = useParams<{ id: string }>();
   const { data: user, isLoading, isError, error } = useUser(id);
+  const { data: userRank } = useUserRank(id);
   const showSkeleton = useDelayedLoading(isLoading);
 
   // Contribution filter state
@@ -66,10 +68,9 @@ function UserProfilePage() {
   const queryClient = useQueryClient();
 
   // Privacy-aware section visibility
-  // NOTE: privacySettings would come from user profile endpoint when available
   const { visibility, isOwner } = useCanViewSection({
     targetUserId: id || '',
-    privacySettings: undefined, // TODO: Add when user endpoint returns privacy settings
+    privacySettings: user?.privacySettings,
   });
 
   // Local follower count adjustment (for optimistic UI update)
@@ -149,8 +150,8 @@ function UserProfilePage() {
     );
   }
 
-  // TODO: Fetch tier level from ranking service when available
-  const tierLevel: TierLevel | undefined = undefined;
+  // Get tier level from ranking data
+  const tierLevel = userRank?.tierLevel;
 
   // Mock expertise data for now (would come from API)
   const topExpertise: TopicExpertise[] = [];

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -82,6 +82,11 @@ export interface UserProfile extends User {
    * Parental consent status for minor users
    */
   parentConsentStatus?: ParentConsentStatus;
+
+  /**
+   * User's privacy settings for profile sections
+   */
+  privacySettings?: PrivacySettings;
 }
 
 export interface UserSummary {

--- a/services/user-service/src/users/dto/user-response.dto.ts
+++ b/services/user-service/src/users/dto/user-response.dto.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { User, VerificationLevel, UserStatus, UserRole } from '@prisma/client';
+import type {
+  User,
+  VerificationLevel,
+  UserStatus,
+  UserRole,
+  UserPrivacySettings,
+} from '@prisma/client';
+import { PrivacySettingsDto, ProfileVisibility, TrustVisibility } from './privacy-settings.dto.js';
 
 /**
  * Response DTO for user data (includes private fields like email)
@@ -63,8 +70,13 @@ export class PublicUserResponseDto {
   createdAt!: Date;
   followerCount?: number;
   followingCount?: number;
+  privacySettings!: PrivacySettingsDto;
 
-  constructor(user: User, followerCount?: number, followingCount?: number) {
+  constructor(
+    user: User & { privacySettings?: UserPrivacySettings | null },
+    followerCount?: number,
+    followingCount?: number,
+  ) {
     this.id = user.id;
     this.displayName = user.displayName ?? '';
     this.bio = user.bio ?? null;
@@ -77,5 +89,17 @@ export class PublicUserResponseDto {
     this.createdAt = user.createdAt;
     this.followerCount = followerCount;
     this.followingCount = followingCount;
+
+    // Map privacy settings or use defaults if not set
+    if (user.privacySettings) {
+      this.privacySettings = {
+        activityHistory: user.privacySettings.activityHistory as ProfileVisibility,
+        detailedTrustScores: user.privacySettings.detailedTrustScores as TrustVisibility,
+        followerList: user.privacySettings.followerList as ProfileVisibility,
+        followingList: user.privacySettings.followingList as ProfileVisibility,
+      };
+    } else {
+      this.privacySettings = PrivacySettingsDto.getDefaults();
+    }
   }
 }

--- a/services/user-service/src/users/users.service.ts
+++ b/services/user-service/src/users/users.service.ts
@@ -126,6 +126,9 @@ export class UsersService {
 
     const user = await this.prisma.user.findUnique({
       where: { id },
+      include: {
+        privacySettings: true,
+      },
     });
 
     if (!user) {


### PR DESCRIPTION
## Summary
- Implements privacy settings and tier level display on user profile page
- Backend now returns privacy settings when fetching user profiles
- Frontend now fetches and displays user's tier level from ranking API

## Changes

### Backend (user-service)
- Added `privacySettings` field to `PublicUserResponseDto`
- Updated `findById` to include `privacySettings` relation in query

### Frontend
- Added `privacySettings` to `UserProfile` type
- Created `useUserRank` hook to fetch tier level from `/users/:id/ranking`
- Updated `UserProfilePage` to:
  - Pass `user.privacySettings` to `useCanViewSection` hook
  - Fetch and display tier level via `useUserRank` hook

## Test plan
- [x] All 877 user-service tests pass
- [x] Frontend TypeScript type check passes
- [x] Pre-commit hooks pass

Resolves #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)