### PR TITLE
feat(contact): implement mutual contacts calculation

### DIFF
--- a/services/contact-service/src/discovery/__tests__/discovery.service.spec.ts
+++ b/services/contact-service/src/discovery/__tests__/discovery.service.spec.ts
@@ -15,6 +15,7 @@ describe('DiscoveryService', () => {
       importedContact: {
         findMany: vi.fn(),
         updateMany: vi.fn(),
+        groupBy: vi.fn(),
       },
       user: {
         findMany: vi.fn(),
@@ -25,12 +26,15 @@ describe('DiscoveryService', () => {
 
   describe('discoverUsers', () => {
     it('should find users matching imported contact email hashes', async () => {
-      // User's imported contacts
-      mockPrisma.importedContact.findMany.mockResolvedValue([
-        { id: 'c1', emailHash: 'hash1', matchedUserId: null },
-        { id: 'c2', emailHash: 'hash2', matchedUserId: null },
-        { id: 'c3', emailHash: 'hash3', matchedUserId: null },
-      ]);
+      // User's imported contacts (first call)
+      mockPrisma.importedContact.findMany
+        .mockResolvedValueOnce([
+          { id: 'c1', emailHash: 'hash1', matchedUserId: null },
+          { id: 'c2', emailHash: 'hash2', matchedUserId: null },
+          { id: 'c3', emailHash: 'hash3', matchedUserId: null },
+        ])
+        // Second call for mutual contacts calculation (matched contacts)
+        .mockResolvedValueOnce([]);
 
       // Discoverable users matching those hashes
       mockPrisma.user.findMany.mockResolvedValue([
@@ -44,6 +48,7 @@ describe('DiscoveryService', () => {
       ]);
 
       mockPrisma.importedContact.updateMany.mockResolvedValue({ count: 2 });
+      mockPrisma.importedContact.groupBy.mockResolvedValue([]);
 
       const result = await service.discoverUsers('owner-123', { limit: 50, offset: 0 });
 
@@ -54,9 +59,12 @@ describe('DiscoveryService', () => {
     });
 
     it('should only find users with discoverableByContacts=true', async () => {
-      mockPrisma.importedContact.findMany.mockResolvedValue([{ id: 'c1', emailHash: 'hash1' }]);
+      mockPrisma.importedContact.findMany
+        .mockResolvedValueOnce([{ id: 'c1', emailHash: 'hash1' }])
+        .mockResolvedValueOnce([]); // For mutual contacts
       mockPrisma.user.findMany.mockResolvedValue([]);
       mockPrisma.importedContact.updateMany.mockResolvedValue({ count: 0 });
+      mockPrisma.importedContact.groupBy.mockResolvedValue([]);
 
       await service.discoverUsers('owner-123', {});
 
@@ -70,11 +78,14 @@ describe('DiscoveryService', () => {
     });
 
     it('should update matchedUserId on imported contacts', async () => {
-      mockPrisma.importedContact.findMany.mockResolvedValue([{ id: 'c1', emailHash: 'hash1' }]);
+      mockPrisma.importedContact.findMany
+        .mockResolvedValueOnce([{ id: 'c1', emailHash: 'hash1' }])
+        .mockResolvedValueOnce([]); // For mutual contacts
       mockPrisma.user.findMany.mockResolvedValue([
         { id: 'user-1', displayName: 'John', emailHash: 'hash1' },
       ]);
       mockPrisma.importedContact.updateMany.mockResolvedValue({ count: 1 });
+      mockPrisma.importedContact.groupBy.mockResolvedValue([]);
 
       await service.discoverUsers('owner-123', {});
 
@@ -100,10 +111,11 @@ describe('DiscoveryService', () => {
     });
 
     it('should exclude the owner from discovered users', async () => {
-      mockPrisma.importedContact.findMany.mockResolvedValue([
-        { id: 'c1', emailHash: 'owner-hash' },
-      ]);
+      mockPrisma.importedContact.findMany
+        .mockResolvedValueOnce([{ id: 'c1', emailHash: 'owner-hash' }])
+        .mockResolvedValueOnce([]); // For mutual contacts
       mockPrisma.user.findMany.mockResolvedValue([]);
+      mockPrisma.importedContact.groupBy.mockResolvedValue([]);
 
       await service.discoverUsers('owner-123', {});
 
@@ -117,8 +129,11 @@ describe('DiscoveryService', () => {
     });
 
     it('should respect pagination parameters', async () => {
-      mockPrisma.importedContact.findMany.mockResolvedValue([{ id: 'c1', emailHash: 'hash1' }]);
+      mockPrisma.importedContact.findMany
+        .mockResolvedValueOnce([{ id: 'c1', emailHash: 'hash1' }])
+        .mockResolvedValueOnce([]); // For mutual contacts
       mockPrisma.user.findMany.mockResolvedValue([]);
+      mockPrisma.importedContact.groupBy.mockResolvedValue([]);
 
       await service.discoverUsers('owner-123', { limit: 10, offset: 20 });
 
@@ -128,6 +143,34 @@ describe('DiscoveryService', () => {
           skip: 20,
         }),
       );
+    });
+
+    it('should calculate mutual contacts correctly', async () => {
+      // User's imported contacts (first call)
+      mockPrisma.importedContact.findMany
+        .mockResolvedValueOnce([
+          { id: 'c1', emailHash: 'hash1', matchedUserId: null },
+          { id: 'c2', emailHash: 'hash2', matchedUserId: 'contact-user-1' },
+        ])
+        // Second call: owner's matched contacts for mutual calculation
+        .mockResolvedValueOnce([{ matchedUserId: 'contact-user-1' }]);
+
+      // Discovered user
+      mockPrisma.user.findMany.mockResolvedValue([
+        { id: 'discovered-user-1', displayName: 'John', emailHash: 'hash1' },
+      ]);
+
+      mockPrisma.importedContact.updateMany.mockResolvedValue({ count: 1 });
+
+      // groupBy returns that contact-user-1 also has discovered-user-1 as a contact
+      mockPrisma.importedContact.groupBy.mockResolvedValue([
+        { matchedUserId: 'discovered-user-1', _count: { ownerId: 1 } },
+      ]);
+
+      const result = await service.discoverUsers('owner-123', {});
+
+      expect(result.users).toHaveLength(1);
+      expect(result.users[0].mutualContacts).toBe(1);
     });
   });
 });

--- a/services/contact-service/src/discovery/discovery.service.ts
+++ b/services/contact-service/src/discovery/discovery.service.ts
@@ -92,14 +92,82 @@ export class DiscoveryService {
 
     this.logger.log(`Discovered ${discoveredUsers.length} users for owner ${ownerId}`);
 
+    // Calculate mutual contacts for each discovered user
+    const mutualContactsCounts = await this.calculateMutualContacts(
+      ownerId,
+      discoveredUsers.map((u) => u.id),
+    );
+
     return {
       users: discoveredUsers.map((u) => ({
         userId: u.id,
         displayName: u.displayName || 'Unknown',
         avatarUrl: u.avatarUrl || undefined,
-        mutualContacts: 0, // TODO: Calculate mutual contacts in future iteration
+        mutualContacts: mutualContactsCounts.get(u.id) || 0,
       })),
       total: discoveredUsers.length,
     };
+  }
+
+  /**
+   * Calculate mutual contacts for a batch of discovered users.
+   *
+   * Mutual contacts are users who:
+   * 1. Are in the requesting user's contact list (matched to a ReasonBridge user)
+   * 2. Also have the discovered user in their own contact list
+   *
+   * @param ownerId - The ID of the requesting user
+   * @param discoveredUserIds - IDs of discovered users to calculate mutual contacts for
+   * @returns Map of discovered user ID to mutual contacts count
+   */
+  private async calculateMutualContacts(
+    ownerId: string,
+    discoveredUserIds: string[],
+  ): Promise<Map<string, number>> {
+    if (discoveredUserIds.length === 0) {
+      return new Map();
+    }
+
+    // Get all of ownerId's contacts who are matched to ReasonBridge users
+    const ownerMatchedContacts = await this.prisma.importedContact.findMany({
+      where: {
+        ownerId,
+        matchedUserId: { not: null },
+      },
+      select: { matchedUserId: true },
+    });
+
+    const matchedContactUserIds = ownerMatchedContacts
+      .map((c) => c.matchedUserId)
+      .filter((id): id is string => id !== null);
+
+    if (matchedContactUserIds.length === 0) {
+      return new Map();
+    }
+
+    // For each discovered user, count how many of owner's contacts also have them as a contact
+    // Query: Find ImportedContact records where:
+    // - ownerId is one of the matched contact users (not the requesting user)
+    // - matchedUserId is one of the discovered users
+    const mutualContactsData = await this.prisma.importedContact.groupBy({
+      by: ['matchedUserId'],
+      where: {
+        ownerId: { in: matchedContactUserIds },
+        matchedUserId: { in: discoveredUserIds },
+      },
+      _count: {
+        ownerId: true,
+      },
+    });
+
+    // Build the result map
+    const result = new Map<string, number>();
+    for (const row of mutualContactsData) {
+      if (row.matchedUserId) {
+        result.set(row.matchedUserId, row._count.ownerId);
+      }
+    }
+
+    return result;
   }
 }


### PR DESCRIPTION
## Summary

Implements the mutual contacts calculation in the discovery service (Issue #1129), replacing the placeholder value of 0.

**What are mutual contacts?**
Users who are both:
1. In the requesting user's contact list (matched to a ReasonBridge user)
2. Have the discovered user in their own contact list

**Implementation:**
- Added `calculateMutualContacts` private method that uses Prisma's `groupBy` for efficient batch calculation
- Updated `discoverUsers` to populate the `mutualContacts` field with actual counts
- Added test case verifying the mutual contacts calculation logic

## Test Plan

- [x] TypeScript compilation passes
- [x] Contact-service unit tests pass (97 tests)
- [x] New test case for mutual contacts calculation
- [ ] CI pipeline passes

Closes #1129

🤖 Generated with [Claude Code](https://claude.ai/code)