### PR TITLE
fix(e2e): enable response editing test by fixing JWT_SECRET config (#1085)

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -214,6 +214,7 @@ services:
       AWS_PROFILE: default
       # Use cross-region inference profile for on-demand access
       BEDROCK_MODEL_ID: us.anthropic.claude-3-5-sonnet-20241022-v2:0
+      JWT_SECRET: mock-jwt-secret-for-e2e-testing
     ports:
       - '3002:3002'
     volumes:
@@ -242,6 +243,7 @@ services:
       DATABASE_URL: postgresql://reasonbridge_test:reasonbridge_test@postgres:5432/reasonbridge_test
       REDIS_URL: redis://redis:6379
       ACTIVITY_SERVICE_URL: http://activity-service:3008
+      JWT_SECRET: mock-jwt-secret-for-e2e-testing
     ports:
       - '3007:3007'
     depends_on:
@@ -267,6 +269,7 @@ services:
       DATABASE_URL: postgresql://reasonbridge_test:reasonbridge_test@postgres:5432/reasonbridge_test
       REDIS_URL: redis://redis:6379
       AI_SERVICE_URL: http://ai-service:3002
+      JWT_SECRET: mock-jwt-secret-for-e2e-testing
     ports:
       - '3003:3003'
     depends_on:
@@ -317,6 +320,7 @@ services:
       NODE_ENV: test
       DATABASE_URL: postgresql://reasonbridge_test:reasonbridge_test@postgres:5432/reasonbridge_test
       REDIS_URL: redis://redis:6379
+      JWT_SECRET: mock-jwt-secret-for-e2e-testing
     ports:
       - '3005:3005'
     depends_on:

--- a/frontend/e2e/response-moderation.spec.ts
+++ b/frontend/e2e/response-moderation.spec.ts
@@ -365,13 +365,9 @@ test.describe('Response Moderation', () => {
     await expect(dialog).not.toBeVisible();
   });
 
-  // SKIPPED: This test requires authenticated PUT requests, which fail in local E2E mode
-  // due to JWT_SECRET mismatch between services. The root .env has one secret while
-  // .env.local has another, and services started at different times may use different values.
-  // The edit functionality IS implemented - see ResponseItem.tsx handleEditSubmit().
-  // The API gateway route is added - see topics-proxy.controller.ts updateResponse().
-  // To fix: Ensure all services use consistent JWT_SECRET from root .env file.
-  test.skip('should allow editing own response', async ({ page }) => {
+  // Test for editing own response - requires JWT_SECRET to be consistent across all services
+  // Fixed: Added JWT_SECRET to discussion-service and moderation-service in docker-compose.e2e.yml
+  test('should allow editing own response', async ({ page }) => {
     // Navigate to known seeded topic where Alice has a response
     await navigateToSeededTopic(page, 'CONGESTION_PRICING');
 


### PR DESCRIPTION
## Summary
- Add `JWT_SECRET` environment variable to ai-service, discussion-service, moderation-service, and notification-service in docker-compose.e2e.yml
- Enable the previously skipped "should allow editing own response" E2E test

## Root Cause
The E2E test was skipped because services had inconsistent JWT secrets:
- `api-gateway` and `user-service` used `mock-jwt-secret-for-e2e-testing`
- Other services defaulted to `mock-jwt-secret-for-testing` (different!)

This caused JWT validation to fail when discussion-service tried to validate tokens issued by api-gateway.

## Note: Edit Functionality Was Already Implemented
The issue description was outdated. The edit functionality is fully implemented:
- `ResponseItem.tsx`: Edit handler opens `EditResponseModal`
- `responses.controller.ts`: PUT endpoint at `/topics/:topicId/responses/:responseId`
- `responseService.ts`: `updateResponse()` method

The skip was purely a configuration issue, not missing code.

## Test plan
- [x] Pre-commit hooks pass
- [ ] E2E test "should allow editing own response" passes in CI

Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)