### PR TITLE
fix(reactions): use regular import for CreateReactionDto

### DIFF
--- a/services/discussion-service/src/reactions/reactions.controller.ts
+++ b/services/discussion-service/src/reactions/reactions.controller.ts
@@ -17,7 +17,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ReactionsService } from './reactions.service.js';
-import type { CreateReactionDto } from './dto/create-reaction.dto.js';
+import { CreateReactionDto } from './dto/create-reaction.dto.js';
 import type { ReactionDto, ReactionListDto } from './dto/reaction.dto.js';
 import { JwtAuthGuard, CurrentUser, type JwtPayload } from '../auth/index.js';
 


### PR DESCRIPTION
## Summary

- Fix `import type` preventing NestJS ValidationPipe from accessing class-validator decorators
- Root cause of Prisma validation error: "Argument 'emoji' is missing"

## Problem

The reactions controller was using `import type { CreateReactionDto }` which:
1. Strips the class entirely at compile time (TypeScript type-only import)
2. Prevents ValidationPipe from accessing `@IsNotEmpty`, `@IsString`, `@MaxLength` decorators
3. Results in empty body being passed to service, causing Prisma composite key validation to fail

## Fix

Changed line 20 from:
```typescript
import type { CreateReactionDto } from './dto/create-reaction.dto.js';
```
to:
```typescript
import { CreateReactionDto } from './dto/create-reaction.dto.js';
```

## Test plan

- [x] All 14 reactions service tests pass
- [ ] E2E emoji reactions tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)