### PR TITLE
fix(e2e): add skip messages to follow-user-activity-feed tests

### DIFF
--- a/frontend/e2e/follow-user-activity-feed.spec.ts
+++ b/frontend/e2e/follow-user-activity-feed.spec.ts
@@ -112,8 +112,7 @@ test.describe('Follow User and Activity Feed', () => {
       // Find and navigate to a user profile
       const userLink = page.locator('a[href^="/profile/"]').first();
       if (!(await userLink.isVisible({ timeout: 5000 }).catch(() => false))) {
-        // No user links visible - skip gracefully
-        test.skip();
+        test.skip(true, 'No user profile links visible in topic');
         return;
       }
       await userLink.click();
@@ -122,8 +121,7 @@ test.describe('Follow User and Activity Feed', () => {
       // Check for follow button (only shows for other users, not self)
       const followButton = page.getByTestId('follow-button');
       if (!(await followButton.isVisible({ timeout: 5000 }).catch(() => false))) {
-        // User is viewing own profile - follow button won't appear
-        test.skip();
+        test.skip(true, 'Follow button not visible - may be own profile');
         return;
       }
 


### PR DESCRIPTION
## Summary
- Add descriptive skip reason strings to `test.skip()` calls in `follow-user-activity-feed.spec.ts`
- Skip reasons now appear in test reports for better CI/CD visibility

## Context
Part of Issue #1144 (Enable or remove 100+ skipped E2E tests).

**Investigation findings:**
- 74 skip occurrences remain across E2E tests
- Most skips are appropriate and well-documented:
  - **Mock-only tests**: Properly documented with PERMANENTLY SKIPPED headers
  - **UI visibility checks**: Runtime defensive skips that gracefully handle missing elements
  - **Backend availability**: Graceful handling of CI cold-start timing
  - **Complex timing tests**: Appropriately skipped for WebSocket/multi-client scenarios

The 2 test.skip() calls in follow-user-activity-feed.spec.ts were missing skip reason strings, causing unclear test reports.

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI pipeline passes
- [ ] Skip messages visible in test reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)