### PR TITLE
fix(auth): add brute force protection to verification tokens

### DIFF
--- a/packages/db-models/prisma/migrations/20260326_add_verification_brute_force_protection/migration.sql
+++ b/packages/db-models/prisma/migrations/20260326_add_verification_brute_force_protection/migration.sql
@@ -1,0 +1,8 @@
+-- Add brute force protection fields to verification_tokens table
+-- These fields track failed verification attempts and lockout state
+
+-- Add attempts counter (defaults to 0 for existing tokens)
+ALTER TABLE "verification_tokens" ADD COLUMN "attempts" INTEGER NOT NULL DEFAULT 0;
+
+-- Add locked_at timestamp (null means not locked)
+ALTER TABLE "verification_tokens" ADD COLUMN "locked_at" TIMESTAMP(3);

--- a/packages/db-models/prisma/schema.prisma
+++ b/packages/db-models/prisma/schema.prisma
@@ -1461,6 +1461,7 @@ enum VerificationTokenType {
 }
 
 /// Email verification token for signup flow and password reset
+/// Includes brute force protection via attempts tracking
 model VerificationToken {
   id        String                @id @default(uuid()) @db.Uuid
   userId    String                @map("user_id") @db.Uuid
@@ -1470,6 +1471,10 @@ model VerificationToken {
   expiresAt DateTime              @map("expires_at")
   used      Boolean               @default(false)
   usedAt    DateTime?             @map("used_at")
+  /// Number of failed verification attempts (brute force protection)
+  attempts  Int                   @default(0)
+  /// Timestamp when token was locked due to max failed attempts
+  lockedAt  DateTime?             @map("locked_at")
 
   @@index([userId])
   @@index([expiresAt])

--- a/services/user-service/src/auth/verification.service.test.ts
+++ b/services/user-service/src/auth/verification.service.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { VerificationService } from './verification.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { VerificationTokenType } from '@prisma/client';
+
+describe('VerificationService', () => {
+  let service: VerificationService;
+  let mockPrisma: {
+    user: { findUnique: ReturnType<typeof vi.fn> };
+    verificationToken: {
+      findFirst: ReturnType<typeof vi.fn>;
+      create: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+      updateMany: ReturnType<typeof vi.fn>;
+      deleteMany: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  const mockUser = {
+    id: 'user-123',
+    email: 'test@example.com',
+  };
+
+  const mockToken = {
+    id: 'token-123',
+    userId: 'user-123',
+    token: '123456',
+    type: VerificationTokenType.EMAIL_VERIFICATION,
+    createdAt: new Date(),
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24h in future
+    used: false,
+    usedAt: null,
+    attempts: 0,
+    lockedAt: null,
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    mockPrisma = {
+      user: {
+        findUnique: vi.fn(),
+      },
+      verificationToken: {
+        findFirst: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        updateMany: vi.fn(),
+        deleteMany: vi.fn(),
+      },
+    };
+
+    service = new VerificationService(mockPrisma as unknown as PrismaService);
+  });
+
+  describe('verifyToken', () => {
+    it('should verify a valid code successfully', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.verificationToken.findFirst.mockResolvedValue(mockToken);
+      mockPrisma.verificationToken.update.mockResolvedValue({ ...mockToken, used: true });
+
+      const result = await service.verifyToken('test@example.com', '123456');
+
+      expect(result).toBe('user-123');
+      expect(mockPrisma.verificationToken.update).toHaveBeenCalledWith({
+        where: { id: 'token-123' },
+        data: {
+          used: true,
+          usedAt: expect.any(Date),
+        },
+      });
+    });
+
+    it('should throw NotFoundException if user not found', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.verifyToken('unknown@example.com', '123456')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw NotFoundException if no token found', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.verificationToken.findFirst.mockResolvedValue(null);
+
+      await expect(service.verifyToken('test@example.com', '123456')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw BadRequestException for expired token', async () => {
+      const expiredToken = {
+        ...mockToken,
+        expiresAt: new Date(Date.now() - 1000), // Expired
+      };
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.verificationToken.findFirst.mockResolvedValue(expiredToken);
+
+      await expect(service.verifyToken('test@example.com', '123456')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    describe('brute force protection', () => {
+      it('should increment attempts on invalid code', async () => {
+        mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+        mockPrisma.verificationToken.findFirst.mockResolvedValue(mockToken);
+        mockPrisma.verificationToken.update.mockResolvedValue({ ...mockToken, attempts: 1 });
+
+        await expect(service.verifyToken('test@example.com', 'wrong!')).rejects.toThrow(
+          BadRequestException,
+        );
+
+        expect(mockPrisma.verificationToken.update).toHaveBeenCalledWith({
+          where: { id: 'token-123' },
+          data: {
+            attempts: 1,
+            lockedAt: null,
+          },
+        });
+      });
+
+      it('should include remaining attempts in error response', async () => {
+        const tokenWith3Attempts = { ...mockToken, attempts: 3 };
+        mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+        mockPrisma.verificationToken.findFirst.mockResolvedValue(tokenWith3Attempts);
+        mockPrisma.verificationToken.update.mockResolvedValue({
+          ...tokenWith3Attempts,
+          attempts: 4,
+        });
+
+        try {
+          await service.verifyToken('test@example.com', 'wrong!');
+          expect.fail('Should have thrown');
+        } catch (error) {
+          expect(error).toBeInstanceOf(BadRequestException);
+          const response = (error as BadRequestException).getResponse() as {
+            details?: { remainingAttempts?: number };
+          };
+          expect(response.details?.remainingAttempts).toBe(1);
+        }
+      });
+
+      it('should lock token after 5 failed attempts', async () => {
+        const tokenWith4Attempts = { ...mockToken, attempts: 4 };
+        mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+        mockPrisma.verificationToken.findFirst.mockResolvedValue(tokenWith4Attempts);
+        mockPrisma.verificationToken.update.mockResolvedValue({
+          ...tokenWith4Attempts,
+          attempts: 5,
+          lockedAt: new Date(),
+        });
+
+        try {
+          await service.verifyToken('test@example.com', 'wrong!');
+          expect.fail('Should have thrown');
+        } catch (error) {
+          expect(error).toBeInstanceOf(BadRequestException);
+          const response = (error as BadRequestException).getResponse() as { error?: string };
+          expect(response.error).toBe('TOKEN_LOCKED');
+        }
+
+        expect(mockPrisma.verificationToken.update).toHaveBeenCalledWith({
+          where: { id: 'token-123' },
+          data: {
+            attempts: 5,
+            lockedAt: expect.any(Date),
+          },
+        });
+      });
+
+      it('should reject verification for locked token', async () => {
+        const lockedToken = {
+          ...mockToken,
+          attempts: 5,
+          lockedAt: new Date(),
+        };
+        mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+        mockPrisma.verificationToken.findFirst.mockResolvedValue(lockedToken);
+
+        try {
+          await service.verifyToken('test@example.com', '123456');
+          expect.fail('Should have thrown');
+        } catch (error) {
+          expect(error).toBeInstanceOf(BadRequestException);
+          const response = (error as BadRequestException).getResponse() as { error?: string };
+          expect(response.error).toBe('TOKEN_LOCKED');
+        }
+
+        // Should not update the token since it's already locked
+        expect(mockPrisma.verificationToken.update).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('getRemainingAttempts', () => {
+    it('should return MAX_ATTEMPTS for fresh token', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.verificationToken.findFirst.mockResolvedValue(mockToken);
+
+      const result = await service.getRemainingAttempts('test@example.com');
+
+      expect(result).toBe(5);
+    });
+
+    it('should return remaining attempts based on token.attempts', async () => {
+      const tokenWith2Attempts = { ...mockToken, attempts: 2 };
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.verificationToken.findFirst.mockResolvedValue(tokenWith2Attempts);
+
+      const result = await service.getRemainingAttempts('test@example.com');
+
+      expect(result).toBe(3);
+    });
+
+    it('should return 0 for locked token', async () => {
+      const lockedToken = { ...mockToken, attempts: 5, lockedAt: new Date() };
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.verificationToken.findFirst.mockResolvedValue(lockedToken);
+
+      const result = await service.getRemainingAttempts('test@example.com');
+
+      expect(result).toBe(0);
+    });
+
+    it('should return null if user not found', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      const result = await service.getRemainingAttempts('unknown@example.com');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null if no token found', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.verificationToken.findFirst.mockResolvedValue(null);
+
+      const result = await service.getRemainingAttempts('test@example.com');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('generateToken', () => {
+    it('should create token with attempts initialized to 0', async () => {
+      mockPrisma.verificationToken.updateMany.mockResolvedValue({ count: 0 });
+      mockPrisma.verificationToken.create.mockResolvedValue(mockToken);
+
+      const result = await service.generateToken(
+        'user-123',
+        'test@example.com',
+        VerificationTokenType.EMAIL_VERIFICATION,
+      );
+
+      expect(result).toMatch(/^\d{6}$/);
+      expect(mockPrisma.verificationToken.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          attempts: 0,
+          lockedAt: null,
+        }),
+      });
+    });
+  });
+});

--- a/services/user-service/src/auth/verification.service.ts
+++ b/services/user-service/src/auth/verification.service.ts
@@ -81,8 +81,7 @@ export class VerificationService {
         });
       }
 
-      // Create new verification token
-      // TODO: Add email and attempts fields to VerificationToken schema
+      // Create new verification token with attempts initialized to 0
       await this.prisma.verificationToken.create({
         data: {
           userId,
@@ -90,6 +89,8 @@ export class VerificationService {
           type,
           expiresAt,
           used: false,
+          attempts: 0,
+          lockedAt: null,
         },
       });
 
@@ -118,7 +119,6 @@ export class VerificationService {
     try {
       this.logger.debug(`Verifying ${type} token for email: ${email}`);
 
-      // TODO: Add attempts tracking to prevent brute force attacks
       // Look up user by email first
       const user = await this.prisma.user.findUnique({
         where: { email },
@@ -156,6 +156,19 @@ export class VerificationService {
         });
       }
 
+      // Check if token is locked due to too many failed attempts
+      if (token.lockedAt) {
+        this.logger.warn(`${type} token locked for email: ${email} (too many failed attempts)`);
+        throw new BadRequestException({
+          error: 'TOKEN_LOCKED',
+          message: 'Verification code has been locked due to too many failed attempts',
+          details: {
+            canResend: true,
+            hint: 'Request a new verification code',
+          },
+        });
+      }
+
       // Check if token has expired
       if (new Date() > token.expiresAt) {
         const expiryMessage =
@@ -174,11 +187,43 @@ export class VerificationService {
 
       // Check if code matches
       if (token.token !== code) {
-        this.logger.warn(`Invalid ${type} code for email: ${email}`);
+        // Increment attempts counter
+        const newAttempts = token.attempts + 1;
+        const isLocked = newAttempts >= this.MAX_ATTEMPTS;
+        const remainingAttempts = Math.max(0, this.MAX_ATTEMPTS - newAttempts);
 
+        // Update token with incremented attempts and lock if necessary
+        await this.prisma.verificationToken.update({
+          where: { id: token.id },
+          data: {
+            attempts: newAttempts,
+            lockedAt: isLocked ? new Date() : null,
+          },
+        });
+
+        if (isLocked) {
+          this.logger.warn(
+            `${type} token locked for email: ${email} after ${newAttempts} failed attempts`,
+          );
+          throw new BadRequestException({
+            error: 'TOKEN_LOCKED',
+            message: 'Verification code has been locked due to too many failed attempts',
+            details: {
+              canResend: true,
+              hint: 'Request a new verification code',
+            },
+          });
+        }
+
+        this.logger.warn(
+          `Invalid ${type} code for email: ${email} (attempt ${newAttempts}/${this.MAX_ATTEMPTS})`,
+        );
         throw new BadRequestException({
           error: 'INVALID_CODE',
-          message: 'Verification code is invalid or expired',
+          message: 'Verification code is invalid',
+          details: {
+            remainingAttempts,
+          },
         });
       }
 
@@ -228,11 +273,8 @@ export class VerificationService {
    *
    * @param email - User's email address
    * @returns Number of remaining attempts, or null if no token found
-   * @deprecated Attempts tracking not yet implemented in schema
    */
   async getRemainingAttempts(email: string): Promise<number | null> {
-    // TODO: Implement attempts tracking in VerificationToken schema
-    // For now, return MAX_ATTEMPTS to indicate feature is not active
     const user = await this.prisma.user.findUnique({
       where: { email },
       select: { id: true },
@@ -256,8 +298,12 @@ export class VerificationService {
       return null;
     }
 
-    // Return MAX_ATTEMPTS since we're not tracking attempts yet
-    return this.MAX_ATTEMPTS;
+    // Return 0 if token is locked, otherwise remaining attempts
+    if (token.lockedAt) {
+      return 0;
+    }
+
+    return Math.max(0, this.MAX_ATTEMPTS - token.attempts);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add `attempts` and `lockedAt` fields to VerificationToken Prisma schema
- Implement failed verification attempt tracking in `verifyToken()`
- Lock tokens after 5 failed attempts (MAX_ATTEMPTS constant)
- Return remaining attempts in error response for invalid codes
- Reject verification on locked tokens with `TOKEN_LOCKED` error
- Update `getRemainingAttempts()` to return actual remaining attempts
- Add 14 unit tests for brute force protection logic

## Security Impact
Before this fix, attackers could brute-force 6-digit verification codes (1 million combinations) without any lockout or rate limiting. This fix:
- Limits verification attempts to 5 per token
- Locks tokens after max attempts exceeded
- Informs users of remaining attempts
- Requires requesting a new code after lockout

## Test Plan
- [x] 14 new unit tests for brute force protection
- [x] All 891 user-service tests pass
- [ ] Integration test verification
- [ ] Manual test: verify lockout after 5 failed attempts

## Migration
Includes database migration to add new columns:
- `attempts` (INT, default 0)
- `locked_at` (TIMESTAMP, nullable)

Closes #1145

🤖 Generated with [Claude Code](https://claude.com/claude-code)