### PR TITLE
feat(ranking): implement quality score calculation from response metrics

### DIFF
--- a/services/user-service/src/ranking/__tests__/ranking.service.test.ts
+++ b/services/user-service/src/ranking/__tests__/ranking.service.test.ts
@@ -130,7 +130,12 @@ describe('RankingService', () => {
       findMany: ReturnType<typeof vi.fn>;
       upsert: ReturnType<typeof vi.fn>;
     };
-    response: { count: ReturnType<typeof vi.fn> };
+    response: {
+      count: ReturnType<typeof vi.fn>;
+      findMany: ReturnType<typeof vi.fn>;
+    };
+    vote: { groupBy: ReturnType<typeof vi.fn> };
+    feedback: { groupBy: ReturnType<typeof vi.fn> };
   };
   let mockRankingCalculator: RankingCalculatorService;
   let mockTrustScoreCalculator: TrustScoreCalculator;
@@ -150,6 +155,13 @@ describe('RankingService', () => {
       },
       response: {
         count: vi.fn(),
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+      vote: {
+        groupBy: vi.fn().mockResolvedValue([]),
+      },
+      feedback: {
+        groupBy: vi.fn().mockResolvedValue([]),
       },
     };
 
@@ -552,6 +564,164 @@ describe('RankingService', () => {
       const result = await service.getUserRank('user-123');
 
       expect(result.badges).toEqual(['first-response', 'verified-human', 'top-contributor']);
+    });
+  });
+
+  describe('quality score calculation', () => {
+    it('should return 0.5 (neutral) when user has no responses', async () => {
+      const mockUser = createMockUser();
+
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.response.count.mockResolvedValue(0);
+      mockPrisma.response.findMany.mockResolvedValue([]);
+      mockPrisma.userRank.upsert.mockImplementation(async (args) => {
+        return {
+          ...createMockUserRank(),
+          qualityScore: args.create.qualityScore,
+          user: mockUser,
+        };
+      });
+
+      const result = await service.recalculateUserRank('user-123');
+
+      // With no responses, quality score should be 0.5 (neutral)
+      expect(result.qualityScore).toBe(0.5);
+    });
+
+    it('should calculate quality score from upvotes and downvotes', async () => {
+      const mockUser = createMockUser();
+
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.response.count.mockResolvedValue(10);
+      mockPrisma.response.findMany.mockResolvedValue([{ id: 'response-1' }, { id: 'response-2' }]);
+      // 80 upvotes, 20 downvotes = 80% vote ratio
+      mockPrisma.vote.groupBy.mockResolvedValue([
+        { voteType: 'UPVOTE', _count: { id: 80 } },
+        { voteType: 'DOWNVOTE', _count: { id: 20 } },
+      ]);
+      // No feedback = 0.5 default
+      mockPrisma.feedback.groupBy.mockResolvedValue([]);
+      mockPrisma.userRank.upsert.mockImplementation(async (args) => {
+        return {
+          ...createMockUserRank(),
+          qualityScore: args.create.qualityScore,
+          user: mockUser,
+        };
+      });
+
+      const result = await service.recalculateUserRank('user-123');
+
+      // Expected: 0.8 * 0.6 + 0.5 * 0.4 = 0.48 + 0.2 = 0.68
+      expect(result.qualityScore).toBeCloseTo(0.68, 2);
+    });
+
+    it('should calculate quality score from feedback helpfulness ratings', async () => {
+      const mockUser = createMockUser();
+
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.response.count.mockResolvedValue(10);
+      mockPrisma.response.findMany.mockResolvedValue([{ id: 'response-1' }, { id: 'response-2' }]);
+      // No votes = 0.5 default
+      mockPrisma.vote.groupBy.mockResolvedValue([]);
+      // 90 helpful, 10 not helpful = 90% feedback ratio
+      mockPrisma.feedback.groupBy.mockResolvedValue([
+        { userHelpfulRating: 'HELPFUL', _count: { id: 90 } },
+        { userHelpfulRating: 'NOT_HELPFUL', _count: { id: 10 } },
+      ]);
+      mockPrisma.userRank.upsert.mockImplementation(async (args) => {
+        return {
+          ...createMockUserRank(),
+          qualityScore: args.create.qualityScore,
+          user: mockUser,
+        };
+      });
+
+      const result = await service.recalculateUserRank('user-123');
+
+      // Expected: 0.5 * 0.6 + 0.9 * 0.4 = 0.3 + 0.36 = 0.66
+      expect(result.qualityScore).toBeCloseTo(0.66, 2);
+    });
+
+    it('should combine votes and feedback for quality score', async () => {
+      const mockUser = createMockUser();
+
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.response.count.mockResolvedValue(10);
+      mockPrisma.response.findMany.mockResolvedValue([{ id: 'response-1' }, { id: 'response-2' }]);
+      // 60 upvotes, 40 downvotes = 60% vote ratio
+      mockPrisma.vote.groupBy.mockResolvedValue([
+        { voteType: 'UPVOTE', _count: { id: 60 } },
+        { voteType: 'DOWNVOTE', _count: { id: 40 } },
+      ]);
+      // 70 helpful, 30 not helpful = 70% feedback ratio
+      mockPrisma.feedback.groupBy.mockResolvedValue([
+        { userHelpfulRating: 'HELPFUL', _count: { id: 70 } },
+        { userHelpfulRating: 'NOT_HELPFUL', _count: { id: 30 } },
+      ]);
+      mockPrisma.userRank.upsert.mockImplementation(async (args) => {
+        return {
+          ...createMockUserRank(),
+          qualityScore: args.create.qualityScore,
+          user: mockUser,
+        };
+      });
+
+      const result = await service.recalculateUserRank('user-123');
+
+      // Expected: 0.6 * 0.6 + 0.7 * 0.4 = 0.36 + 0.28 = 0.64
+      expect(result.qualityScore).toBeCloseTo(0.64, 2);
+    });
+
+    it('should handle all negative votes correctly', async () => {
+      const mockUser = createMockUser();
+
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.response.count.mockResolvedValue(10);
+      mockPrisma.response.findMany.mockResolvedValue([{ id: 'response-1' }]);
+      // 0 upvotes, 100 downvotes = 0% vote ratio
+      mockPrisma.vote.groupBy.mockResolvedValue([{ voteType: 'DOWNVOTE', _count: { id: 100 } }]);
+      // 0 helpful, 100 not helpful = 0% feedback ratio
+      mockPrisma.feedback.groupBy.mockResolvedValue([
+        { userHelpfulRating: 'NOT_HELPFUL', _count: { id: 100 } },
+      ]);
+      mockPrisma.userRank.upsert.mockImplementation(async (args) => {
+        return {
+          ...createMockUserRank(),
+          qualityScore: args.create.qualityScore,
+          user: mockUser,
+        };
+      });
+
+      const result = await service.recalculateUserRank('user-123');
+
+      // Expected: 0 * 0.6 + 0 * 0.4 = 0
+      expect(result.qualityScore).toBe(0);
+    });
+
+    it('should handle perfect quality score correctly', async () => {
+      const mockUser = createMockUser();
+
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      mockPrisma.response.count.mockResolvedValue(10);
+      mockPrisma.response.findMany.mockResolvedValue([{ id: 'response-1' }]);
+      // 100 upvotes, 0 downvotes = 100% vote ratio
+      mockPrisma.vote.groupBy.mockResolvedValue([{ voteType: 'UPVOTE', _count: { id: 100 } }]);
+      // 100 helpful, 0 not helpful = 100% feedback ratio
+      mockPrisma.feedback.groupBy.mockResolvedValue([
+        { userHelpfulRating: 'HELPFUL', _count: { id: 100 } },
+      ]);
+      mockPrisma.userRank.upsert.mockImplementation(async (args) => {
+        return {
+          ...createMockUserRank(),
+          qualityScore: args.create.qualityScore,
+          user: mockUser,
+        };
+      });
+
+      const result = await service.recalculateUserRank('user-123');
+
+      // Expected: 1.0 * 0.6 + 1.0 * 0.4 = 1.0
+      expect(result.qualityScore).toBe(1);
     });
   });
 });

--- a/services/user-service/src/ranking/ranking.service.ts
+++ b/services/user-service/src/ranking/ranking.service.ts
@@ -95,9 +95,8 @@ export class RankingService {
     // Calculate engagement score (0-1 scale, maxes out at MAX_ENGAGEMENT_RESPONSES)
     const engagementScore = Math.min(1, responseCount / MAX_ENGAGEMENT_RESPONSES);
 
-    // Calculate quality score (placeholder - would be based on response quality metrics)
-    // For now, use trust average as a proxy
-    const qualityScore = trustAverage;
+    // Calculate quality score from response votes and feedback
+    const qualityScore = await this.calculateQualityScore(userId);
 
     // Calculate account age in days
     const accountAgeDays = this.calculateAccountAgeDays(user.createdAt);
@@ -229,6 +228,89 @@ export class RankingService {
   private calculateAccountAgeDays(createdAt: Date): number {
     const ageMs = Date.now() - createdAt.getTime();
     return ageMs / (1000 * 60 * 60 * 24);
+  }
+
+  /**
+   * Calculate quality score from votes and feedback for all user responses.
+   *
+   * The quality score is calculated as a weighted combination of:
+   * - Vote ratio: upvotes / (upvotes + downvotes) - weight 0.6
+   * - Feedback helpfulness: helpful / (helpful + not_helpful) - weight 0.4
+   *
+   * If no data is available for a signal, it defaults to 0.5 (neutral).
+   *
+   * @param userId - The user's unique identifier
+   * @returns Quality score between 0 and 1
+   */
+  private async calculateQualityScore(userId: string): Promise<number> {
+    // Get all response IDs for this user
+    const responses = await this.prisma.response.findMany({
+      where: { authorId: userId },
+      select: { id: true },
+    });
+
+    if (responses.length === 0) {
+      return 0.5; // Neutral default for users with no responses
+    }
+
+    const responseIds = responses.map((r) => r.id);
+
+    // Get vote counts
+    const voteCounts = await this.prisma.vote.groupBy({
+      by: ['voteType'],
+      where: {
+        responseId: { in: responseIds },
+      },
+      _count: {
+        id: true,
+      },
+    });
+
+    let upvotes = 0;
+    let downvotes = 0;
+    for (const vc of voteCounts) {
+      if (vc.voteType === 'UPVOTE') {
+        upvotes = vc._count.id;
+      } else if (vc.voteType === 'DOWNVOTE') {
+        downvotes = vc._count.id;
+      }
+    }
+
+    // Get feedback helpfulness ratings
+    const feedbackCounts = await this.prisma.feedback.groupBy({
+      by: ['userHelpfulRating'],
+      where: {
+        responseId: { in: responseIds },
+        userHelpfulRating: { not: null },
+      },
+      _count: {
+        id: true,
+      },
+    });
+
+    let helpful = 0;
+    let notHelpful = 0;
+    for (const fc of feedbackCounts) {
+      if (fc.userHelpfulRating === 'HELPFUL') {
+        helpful = fc._count.id;
+      } else if (fc.userHelpfulRating === 'NOT_HELPFUL') {
+        notHelpful = fc._count.id;
+      }
+    }
+
+    // Calculate vote ratio (0.5 default if no votes)
+    const totalVotes = upvotes + downvotes;
+    const voteRatio = totalVotes > 0 ? upvotes / totalVotes : 0.5;
+
+    // Calculate feedback ratio (0.5 default if no feedback)
+    const totalFeedback = helpful + notHelpful;
+    const feedbackRatio = totalFeedback > 0 ? helpful / totalFeedback : 0.5;
+
+    // Weighted combination: votes (60%), feedback (40%)
+    // This weights community votes more heavily than AI feedback helpfulness
+    const qualityScore = voteRatio * 0.6 + feedbackRatio * 0.4;
+
+    return qualityScore;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Replace placeholder quality score in RankingService with actual calculation from user response data
- Use weighted combination of vote ratio (60%) and feedback helpfulness (40%)
- Add comprehensive unit tests for all quality score calculation scenarios

## Details

The RankingService previously used trust average as a proxy for quality score:

```typescript
// Calculate quality score (placeholder - would be based on response quality metrics)
// For now, use trust average as a proxy
const qualityScore = trustAverage;
```

This PR implements proper quality score calculation mirroring the pattern already in ExpertiseService:

1. **Vote Ratio (60% weight)**: upvotes / (upvotes + downvotes)
2. **Feedback Helpfulness (40% weight)**: helpful / (helpful + not_helpful)

If no data is available for either signal, it defaults to 0.5 (neutral).

## Test Plan

- [x] Unit tests for quality score calculation (6 new tests)
- [x] All 902 user-service tests pass
- [ ] Manual verification: Calculate rank for user with mixed vote/feedback data

## Related

- Closes the RankingService placeholder that was complementary to #1130 (ExpertiseService)
- #1130 was closed as it was already implemented in PR #1142

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)