### PR TITLE
fix(auth): critical security fixes #1156 #1157 #1158

### DIFF
--- a/services/api-gateway/src/middleware/jwt-user.middleware.ts
+++ b/services/api-gateway/src/middleware/jwt-user.middleware.ts
@@ -37,7 +37,11 @@ export class JwtUserMiddleware implements NestMiddleware {
 
     try {
       const token = authHeader.substring(7); // Remove 'Bearer ' prefix
-      const jwtSecret = process.env['JWT_SECRET'] || 'your-secret-key';
+      const jwtSecret = process.env['JWT_SECRET'];
+      if (!jwtSecret) {
+        this.logger.error('JWT_SECRET environment variable is not set');
+        return next();
+      }
 
       // Decode and verify JWT
       const decoded = jwt.verify(token, jwtSecret) as {

--- a/services/contact-service/src/auth/auth.module.ts
+++ b/services/contact-service/src/auth/auth.module.ts
@@ -19,13 +19,23 @@ import { JwtAuthGuard } from './jwt-auth.guard.js';
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
-      useFactory: (configService: ConfigService) => ({
-        secret: configService.get<string>('JWT_SECRET') ?? 'mock-jwt-secret-for-testing',
-        signOptions: {
-          expiresIn: (configService.get<string>('JWT_EXPIRES_IN') ??
-            '24h') as `${number}${'s' | 'm' | 'h' | 'd'}`,
-        },
-      }),
+      useFactory: (configService: ConfigService) => {
+        const jwtSecret = configService.get<string>('JWT_SECRET');
+        const nodeEnv = configService.get<string>('NODE_ENV');
+        const isTestOrDev = nodeEnv === 'test' || nodeEnv === 'development' || !nodeEnv;
+
+        if (!jwtSecret && !isTestOrDev) {
+          throw new Error('JWT_SECRET environment variable is required in production');
+        }
+
+        return {
+          secret: jwtSecret ?? 'mock-jwt-secret-for-testing',
+          signOptions: {
+            expiresIn: (configService.get<string>('JWT_EXPIRES_IN') ??
+              '24h') as `${number}${'s' | 'm' | 'h' | 'd'}`,
+          },
+        };
+      },
     }),
   ],
   providers: [JwtAuthGuard],

--- a/services/moderation-service/src/clients/notification-service.client.ts
+++ b/services/moderation-service/src/clients/notification-service.client.ts
@@ -59,9 +59,24 @@ export interface SlaBreachNotificationResponse {
 export class NotificationServiceClient {
   private readonly logger = new Logger(NotificationServiceClient.name);
   private readonly baseUrl: string;
+  private readonly internalApiKey: string | undefined;
 
   constructor() {
     this.baseUrl = process.env['NOTIFICATION_SERVICE_URL'] || getServiceUrl('NOTIFICATION_SERVICE');
+    this.internalApiKey = process.env['INTERNAL_API_KEY'];
+  }
+
+  /**
+   * Build headers for internal API requests
+   */
+  private getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.internalApiKey) {
+      headers['X-Internal-Api-Key'] = this.internalApiKey;
+    }
+    return headers;
   }
 
   /**
@@ -85,7 +100,7 @@ export class NotificationServiceClient {
     try {
       const response = await fetch(`${this.baseUrl}/internal/sla-breach`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: this.getHeaders(),
         body: JSON.stringify({
           breaches,
           checkedAt: new Date().toISOString(),

--- a/services/moderation-service/src/internal/internal-api-key.guard.ts
+++ b/services/moderation-service/src/internal/internal-api-key.guard.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2026 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+  Logger,
+} from '@nestjs/common';
+import { timingSafeEqual } from 'crypto';
+
+/**
+ * Guard for internal service-to-service API endpoints.
+ *
+ * Validates the X-Internal-Api-Key header against the INTERNAL_API_KEY
+ * environment variable. This provides a simple shared-secret authentication
+ * mechanism for internal service communication.
+ *
+ * @remarks
+ * - In test/development mode, the guard is permissive if INTERNAL_API_KEY is not set
+ * - In production, INTERNAL_API_KEY must be set or all requests are rejected
+ * - Uses timing-safe comparison to prevent timing attacks
+ *
+ * @example
+ * ```typescript
+ * @Controller('internal/endpoint')
+ * @UseGuards(InternalApiKeyGuard)
+ * export class InternalController { }
+ * ```
+ */
+@Injectable()
+export class InternalApiKeyGuard implements CanActivate {
+  private readonly logger = new Logger(InternalApiKeyGuard.name);
+  private readonly apiKey: string | undefined;
+  private readonly isTestOrDev: boolean;
+
+  constructor() {
+    this.apiKey = process.env['INTERNAL_API_KEY'];
+    const nodeEnv = process.env['NODE_ENV'];
+    this.isTestOrDev = nodeEnv === 'test' || nodeEnv === 'development' || !nodeEnv;
+
+    if (!this.apiKey && !this.isTestOrDev) {
+      this.logger.error('INTERNAL_API_KEY is required in production mode');
+    }
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const providedKey = request.headers['x-internal-api-key'];
+
+    // In test/dev mode without API key configured, allow all requests
+    if (!this.apiKey && this.isTestOrDev) {
+      this.logger.debug('Internal API key not configured, allowing request in test/dev mode');
+      return true;
+    }
+
+    // In production without API key configured, reject all requests
+    if (!this.apiKey) {
+      this.logger.error('Internal API request rejected: INTERNAL_API_KEY not configured');
+      throw new UnauthorizedException('Internal API key required');
+    }
+
+    // No key provided in request
+    if (!providedKey) {
+      this.logger.warn('Internal API request rejected: no X-Internal-Api-Key header');
+      throw new UnauthorizedException('Internal API key required');
+    }
+
+    // Validate key using timing-safe comparison
+    const expectedBuffer = Buffer.from(this.apiKey, 'utf8');
+    const providedBuffer = Buffer.from(providedKey, 'utf8');
+
+    if (
+      expectedBuffer.length !== providedBuffer.length ||
+      !timingSafeEqual(expectedBuffer, providedBuffer)
+    ) {
+      this.logger.warn('Internal API request rejected: invalid API key');
+      throw new UnauthorizedException('Invalid internal API key');
+    }
+
+    return true;
+  }
+}

--- a/services/moderation-service/src/internal/internal-bot-flagged.controller.ts
+++ b/services/moderation-service/src/internal/internal-bot-flagged.controller.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Controller, Post, Body, Logger } from '@nestjs/common';
+import { Controller, Post, Body, Logger, UseGuards } from '@nestjs/common';
+import { InternalApiKeyGuard } from './internal-api-key.guard.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 
 /**
@@ -42,6 +43,7 @@ export interface BotFlaggedResponse {
  * service-to-service communication only.
  */
 @Controller('internal/bot-flagged')
+@UseGuards(InternalApiKeyGuard)
 export class InternalBotFlaggedController {
   private readonly logger = new Logger(InternalBotFlaggedController.name);
 

--- a/services/notification-service/src/auth/auth.module.ts
+++ b/services/notification-service/src/auth/auth.module.ts
@@ -21,13 +21,23 @@ import { JwtAuthGuard } from './jwt-auth.guard.js';
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
-      useFactory: (configService: ConfigService) => ({
-        secret: configService.get<string>('JWT_SECRET') ?? 'mock-jwt-secret-for-testing',
-        signOptions: {
-          expiresIn: (configService.get<string>('JWT_EXPIRES_IN') ??
-            '24h') as `${number}${'s' | 'm' | 'h' | 'd'}`,
-        },
-      }),
+      useFactory: (configService: ConfigService) => {
+        const jwtSecret = configService.get<string>('JWT_SECRET');
+        const nodeEnv = configService.get<string>('NODE_ENV');
+        const isTestOrDev = nodeEnv === 'test' || nodeEnv === 'development' || !nodeEnv;
+
+        if (!jwtSecret && !isTestOrDev) {
+          throw new Error('JWT_SECRET environment variable is required in production');
+        }
+
+        return {
+          secret: jwtSecret ?? 'mock-jwt-secret-for-testing',
+          signOptions: {
+            expiresIn: (configService.get<string>('JWT_EXPIRES_IN') ??
+              '24h') as `${number}${'s' | 'm' | 'h' | 'd'}`,
+          },
+        };
+      },
     }),
   ],
   providers: [JwtVerificationService, JwtAuthGuard],

--- a/services/notification-service/src/internal/internal-api-key.guard.ts
+++ b/services/notification-service/src/internal/internal-api-key.guard.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2026 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+  Logger,
+} from '@nestjs/common';
+import { timingSafeEqual } from 'crypto';
+
+/**
+ * Guard for internal service-to-service API endpoints.
+ *
+ * Validates the X-Internal-Api-Key header against the INTERNAL_API_KEY
+ * environment variable. This provides a simple shared-secret authentication
+ * mechanism for internal service communication.
+ *
+ * @remarks
+ * - In test/development mode, the guard is permissive if INTERNAL_API_KEY is not set
+ * - In production, INTERNAL_API_KEY must be set or all requests are rejected
+ * - Uses timing-safe comparison to prevent timing attacks
+ *
+ * @example
+ * ```typescript
+ * @Controller('internal/endpoint')
+ * @UseGuards(InternalApiKeyGuard)
+ * export class InternalController { }
+ * ```
+ */
+@Injectable()
+export class InternalApiKeyGuard implements CanActivate {
+  private readonly logger = new Logger(InternalApiKeyGuard.name);
+  private readonly apiKey: string | undefined;
+  private readonly isTestOrDev: boolean;
+
+  constructor() {
+    this.apiKey = process.env['INTERNAL_API_KEY'];
+    const nodeEnv = process.env['NODE_ENV'];
+    this.isTestOrDev = nodeEnv === 'test' || nodeEnv === 'development' || !nodeEnv;
+
+    if (!this.apiKey && !this.isTestOrDev) {
+      this.logger.error('INTERNAL_API_KEY is required in production mode');
+    }
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const providedKey = request.headers['x-internal-api-key'];
+
+    // In test/dev mode without API key configured, allow all requests
+    if (!this.apiKey && this.isTestOrDev) {
+      this.logger.debug('Internal API key not configured, allowing request in test/dev mode');
+      return true;
+    }
+
+    // In production without API key configured, reject all requests
+    if (!this.apiKey) {
+      this.logger.error('Internal API request rejected: INTERNAL_API_KEY not configured');
+      throw new UnauthorizedException('Internal API key required');
+    }
+
+    // No key provided in request
+    if (!providedKey) {
+      this.logger.warn('Internal API request rejected: no X-Internal-Api-Key header');
+      throw new UnauthorizedException('Internal API key required');
+    }
+
+    // Validate key using timing-safe comparison
+    const expectedBuffer = Buffer.from(this.apiKey, 'utf8');
+    const providedBuffer = Buffer.from(providedKey, 'utf8');
+
+    if (
+      expectedBuffer.length !== providedBuffer.length ||
+      !timingSafeEqual(expectedBuffer, providedBuffer)
+    ) {
+      this.logger.warn('Internal API request rejected: invalid API key');
+      throw new UnauthorizedException('Invalid internal API key');
+    }
+
+    return true;
+  }
+}

--- a/services/notification-service/src/internal/internal-sla-breach.controller.ts
+++ b/services/notification-service/src/internal/internal-sla-breach.controller.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Controller, Post, Body, Logger } from '@nestjs/common';
+import { Controller, Post, Body, Logger, UseGuards } from '@nestjs/common';
+import { InternalApiKeyGuard } from './internal-api-key.guard.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { NotificationGateway } from '../gateways/notification.gateway.js';
 
@@ -50,6 +51,7 @@ export interface SlaBreachNotificationResponse {
  * service-to-service communication only.
  */
 @Controller('internal/sla-breach')
+@UseGuards(InternalApiKeyGuard)
 export class InternalSlaBreachController {
   private readonly logger = new Logger(InternalSlaBreachController.name);
 

--- a/services/notification-service/src/internal/internal-sms.controller.ts
+++ b/services/notification-service/src/internal/internal-sms.controller.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Controller, Post, Body, HttpCode, HttpStatus, Logger } from '@nestjs/common';
+import { Controller, Post, Body, HttpCode, HttpStatus, Logger, UseGuards } from '@nestjs/common';
+import { InternalApiKeyGuard } from './internal-api-key.guard.js';
 import { IsString, IsNotEmpty, Matches, MaxLength } from 'class-validator';
 import { SmsService, type SmsResult } from '../services/sms.service.js';
 
@@ -52,6 +53,7 @@ export interface SendSmsResponseDto {
  * - Uses fire-and-forget pattern on client side but returns result for error handling
  */
 @Controller('internal/sms')
+@UseGuards(InternalApiKeyGuard)
 export class InternalSmsController {
   private readonly logger = new Logger(InternalSmsController.name);
 

--- a/services/user-service/src/auth/auth.service.ts
+++ b/services/user-service/src/auth/auth.service.ts
@@ -577,7 +577,10 @@ export class AuthService {
   private async generateJwtTokens(
     user: any,
   ): Promise<{ accessToken: string; refreshToken: string; expiresIn: number }> {
-    const jwtSecret = this.configService?.get<string>('JWT_SECRET') || 'your-secret-key';
+    const jwtSecret = this.configService?.get<string>('JWT_SECRET');
+    if (!jwtSecret) {
+      throw new Error('JWT_SECRET environment variable is required');
+    }
     const jwtExpiration = this.configService?.get<string>('JWT_EXPIRATION') || '15m';
 
     // Parse expiration to seconds (format: '15m', '1h', '7d')

--- a/services/user-service/src/auth/verification.service.ts
+++ b/services/user-service/src/auth/verification.service.ts
@@ -6,7 +6,7 @@
 import { Injectable, Logger, BadRequestException, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { VerificationTokenType } from '@prisma/client';
-import { randomBytes } from 'crypto';
+import { randomBytes, timingSafeEqual } from 'crypto';
 
 /**
  * Verification Token Service
@@ -185,8 +185,14 @@ export class VerificationService {
         });
       }
 
-      // Check if code matches
-      if (token.token !== code) {
+      // Check if code matches using timing-safe comparison to prevent timing attacks
+      const storedBuffer = Buffer.from(token.token, 'utf8');
+      const providedBuffer = Buffer.from(code, 'utf8');
+      const codeMatches =
+        storedBuffer.length === providedBuffer.length &&
+        timingSafeEqual(storedBuffer, providedBuffer);
+
+      if (!codeMatches) {
         // Increment attempts counter
         const newAttempts = token.attempts + 1;
         const isLocked = newAttempts >= this.MAX_ATTEMPTS;

--- a/services/user-service/src/clients/moderation-service.client.ts
+++ b/services/user-service/src/clients/moderation-service.client.ts
@@ -55,9 +55,24 @@ export interface BotFlagResult {
 export class ModerationServiceClient {
   private readonly logger = new Logger(ModerationServiceClient.name);
   private readonly baseUrl: string;
+  private readonly internalApiKey: string | undefined;
 
   constructor() {
     this.baseUrl = process.env['MODERATION_SERVICE_URL'] || getServiceUrl('MODERATION_SERVICE');
+    this.internalApiKey = process.env['INTERNAL_API_KEY'];
+  }
+
+  /**
+   * Build headers for internal API requests
+   */
+  private getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.internalApiKey) {
+      headers['X-Internal-Api-Key'] = this.internalApiKey;
+    }
+    return headers;
   }
 
   /**
@@ -75,7 +90,7 @@ export class ModerationServiceClient {
     try {
       const response = await fetch(endpoint, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: this.getHeaders(),
         body: JSON.stringify({
           ...request,
           detectedAt: new Date().toISOString(),

--- a/services/user-service/src/clients/sms.client.ts
+++ b/services/user-service/src/clients/sms.client.ts
@@ -38,9 +38,24 @@ export interface SmsDeliveryResult {
 export class SmsClient {
   private readonly logger = new Logger(SmsClient.name);
   private readonly baseUrl: string;
+  private readonly internalApiKey: string | undefined;
 
   constructor() {
     this.baseUrl = process.env['NOTIFICATION_SERVICE_URL'] || getServiceUrl('NOTIFICATION_SERVICE');
+    this.internalApiKey = process.env['INTERNAL_API_KEY'];
+  }
+
+  /**
+   * Build headers for internal API requests
+   */
+  private getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.internalApiKey) {
+      headers['X-Internal-Api-Key'] = this.internalApiKey;
+    }
+    return headers;
   }
 
   /**
@@ -59,7 +74,7 @@ export class SmsClient {
     try {
       const response = await fetch(endpoint, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: this.getHeaders(),
         body: JSON.stringify({ phoneNumber, code }),
       });
 


### PR DESCRIPTION
## Summary
- **#1156**: Remove hardcoded JWT secret fallbacks - services now require `JWT_SECRET` in production
- **#1157**: Add `InternalApiKeyGuard` to protect internal service-to-service endpoints
- **#1158**: Use timing-safe comparison for verification codes to prevent timing attacks

## Changes

### JWT Secret Hardening (#1156)
- `api-gateway`: Removed fallback in `jwt-user.middleware.ts`, returns early if `JWT_SECRET` missing
- `user-service`: Throws error if `JWT_SECRET` missing in `auth.service.ts`
- `notification-service` & `contact-service`: Added production check in `auth.module.ts` - allows mock secret in test/dev only

### Internal Endpoint Authentication (#1157)
- Created `InternalApiKeyGuard` in both `notification-service` and `moderation-service`
- Guard validates `X-Internal-Api-Key` header with timing-safe comparison
- Protected endpoints: `/internal/sms/verification-code`, `/internal/sla-breach`, `/internal/bot-flagged`
- Updated client services to send `X-Internal-Api-Key` header

### Timing-Safe Verification (#1158)
- Updated `verification.service.ts` to use `crypto.timingSafeEqual()` for code comparison
- Prevents timing attacks on OTP verification

## Test Plan
- [x] user-service tests pass (902 tests)
- [x] notification-service tests pass (138 tests)
- [x] moderation-service tests pass (265 tests)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)