### PR TITLE
fix(security): remove hardcoded JWT secret fallbacks

### DIFF
--- a/packages/common/src/auth/jwt-auth.guard.ts
+++ b/packages/common/src/auth/jwt-auth.guard.ts
@@ -107,7 +107,11 @@ export class JwtAuthGuard implements CanActivate {
 
     if (this.useMockAuth) {
       // Mock mode - use simple JWT secret
-      this.jwtSecret = getConfig('JWT_SECRET') ?? 'mock-jwt-secret-for-testing';
+      const secret = getConfig('JWT_SECRET');
+      if (!secret && nodeEnv !== 'test') {
+        throw new Error('JWT_SECRET environment variable is required');
+      }
+      this.jwtSecret = secret ?? 'mock-jwt-secret-for-testing';
     } else {
       // Production mode - use Cognito JWKS
       this.userPoolId = getConfig('COGNITO_USER_POOL_ID');

--- a/services/api-gateway/src/middleware/jwt-user.middleware.ts
+++ b/services/api-gateway/src/middleware/jwt-user.middleware.ts
@@ -26,6 +26,16 @@ import jwt from 'jsonwebtoken';
 @Injectable()
 export class JwtUserMiddleware implements NestMiddleware {
   private readonly logger = new Logger(JwtUserMiddleware.name);
+  private readonly jwtSecret: string;
+
+  constructor() {
+    const secret = process.env['JWT_SECRET'];
+    const nodeEnv = process.env['NODE_ENV'];
+    if (!secret && nodeEnv !== 'test') {
+      throw new Error('JWT_SECRET environment variable is required');
+    }
+    this.jwtSecret = secret ?? 'mock-jwt-secret-for-testing';
+  }
 
   use(req: FastifyRequest, res: FastifyReply, next: () => void) {
     const authHeader = req.headers.authorization;
@@ -37,10 +47,9 @@ export class JwtUserMiddleware implements NestMiddleware {
 
     try {
       const token = authHeader.substring(7); // Remove 'Bearer ' prefix
-      const jwtSecret = process.env['JWT_SECRET'] || 'your-secret-key';
 
       // Decode and verify JWT
-      const decoded = jwt.verify(token, jwtSecret) as {
+      const decoded = jwt.verify(token, this.jwtSecret) as {
         sub?: string;
         userId?: string;
         id?: string;

--- a/services/contact-service/src/auth/auth.module.ts
+++ b/services/contact-service/src/auth/auth.module.ts
@@ -19,13 +19,20 @@ import { JwtAuthGuard } from './jwt-auth.guard.js';
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
-      useFactory: (configService: ConfigService) => ({
-        secret: configService.get<string>('JWT_SECRET') ?? 'mock-jwt-secret-for-testing',
-        signOptions: {
-          expiresIn: (configService.get<string>('JWT_EXPIRES_IN') ??
-            '24h') as `${number}${'s' | 'm' | 'h' | 'd'}`,
-        },
-      }),
+      useFactory: (configService: ConfigService) => {
+        const secret = configService.get<string>('JWT_SECRET');
+        const nodeEnv = configService.get<string>('NODE_ENV') ?? process.env['NODE_ENV'];
+        if (!secret && nodeEnv !== 'test') {
+          throw new Error('JWT_SECRET environment variable is required');
+        }
+        return {
+          secret: secret ?? 'mock-jwt-secret-for-testing',
+          signOptions: {
+            expiresIn: (configService.get<string>('JWT_EXPIRES_IN') ??
+              '24h') as `${number}${'s' | 'm' | 'h' | 'd'}`,
+          },
+        };
+      },
     }),
   ],
   providers: [JwtAuthGuard],

--- a/services/discussion-service/src/auth/guards/optional-auth.guard.ts
+++ b/services/discussion-service/src/auth/guards/optional-auth.guard.ts
@@ -32,7 +32,12 @@ export class OptionalAuthGuard implements CanActivate {
     @Optional() @Inject(ConfigService) private configService?: ConfigService,
   ) {
     const getConfig = (key: string) => this.configService?.get<string>(key) ?? process.env[key];
-    this.jwtSecret = getConfig('JWT_SECRET') ?? 'mock-jwt-secret-for-testing';
+    const secret = getConfig('JWT_SECRET');
+    const nodeEnv = getConfig('NODE_ENV');
+    if (!secret && nodeEnv !== 'test') {
+      throw new Error('JWT_SECRET environment variable is required');
+    }
+    this.jwtSecret = secret ?? 'mock-jwt-secret-for-testing';
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {

--- a/services/notification-service/src/auth/auth.module.ts
+++ b/services/notification-service/src/auth/auth.module.ts
@@ -21,13 +21,20 @@ import { JwtAuthGuard } from './jwt-auth.guard.js';
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
-      useFactory: (configService: ConfigService) => ({
-        secret: configService.get<string>('JWT_SECRET') ?? 'mock-jwt-secret-for-testing',
-        signOptions: {
-          expiresIn: (configService.get<string>('JWT_EXPIRES_IN') ??
-            '24h') as `${number}${'s' | 'm' | 'h' | 'd'}`,
-        },
-      }),
+      useFactory: (configService: ConfigService) => {
+        const secret = configService.get<string>('JWT_SECRET');
+        const nodeEnv = configService.get<string>('NODE_ENV') ?? process.env['NODE_ENV'];
+        if (!secret && nodeEnv !== 'test') {
+          throw new Error('JWT_SECRET environment variable is required');
+        }
+        return {
+          secret: secret ?? 'mock-jwt-secret-for-testing',
+          signOptions: {
+            expiresIn: (configService.get<string>('JWT_EXPIRES_IN') ??
+              '24h') as `${number}${'s' | 'm' | 'h' | 'd'}`,
+          },
+        };
+      },
     }),
   ],
   providers: [JwtVerificationService, JwtAuthGuard],

--- a/services/notification-service/src/auth/jwt-verification.service.ts
+++ b/services/notification-service/src/auth/jwt-verification.service.ts
@@ -54,8 +54,11 @@ export class JwtVerificationService {
       !nodeEnv;
 
     if (this.useMockAuth) {
-      this.jwtSecret =
-        this.configService.get<string>('JWT_SECRET') ?? 'mock-jwt-secret-for-testing';
+      const secret = this.configService.get<string>('JWT_SECRET');
+      if (!secret && nodeEnv !== 'test') {
+        throw new Error('JWT_SECRET environment variable is required');
+      }
+      this.jwtSecret = secret ?? 'mock-jwt-secret-for-testing';
       this.logger.debug('JwtVerificationService initialized in mock/development mode');
     } else {
       this.userPoolId = this.configService.get<string>('COGNITO_USER_POOL_ID');

--- a/services/user-service/src/auth/auth.service.ts
+++ b/services/user-service/src/auth/auth.service.ts
@@ -577,7 +577,12 @@ export class AuthService {
   private async generateJwtTokens(
     user: any,
   ): Promise<{ accessToken: string; refreshToken: string; expiresIn: number }> {
-    const jwtSecret = this.configService?.get<string>('JWT_SECRET') || 'your-secret-key';
+    const secret = this.configService?.get<string>('JWT_SECRET');
+    const nodeEnv = process.env['NODE_ENV'];
+    if (!secret && nodeEnv !== 'test') {
+      throw new Error('JWT_SECRET environment variable is required');
+    }
+    const jwtSecret = secret ?? 'mock-jwt-secret-for-testing';
     const jwtExpiration = this.configService?.get<string>('JWT_EXPIRATION') || '15m';
 
     // Parse expiration to seconds (format: '15m', '1h', '7d')


### PR DESCRIPTION
## Summary
- Remove hardcoded JWT secret fallbacks across all services
- Services now require `JWT_SECRET` environment variable (except in test mode)
- Prevents attackers from forging valid JWT tokens if `JWT_SECRET` is missing

## Security Fix
Previously, multiple services fell back to weak hardcoded secrets like `'your-secret-key'` or `'mock-jwt-secret-for-testing'` if `JWT_SECRET` was not set. This meant:
- If `JWT_SECRET` was accidentally missing in production deployment
- Attackers could forge valid JWT tokens using the known fallback secret
- Complete authentication bypass possible

## Files Changed (7 files)
| Service | File | Change |
|---------|------|--------|
| common | jwt-auth.guard.ts | Throw error if JWT_SECRET missing in non-test mode |
| api-gateway | jwt-user.middleware.ts | Require JWT_SECRET at startup |
| contact-service | auth.module.ts | Validate JWT_SECRET in JwtModule factory |
| discussion-service | optional-auth.guard.ts | Require JWT_SECRET in constructor |
| notification-service | auth.module.ts | Validate JWT_SECRET in JwtModule factory |
| notification-service | jwt-verification.service.ts | Require JWT_SECRET in mock mode |
| user-service | auth.service.ts | Require JWT_SECRET in generateJwtTokens |

## Test Plan
- [x] All unit tests pass (79 tests)
- [x] Test mode (`NODE_ENV=test`) still allows fallback for unit tests
- [x] Non-test mode throws Error if JWT_SECRET not set

Fixes #1156

🤖 Generated with [Claude Code](https://claude.ai/claude-code)