### PR TITLE
perf(e2e): increase CI workers from 1 to 2

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { defineConfig, devices } from '@playwright/test';
 
 /**
@@ -21,8 +26,8 @@ export default defineConfig({
   grep: process.env.CI || process.env.E2E_DOCKER ? /^(?!.*@ai)/ : undefined,
   /* Retry disabled to prevent crash from accumulated timeout failures */
   retries: 0,
-  /* Serialize tests in CI to prevent OOM - single worker uses less peak memory */
-  workers: process.env.CI ? 1 : undefined,
+  /* Limit workers in CI to prevent OOM - 2 workers balances speed vs memory */
+  workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters
    * In CI, skip allure-playwright to avoid npm install overhead during E2E startup
    */


### PR DESCRIPTION
## Summary
- Increase Playwright CI workers from 1 to 2 to reduce E2E execution time
- Build #506 showed E2E tests taking 1h47m with single worker for 804 tests
- With 2 workers, expect ~50% reduction to ~50-55 minutes
- Server has 19GB RAM with ~10GB used, so headroom exists for 2 workers

## Test plan
- [ ] Verify E2E tests complete without OOM (exit code 137)
- [ ] Monitor memory usage during E2E stage
- [ ] Confirm execution time reduction

🤖 Generated with [Claude Code](https://claude.ai/code)