### PR TITLE
fix(e2e): increase db-seed memory limit from 192m to 384m

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -112,7 +112,7 @@ services:
     depends_on:
       db-migrate:
         condition: service_completed_successfully
-    mem_limit: 192m
+    mem_limit: 384m
     networks:
       - reasonbridge-e2e
     restart: 'no'


### PR DESCRIPTION
## Summary
The db-seed container was being OOM killed (exit 137) during E2E setup because 192MB is insufficient for running `npx tsx` with Prisma seed scripts.

This fix increases the memory limit from 192m to 384m.

## Evidence
Build #1 of PR #1185 showed:
```
Container e2e-build-1-db-seed-1 Error service "db-seed" didn't complete successfully: exit 137
```

## Test plan
- [ ] E2E tests complete without db-seed OOM errors
- [ ] db-seed container starts and seeds database successfully

🤖 Generated with [Claude Code](https://claude.ai/code)