### PR TITLE
fix(security): add rate limiting to auth gateway proxy endpoints (#1173)

### DIFF
--- a/services/api-gateway/src/app.module.ts
+++ b/services/api-gateway/src/app.module.ts
@@ -5,7 +5,8 @@
 
 import { Module } from '@nestjs/common';
 import type { MiddlewareConsumer, NestModule } from '@nestjs/common';
-import { ThrottlerModule } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { HealthModule } from './health/health.module.js';
 import { ProxyModule } from './proxy/proxy.module.js';
@@ -56,7 +57,14 @@ import { JwtUserMiddleware } from './middleware/jwt-user.middleware.js';
     ProxyModule,
   ],
   controllers: [],
-  providers: [],
+  providers: [
+    // Apply ThrottlerGuard globally - all endpoints are rate limited
+    // Specific limits can be set per-endpoint using @Throttle decorator
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
 })
 export class AppModule implements NestModule {
   /**

--- a/services/api-gateway/src/proxy/auth-proxy.controller.ts
+++ b/services/api-gateway/src/proxy/auth-proxy.controller.ts
@@ -3,15 +3,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Controller, Post, Body, Req, Res, Headers, Inject } from '@nestjs/common';
-import type { FastifyRequest, FastifyReply } from 'fastify';
+import { Controller, Post, Body, Res, Headers, Inject } from '@nestjs/common';
+import type { FastifyReply } from 'fastify';
+import { Throttle } from '@nestjs/throttler';
 import { ProxyService } from './proxy.service.js';
+
+/**
+ * Rate limits for auth endpoints (requests per minute)
+ * These match the user-service throttle limits to provide defense-in-depth
+ * In test mode, limits are relaxed to avoid test flakiness
+ */
+const isTest = process.env['NODE_ENV'] === 'test';
+const THROTTLE_LIMITS = {
+  register: isTest ? 10000 : 3, // 3/min in prod
+  login: isTest ? 10000 : 5, // 5/min in prod
+  refresh: isTest ? 10000 : 10, // 10/min in prod
+  verifyEmail: isTest ? 10000 : 5, // 5/min in prod
+  resendVerification: isTest ? 10000 : 3, // 3/min in prod
+  forgotPassword: isTest ? 10000 : 3, // 3/min in prod
+  resetPassword: isTest ? 10000 : 5, // 5/min in prod
+};
 
 @Controller('auth')
 export class AuthProxyController {
   constructor(@Inject(ProxyService) private readonly proxyService: ProxyService) {}
 
   @Post('register')
+  @Throttle({ default: { limit: THROTTLE_LIMITS.register, ttl: 60000 } })
   async register(
     @Body() body: unknown,
     @Headers('authorization') authHeader: string | undefined,
@@ -28,6 +46,7 @@ export class AuthProxyController {
   }
 
   @Post('login')
+  @Throttle({ default: { limit: THROTTLE_LIMITS.login, ttl: 60000 } })
   async login(
     @Body() body: unknown,
     @Headers('authorization') authHeader: string | undefined,
@@ -44,6 +63,7 @@ export class AuthProxyController {
   }
 
   @Post('refresh')
+  @Throttle({ default: { limit: THROTTLE_LIMITS.refresh, ttl: 60000 } })
   async refresh(
     @Body() body: unknown,
     @Headers('authorization') authHeader: string | undefined,
@@ -60,6 +80,7 @@ export class AuthProxyController {
   }
 
   @Post('signup')
+  @Throttle({ default: { limit: THROTTLE_LIMITS.register, ttl: 60000 } })
   async signup(
     @Body() body: unknown,
     @Headers('authorization') authHeader: string | undefined,
@@ -76,6 +97,7 @@ export class AuthProxyController {
   }
 
   @Post('verify-email')
+  @Throttle({ default: { limit: THROTTLE_LIMITS.verifyEmail, ttl: 60000 } })
   async verifyEmail(
     @Body() body: unknown,
     @Headers('authorization') authHeader: string | undefined,
@@ -92,6 +114,7 @@ export class AuthProxyController {
   }
 
   @Post('resend-verification')
+  @Throttle({ default: { limit: THROTTLE_LIMITS.resendVerification, ttl: 60000 } })
   async resendVerification(
     @Body() body: unknown,
     @Headers('authorization') authHeader: string | undefined,
@@ -100,6 +123,40 @@ export class AuthProxyController {
     const response = await this.proxyService.proxyToUserService({
       method: 'POST',
       path: '/auth/resend-verification',
+      body,
+      headers: authHeader ? { Authorization: authHeader } : undefined,
+    });
+
+    res.status(response.status).send(response.data);
+  }
+
+  @Post('forgot-password')
+  @Throttle({ default: { limit: THROTTLE_LIMITS.forgotPassword, ttl: 60000 } })
+  async forgotPassword(
+    @Body() body: unknown,
+    @Headers('authorization') authHeader: string | undefined,
+    @Res() res: FastifyReply,
+  ) {
+    const response = await this.proxyService.proxyToUserService({
+      method: 'POST',
+      path: '/auth/forgot-password',
+      body,
+      headers: authHeader ? { Authorization: authHeader } : undefined,
+    });
+
+    res.status(response.status).send(response.data);
+  }
+
+  @Post('reset-password')
+  @Throttle({ default: { limit: THROTTLE_LIMITS.resetPassword, ttl: 60000 } })
+  async resetPassword(
+    @Body() body: unknown,
+    @Headers('authorization') authHeader: string | undefined,
+    @Res() res: FastifyReply,
+  ) {
+    const response = await this.proxyService.proxyToUserService({
+      method: 'POST',
+      path: '/auth/reset-password',
       body,
       headers: authHeader ? { Authorization: authHeader } : undefined,
     });


### PR DESCRIPTION
## Summary

- Adds global `ThrottlerGuard` to API gateway via `APP_GUARD` provider
- Adds explicit `@Throttle` decorators to all auth proxy endpoints
- Adds missing `forgot-password` and `reset-password` proxy endpoints
- Matches rate limits with user-service for defense-in-depth protection

## Rate Limits Applied

| Endpoint | Limit | Purpose |
|----------|-------|---------|
| `/auth/register` | 3/min | Prevent spam registrations |
| `/auth/signup` | 3/min | Alias for register |
| `/auth/login` | 5/min | Prevent credential stuffing |
| `/auth/refresh` | 10/min | Token refresh (more lenient) |
| `/auth/verify-email` | 5/min | Prevent brute-force code guessing |
| `/auth/resend-verification` | 3/min | Prevent email spam |
| `/auth/forgot-password` | 3/min | Prevent enumeration attacks |
| `/auth/reset-password` | 5/min | Prevent brute-force code guessing |

## Security Impact

Previously, the gateway defaulted to 100 req/min, allowing attackers to make many requests before user-service throttling kicked in. Now both layers enforce the same limits, providing defense-in-depth.

## Test Plan

- [x] All 85 api-gateway tests pass
- [x] TypeScript check passes
- [x] Rate limits relaxed in test mode (NODE_ENV=test) to avoid flakiness

Closes #1173

🤖 Generated with [Claude Code](https://claude.ai/code)