### PR TITLE
chore: consolidate jenkins-lib - use single library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,34 +2,27 @@
 /**
  * reasonBridge CI/CD Pipeline Stub
  *
- * This minimal stub loads the actual pipeline definition from the jenkins-lib repository.
- * Keeping the real Jenkinsfile in jenkins-lib avoids chicken-and-egg problems with protected branches.
+ * This minimal stub loads the pipeline definition from the consolidated jenkins-config repository.
+ * All shared functions AND project-specific pipelines now live in jenkins-shared-lib.
  *
  * Architecture:
  *   - This stub: Lives in main reasonBridge repo (rarely changes)
- *   - Shared functions: Lives in jenkins-config repo (jenkins-shared-lib)
- *   - Project pipeline: Lives in reasonbridge-jenkins-lib repo (reasonbridgeMultibranchPipeline)
- *   - Jenkins scans: Main repo branches, finds this stub, loads libraries, executes pipeline
+ *   - All pipeline code: Lives in jenkins-config repo (jenkins-shared-lib)
+ *     - Shared functions: githubStatusReporter, dockerCleanup, runUnitTests, etc.
+ *     - Project pipeline: reasonbridgeMultibranchPipeline
+ *   - Jenkins scans: Main repo branches, finds this stub, loads library, executes pipeline
  *
- * Library Loading Order:
- *   1. jenkins-shared-lib (common functions: githubStatusReporter, dockerCleanup, etc.)
- *   2. reasonbridge-lib (project-specific: reasonbridgeMultibranchPipeline)
+ * Consolidation (2026-03):
+ *   - reasonbridge-jenkins-lib merged into jenkins-config
+ *   - Single library load simplifies dependency management
  */
 
-// First, load the shared library with common functions
-// This must be loaded first so functions are available to reasonbridge-lib
+// Load the consolidated shared library
+// Contains both shared functions AND reasonbridgeMultibranchPipeline
 library identifier: 'jenkins-shared-lib@main',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'https://github.com/steiner385/jenkins-config.git',
-        credentialsId: 'github-credentials'
-    ])
-
-// Then load the project-specific library
-library identifier: 'reasonbridge-lib@main',
-    retriever: modernSCM([
-        $class: 'GitSCMSource',
-        remote: 'https://github.com/steiner385/reasonbridge-jenkins-lib.git',
         credentialsId: 'github-credentials'
     ])
 


### PR DESCRIPTION
## Summary

- Updates Jenkinsfile to use the consolidated `jenkins-shared-lib` which now contains both shared functions AND `reasonbridgeMultibranchPipeline`
- Removes the separate `reasonbridge-lib` library load, simplifying to a single library

## Why

This is part of the Jenkins library consolidation effort (steiner385/jenkins-config):

- **Single repository**: All Jenkins pipeline code now lives in jenkins-config
- **Unified issue tracking**: CI/CD improvements tracked in one place
- **No synchronization issues**: Changes to shared functions automatically available to all projects
- **Simpler Jenkinsfile**: Only one library load instead of two

## Test plan

- [ ] CI build passes with the new single-library configuration
- [ ] All pipeline stages execute correctly (lint, unit, integration, E2E)
- [ ] GitHub status checks are posted correctly

## Related

- jenkins-config consolidation: steiner385/jenkins-config@0c6e4af

🤖 Generated with [Claude Code](https://claude.com/claude-code)