### PR TITLE
chore(common): add BaseHttpClient for service-to-service communication

### DIFF
--- a/packages/common/src/clients/__tests__/base-http-client.spec.ts
+++ b/packages/common/src/clients/__tests__/base-http-client.spec.ts
@@ -1,0 +1,275 @@
+/**
+ * Copyright 2026 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  BaseHttpClient,
+  ServiceUnavailableError,
+  type HttpClientLogger,
+} from '../base-http-client.js';
+
+/**
+ * Concrete implementation for testing
+ */
+class TestHttpClient extends BaseHttpClient {
+  // Expose protected methods for testing
+  public testGet<T>(path: string) {
+    return this.get<T>(path);
+  }
+
+  public testPost<T>(path: string, body?: unknown) {
+    return this.post<T>(path, body);
+  }
+
+  public testFireAndForget(path: string, body?: unknown) {
+    return this.fireAndForget(path, body);
+  }
+
+  public testRequestRequired<T>(method: 'GET' | 'POST', path: string, body?: unknown) {
+    return this.requestRequired<T>(method, path, body);
+  }
+}
+
+/**
+ * Create a mock Response object
+ */
+function createMockResponse(data: unknown, ok = true, status = 200): Partial<Response> {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    headers: {
+      get: (name: string) => {
+        if (name.toLowerCase() === 'content-length') {
+          return data ? JSON.stringify(data).length.toString() : '0';
+        }
+        return null;
+      },
+    } as Headers,
+    json: () => Promise.resolve(data),
+  };
+}
+
+/**
+ * Create a mock logger
+ */
+function createMockLogger(): HttpClientLogger {
+  return {
+    debug: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe('BaseHttpClient', () => {
+  let client: TestHttpClient;
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let mockLogger: HttpClientLogger;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    mockLogger = createMockLogger();
+
+    client = new TestHttpClient({
+      baseUrl: 'http://test-service:3000',
+      timeoutMs: 5000,
+      logger: mockLogger,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('GET requests', () => {
+    it('should make GET request and return data', async () => {
+      const mockData = { id: '1', name: 'Test' };
+      mockFetch.mockResolvedValue(createMockResponse(mockData));
+
+      const result = await client.testGet<typeof mockData>('/items/1');
+
+      expect(result).toEqual(mockData);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://test-service:3000/items/1',
+        expect.objectContaining({
+          method: 'GET',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    it('should return null on non-ok response', async () => {
+      mockFetch.mockResolvedValue(createMockResponse(null, false, 404));
+
+      const result = await client.testGet('/items/999');
+
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalled();
+    });
+
+    it('should return null on network error', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      const result = await client.testGet('/items/1');
+
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('POST requests', () => {
+    it('should make POST request with body', async () => {
+      const requestBody = { name: 'New Item' };
+      const responseData = { id: '2', name: 'New Item' };
+      mockFetch.mockResolvedValue(createMockResponse(responseData));
+
+      const result = await client.testPost<typeof responseData>('/items', requestBody);
+
+      expect(result).toEqual(responseData);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://test-service:3000/items',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify(requestBody),
+        }),
+      );
+    });
+  });
+
+  describe('timeout handling', () => {
+    it('should handle timeout via AbortController', async () => {
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+      mockFetch.mockRejectedValue(abortError);
+
+      const result = await client.testGet('/slow-endpoint');
+
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('timed out'),
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('retry logic', () => {
+    it('should retry on 5xx errors', async () => {
+      const clientWithRetry = new TestHttpClient({
+        baseUrl: 'http://test-service:3000',
+        retryAttempts: 2,
+        retryDelayMs: 10, // Short delay for tests
+        logger: mockLogger,
+      });
+
+      mockFetch
+        .mockResolvedValueOnce(createMockResponse(null, false, 503))
+        .mockResolvedValueOnce(createMockResponse(null, false, 503))
+        .mockResolvedValueOnce(createMockResponse({ success: true }));
+
+      const result = await clientWithRetry.testGet<{ success: boolean }>('/flaky-endpoint');
+
+      expect(result).toEqual({ success: true });
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not retry on 4xx errors', async () => {
+      const clientWithRetry = new TestHttpClient({
+        baseUrl: 'http://test-service:3000',
+        retryAttempts: 2,
+        retryDelayMs: 10,
+        logger: mockLogger,
+      });
+
+      mockFetch.mockResolvedValue(createMockResponse(null, false, 400));
+
+      const result = await clientWithRetry.testGet('/bad-request');
+
+      expect(result).toBeNull();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('internal API key authentication', () => {
+    it('should include Authorization header when API key is set', async () => {
+      const clientWithApiKey = new TestHttpClient({
+        baseUrl: 'http://test-service:3000',
+        internalApiKey: 'test-api-key',
+        logger: mockLogger,
+      });
+
+      mockFetch.mockResolvedValue(createMockResponse({ data: 'secret' }));
+
+      await clientWithApiKey.testGet('/internal/data');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'ApiKey test-api-key',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('fireAndForget', () => {
+    it('should log success on ok response', async () => {
+      mockFetch.mockResolvedValue(createMockResponse({ queued: true }));
+
+      await client.testFireAndForget('/queue', { task: 'process' });
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('succeeded'),
+        undefined,
+      );
+    });
+
+    it('should log warning on failure but not throw', async () => {
+      mockFetch.mockResolvedValue(createMockResponse(null, false, 500));
+
+      // Should not throw
+      await client.testFireAndForget('/queue', { task: 'process' });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('failed'), undefined);
+    });
+  });
+
+  describe('requestRequired', () => {
+    it('should return data on success', async () => {
+      mockFetch.mockResolvedValue(createMockResponse({ id: '1' }));
+
+      const result = await client.testRequestRequired<{ id: string }>('GET', '/items/1');
+
+      expect(result).toEqual({ id: '1' });
+    });
+
+    it('should throw ServiceUnavailableError on failure', async () => {
+      mockFetch.mockResolvedValue(createMockResponse(null, false, 500));
+
+      await expect(client.testRequestRequired('GET', '/items/1')).rejects.toThrow(
+        ServiceUnavailableError,
+      );
+    });
+  });
+
+  describe('204 No Content handling', () => {
+    it('should return null for 204 responses', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 204,
+        headers: {
+          get: () => '0',
+        } as Headers,
+        json: () => Promise.reject(new Error('No content')),
+      });
+
+      const result = await client.testGet('/items/1/delete');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/common/src/clients/base-http-client.ts
+++ b/packages/common/src/clients/base-http-client.ts
@@ -1,0 +1,383 @@
+/**
+ * Copyright 2026 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Logger interface compatible with NestJS Logger
+ */
+export interface HttpClientLogger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  log(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+}
+
+/**
+ * Configuration options for BaseHttpClient
+ */
+export interface HttpClientOptions {
+  /** Base URL for the service */
+  baseUrl: string;
+  /** Request timeout in milliseconds (default: 30000) */
+  timeoutMs?: number;
+  /** Internal API key for service-to-service authentication */
+  internalApiKey?: string;
+  /** Number of retry attempts (default: 0 = no retries) */
+  retryAttempts?: number;
+  /** Delay between retries in milliseconds (default: 1000) */
+  retryDelayMs?: number;
+  /** Logger instance */
+  logger?: HttpClientLogger;
+}
+
+/**
+ * Default timeout for HTTP requests in milliseconds
+ */
+const DEFAULT_TIMEOUT_MS = 30000;
+
+/**
+ * Default retry delay in milliseconds
+ */
+const DEFAULT_RETRY_DELAY_MS = 1000;
+
+/**
+ * No-op fallback logger.
+ *
+ * Concrete implementations should always provide a real logger (e.g., NestJS Logger).
+ * This fallback silently discards messages to avoid unexpected console output.
+ */
+const noopLogger: HttpClientLogger = {
+  debug: () => {},
+  log: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+/**
+ * Base HTTP client for service-to-service communication.
+ *
+ * @remarks
+ * Provides common patterns for HTTP requests between microservices:
+ * - Timeout handling with AbortController
+ * - Fire-and-forget error handling (returns null/default instead of throwing)
+ * - Internal API key authentication
+ * - Optional retry logic with configurable attempts and delays
+ * - Consistent logging patterns
+ *
+ * @example
+ * ```typescript
+ * class UserServiceClient extends BaseHttpClient {
+ *   constructor(configService: ConfigService) {
+ *     super({
+ *       baseUrl: getServiceUrl('USER_SERVICE'),
+ *       timeoutMs: 5000,
+ *       internalApiKey: configService.get('INTERNAL_API_KEY'),
+ *       retryAttempts: 2,
+ *       logger: new Logger(UserServiceClient.name),
+ *     });
+ *   }
+ *
+ *   async getUser(id: string): Promise<User | null> {
+ *     return this.get<User>(`/users/${id}`);
+ *   }
+ *
+ *   async createUser(data: CreateUserDto): Promise<User | null> {
+ *     return this.post<User>('/users', data);
+ *   }
+ * }
+ * ```
+ */
+export abstract class BaseHttpClient {
+  protected readonly baseUrl: string;
+  protected readonly timeoutMs: number;
+  protected readonly internalApiKey?: string;
+  protected readonly retryAttempts: number;
+  protected readonly retryDelayMs: number;
+  protected readonly logger: HttpClientLogger;
+
+  constructor(options: HttpClientOptions) {
+    this.baseUrl = options.baseUrl;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.internalApiKey = options.internalApiKey;
+    this.retryAttempts = options.retryAttempts ?? 0;
+    this.retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+    this.logger = options.logger ?? noopLogger;
+  }
+
+  /**
+   * Build headers for HTTP requests.
+   *
+   * @param additionalHeaders - Additional headers to include
+   * @returns Headers object with Content-Type and optional Authorization
+   */
+  protected buildHeaders(additionalHeaders?: Record<string, string>): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...additionalHeaders,
+    };
+
+    if (this.internalApiKey) {
+      headers['Authorization'] = `ApiKey ${this.internalApiKey}`;
+    }
+
+    return headers;
+  }
+
+  /**
+   * Execute fetch with timeout using AbortController.
+   *
+   * @param url - Full URL to fetch
+   * @param options - Fetch options
+   * @returns Response object
+   * @throws Error if request times out or fails
+   */
+  protected async fetchWithTimeout(url: string, options: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      return await fetch(url, { ...options, signal: controller.signal });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Sleep for the specified duration.
+   */
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Execute a request with optional retry logic.
+   *
+   * @param method - HTTP method
+   * @param path - URL path (appended to baseUrl)
+   * @param body - Optional request body
+   * @param additionalHeaders - Optional additional headers
+   * @returns Parsed JSON response or null on error
+   */
+  protected async request<T>(
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+    path: string,
+    body?: unknown,
+    additionalHeaders?: Record<string, string>,
+  ): Promise<T | null> {
+    const url = `${this.baseUrl}${path}`;
+    const options: RequestInit = {
+      method,
+      headers: this.buildHeaders(additionalHeaders),
+    };
+
+    if (body !== undefined) {
+      options.body = JSON.stringify(body);
+    }
+
+    let lastError: Error | null = null;
+    const maxAttempts = this.retryAttempts + 1;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const response = await this.fetchWithTimeout(url, options);
+
+        if (!response.ok) {
+          this.logger.warn(`${method} ${path} failed: ${response.status} ${response.statusText}`, {
+            attempt,
+            maxAttempts,
+          });
+
+          // Don't retry client errors (4xx)
+          if (response.status >= 400 && response.status < 500) {
+            return null;
+          }
+
+          // Retry server errors (5xx) if attempts remain
+          if (attempt < maxAttempts) {
+            await this.sleep(this.retryDelayMs);
+            continue;
+          }
+
+          return null;
+        }
+
+        // Handle empty responses (204 No Content)
+        const contentLength = response.headers.get('content-length');
+        if (response.status === 204 || contentLength === '0') {
+          return null;
+        }
+
+        return (await response.json()) as T;
+      } catch (error) {
+        lastError = error as Error;
+
+        if (lastError.name === 'AbortError') {
+          this.logger.warn(`${method} ${path} timed out`, { attempt, maxAttempts });
+        } else {
+          this.logger.warn(`${method} ${path} error: ${lastError.message}`, {
+            attempt,
+            maxAttempts,
+          });
+        }
+
+        // Retry if attempts remain
+        if (attempt < maxAttempts) {
+          await this.sleep(this.retryDelayMs);
+          continue;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Execute a GET request.
+   *
+   * @param path - URL path (appended to baseUrl)
+   * @param additionalHeaders - Optional additional headers
+   * @returns Parsed JSON response or null on error
+   */
+  protected async get<T>(
+    path: string,
+    additionalHeaders?: Record<string, string>,
+  ): Promise<T | null> {
+    return this.request<T>('GET', path, undefined, additionalHeaders);
+  }
+
+  /**
+   * Execute a POST request.
+   *
+   * @param path - URL path (appended to baseUrl)
+   * @param body - Request body
+   * @param additionalHeaders - Optional additional headers
+   * @returns Parsed JSON response or null on error
+   */
+  protected async post<T>(
+    path: string,
+    body?: unknown,
+    additionalHeaders?: Record<string, string>,
+  ): Promise<T | null> {
+    return this.request<T>('POST', path, body, additionalHeaders);
+  }
+
+  /**
+   * Execute a PUT request.
+   *
+   * @param path - URL path (appended to baseUrl)
+   * @param body - Request body
+   * @param additionalHeaders - Optional additional headers
+   * @returns Parsed JSON response or null on error
+   */
+  protected async put<T>(
+    path: string,
+    body?: unknown,
+    additionalHeaders?: Record<string, string>,
+  ): Promise<T | null> {
+    return this.request<T>('PUT', path, body, additionalHeaders);
+  }
+
+  /**
+   * Execute a PATCH request.
+   *
+   * @param path - URL path (appended to baseUrl)
+   * @param body - Request body
+   * @param additionalHeaders - Optional additional headers
+   * @returns Parsed JSON response or null on error
+   */
+  protected async patch<T>(
+    path: string,
+    body?: unknown,
+    additionalHeaders?: Record<string, string>,
+  ): Promise<T | null> {
+    return this.request<T>('PATCH', path, body, additionalHeaders);
+  }
+
+  /**
+   * Execute a DELETE request.
+   *
+   * @param path - URL path (appended to baseUrl)
+   * @param additionalHeaders - Optional additional headers
+   * @returns Parsed JSON response or null on error
+   */
+  protected async delete<T>(
+    path: string,
+    additionalHeaders?: Record<string, string>,
+  ): Promise<T | null> {
+    return this.request<T>('DELETE', path, undefined, additionalHeaders);
+  }
+
+  /**
+   * Execute a fire-and-forget POST request.
+   *
+   * Logs result but never throws. Use for non-critical operations
+   * where failure shouldn't block the calling operation.
+   *
+   * @param path - URL path (appended to baseUrl)
+   * @param body - Request body
+   * @param context - Optional context for logging
+   */
+  protected async fireAndForget(
+    path: string,
+    body?: unknown,
+    context?: Record<string, unknown>,
+  ): Promise<void> {
+    const url = `${this.baseUrl}${path}`;
+
+    try {
+      const response = await this.fetchWithTimeout(url, {
+        method: 'POST',
+        headers: this.buildHeaders(),
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+
+      if (!response.ok) {
+        this.logger.warn(`Fire-and-forget POST ${path} failed: ${response.status}`, context);
+      } else {
+        this.logger.debug(`Fire-and-forget POST ${path} succeeded`, context);
+      }
+    } catch (error) {
+      const err = error as Error;
+      if (err.name === 'AbortError') {
+        this.logger.warn(`Fire-and-forget POST ${path} timed out`, context);
+      } else {
+        this.logger.warn(`Fire-and-forget POST ${path} error: ${err.message}`, context);
+      }
+    }
+  }
+
+  /**
+   * Execute a required request that throws on failure.
+   *
+   * Use when the downstream service response is critical and the caller
+   * should handle the error explicitly.
+   *
+   * @param method - HTTP method
+   * @param path - URL path (appended to baseUrl)
+   * @param body - Optional request body
+   * @returns Parsed JSON response
+   * @throws ServiceUnavailableError if request fails
+   */
+  protected async requestRequired<T>(
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const result = await this.request<T>(method, path, body);
+    if (result === null) {
+      throw new ServiceUnavailableError(`${method} ${path} failed`);
+    }
+    return result;
+  }
+}
+
+/**
+ * Error thrown when a required downstream service is unavailable.
+ */
+export class ServiceUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ServiceUnavailableError';
+  }
+}

--- a/packages/common/src/clients/index.ts
+++ b/packages/common/src/clients/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export {
+  BaseHttpClient,
+  ServiceUnavailableError,
+  type HttpClientOptions,
+  type HttpClientLogger,
+} from './base-http-client.js';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -16,3 +16,4 @@ export * from './validation/index.js';
 export * from './config/index.js';
 export * from './observability/index.js';
 export * from './auth/index.js';
+export * from './clients/index.js';

--- a/services/contact-service/src/clients/__tests__/user-service.client.spec.ts
+++ b/services/contact-service/src/clients/__tests__/user-service.client.spec.ts
@@ -6,6 +6,26 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { UserServiceClient } from '../user-service.client.js';
 
+/**
+ * Create a mock Response object with proper headers
+ */
+function createMockResponse(data: unknown, ok = true, status = 200): Partial<Response> {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    headers: {
+      get: (name: string) => {
+        if (name.toLowerCase() === 'content-length') {
+          return data ? JSON.stringify(data).length.toString() : '0';
+        }
+        return null;
+      },
+    } as Headers,
+    json: () => Promise.resolve(data),
+  };
+}
+
 describe('UserServiceClient', () => {
   let client: UserServiceClient;
   let mockFetch: ReturnType<typeof vi.fn>;
@@ -22,13 +42,11 @@ describe('UserServiceClient', () => {
 
   describe('findDiscoverableUsersByEmailHashes', () => {
     it('should call user-service with email hashes', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            users: [{ id: 'user-1', displayName: 'John', emailHash: 'hash1' }],
-          }),
-      });
+      mockFetch.mockResolvedValue(
+        createMockResponse({
+          users: [{ id: 'user-1', displayName: 'John', emailHash: 'hash1' }],
+        }),
+      );
 
       const result = await client.findDiscoverableUsersByEmailHashes(['hash1', 'hash2']);
 
@@ -51,10 +69,7 @@ describe('UserServiceClient', () => {
     });
 
     it('should return empty array on non-ok response', async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 500,
-      });
+      mockFetch.mockResolvedValue(createMockResponse(null, false, 500));
 
       const result = await client.findDiscoverableUsersByEmailHashes(['hash1']);
 
@@ -64,15 +79,13 @@ describe('UserServiceClient', () => {
 
   describe('getUserById', () => {
     it('should fetch user by ID', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            id: 'user-1',
-            displayName: 'John Smith',
-            avatarUrl: 'https://example.com/avatar.jpg',
-          }),
-      });
+      mockFetch.mockResolvedValue(
+        createMockResponse({
+          id: 'user-1',
+          displayName: 'John Smith',
+          avatarUrl: 'https://example.com/avatar.jpg',
+        }),
+      );
 
       const result = await client.getUserById('user-1');
 

--- a/services/contact-service/src/clients/user-service.client.ts
+++ b/services/contact-service/src/clients/user-service.client.ts
@@ -4,7 +4,7 @@
  */
 
 import { Injectable, Logger } from '@nestjs/common';
-import { getServiceUrl } from '@reason-bridge/common';
+import { BaseHttpClient, getServiceUrl } from '@reason-bridge/common';
 
 export interface DiscoverableUser {
   id: string;
@@ -18,6 +18,10 @@ export interface UserProfile {
   displayName: string;
   avatarUrl?: string;
   email?: string;
+}
+
+interface DiscoverableUsersResponse {
+  users: DiscoverableUser[];
 }
 
 /**
@@ -41,35 +45,17 @@ export interface UserProfile {
  * const user = await userServiceClient.getUserById('user-123');
  * ```
  */
-/** Default timeout for HTTP requests in milliseconds */
-const DEFAULT_TIMEOUT_MS = 30000;
-
 @Injectable()
-export class UserServiceClient {
-  private readonly logger = new Logger(UserServiceClient.name);
-  private readonly baseUrl: string;
-  private readonly timeoutMs: number;
-
+export class UserServiceClient extends BaseHttpClient {
   constructor() {
-    this.baseUrl = process.env['USER_SERVICE_URL'] || getServiceUrl('USER_SERVICE');
-    this.timeoutMs = parseInt(
-      process.env['USER_SERVICE_TIMEOUT_MS'] || String(DEFAULT_TIMEOUT_MS),
-      10,
-    );
-  }
+    const baseUrl = process.env['USER_SERVICE_URL'] || getServiceUrl('USER_SERVICE');
+    const timeoutMs = parseInt(process.env['USER_SERVICE_TIMEOUT_MS'] || '30000', 10);
 
-  /**
-   * Fetch with timeout using AbortController
-   */
-  private async fetchWithTimeout(url: string, options: RequestInit): Promise<Response> {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
-
-    try {
-      return await fetch(url, { ...options, signal: controller.signal });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    super({
+      baseUrl,
+      timeoutMs,
+      logger: new Logger(UserServiceClient.name),
+    });
   }
 
   /**
@@ -80,28 +66,10 @@ export class UserServiceClient {
    * @returns Array of discoverable users matching the hashes, or empty array on error
    */
   async findDiscoverableUsersByEmailHashes(emailHashes: string[]): Promise<DiscoverableUser[]> {
-    try {
-      const response = await this.fetchWithTimeout(`${this.baseUrl}/users/discoverable`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ emailHashes }),
-      });
-
-      if (!response.ok) {
-        this.logger.warn(`Failed to find discoverable users: ${response.status}`);
-        return [];
-      }
-
-      const data = await response.json();
-      return data.users || [];
-    } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
-        this.logger.warn('Request to user-service timed out');
-      } else {
-        this.logger.warn(`Error calling user-service: ${(error as Error).message}`);
-      }
-      return [];
-    }
+    const result = await this.post<DiscoverableUsersResponse>('/users/discoverable', {
+      emailHashes,
+    });
+    return result?.users ?? [];
   }
 
   /**
@@ -112,25 +80,6 @@ export class UserServiceClient {
    * @returns User profile or null if not found/error
    */
   async getUserById(userId: string): Promise<UserProfile | null> {
-    try {
-      const response = await this.fetchWithTimeout(`${this.baseUrl}/users/${userId}`, {
-        method: 'GET',
-        headers: { 'Content-Type': 'application/json' },
-      });
-
-      if (!response.ok) {
-        this.logger.warn(`Failed to get user ${userId}: ${response.status}`);
-        return null;
-      }
-
-      return await response.json();
-    } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
-        this.logger.warn(`Request to get user ${userId} timed out`);
-      } else {
-        this.logger.warn(`Error fetching user ${userId}: ${(error as Error).message}`);
-      }
-      return null;
-    }
+    return this.get<UserProfile>(`/users/${userId}`);
   }
 }


### PR DESCRIPTION
## Summary
- Add `BaseHttpClient` class to `@reason-bridge/common` to eliminate code duplication across 8+ service clients
- Refactored `UserServiceClient` in contact-service as proof of concept (137 → 83 lines, 39% reduction)

## Features
- Timeout handling with `AbortController`
- Fire-and-forget error handling (returns `null` instead of throwing)
- Internal API key authentication (`Authorization: ApiKey`)
- Optional retry logic with configurable attempts and delays
- Consistent logging patterns
- Helper methods: `get`, `post`, `put`, `patch`, `delete`, `fireAndForget`
- `requestRequired` method that throws `ServiceUnavailableError` for critical requests

## Usage
```typescript
import { BaseHttpClient, getServiceUrl } from '@reason-bridge/common';

@Injectable()
export class UserServiceClient extends BaseHttpClient {
  constructor() {
    super({
      baseUrl: getServiceUrl('USER_SERVICE'),
      timeoutMs: 5000,
      internalApiKey: process.env['INTERNAL_API_KEY'],
      retryAttempts: 2,
      logger: new Logger(UserServiceClient.name),
    });
  }

  async getUser(id: string): Promise<User | null> {
    return this.get<User>(`/users/${id}`);
  }
}
```

## Test plan
- [x] Unit tests for BaseHttpClient (13 tests passing)
- [x] contact-service tests pass (110 tests)
- [ ] CI passes

Closes #1165

🤖 Generated with [Claude Code](https://claude.com/claude-code)