### PR TITLE
refactor(services): extract magic numbers to constants files

### DIFF
--- a/services/discussion-service/src/constants/index.ts
+++ b/services/discussion-service/src/constants/index.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2026 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Cache TTL constants in milliseconds.
+ *
+ * @remarks
+ * Topic lists are cached for 5 minutes to balance freshness with performance.
+ * Individual topic details (including common ground analysis) are cached for 1 hour
+ * since they change less frequently.
+ */
+export const CACHE_TTL = {
+  /** 5 minutes - for paginated topic lists */
+  TOPICS_LIST_MS: 5 * 60 * 1000,
+  /** 1 hour - for individual topic details and common ground analysis */
+  TOPIC_DETAIL_MS: 60 * 60 * 1000,
+} as const;
+
+/**
+ * Response content constraints.
+ *
+ * @remarks
+ * Minimum length ensures meaningful contributions.
+ * Maximum length prevents abuse and ensures readability.
+ * Citation limit prevents link spam while allowing adequate sourcing.
+ */
+export const RESPONSE_CONSTRAINTS = {
+  /** Minimum response content length (characters) */
+  MIN_LENGTH: 10,
+  /** Maximum response content length (characters) */
+  MAX_LENGTH: 10000,
+  /** Maximum citations per response */
+  MAX_CITATIONS: 10,
+} as const;
+
+/**
+ * Search result display constraints.
+ *
+ * @remarks
+ * Truncation lengths optimize search result display while
+ * providing enough context for users to identify relevant content.
+ */
+export const SEARCH_DISPLAY = {
+  /** Truncation length for topic descriptions in search results */
+  DESCRIPTION_TRUNCATE_LENGTH: 200,
+  /** Truncation length for response content in search results */
+  CONTENT_TRUNCATE_LENGTH: 300,
+} as const;
+
+/**
+ * Proposition constraints.
+ *
+ * @remarks
+ * Propositions must be substantial enough to be meaningful (10 chars)
+ * but concise enough to be clear (1000 chars).
+ */
+export const PROPOSITION_CONSTRAINTS = {
+  /** Minimum proposition statement length (characters) */
+  MIN_LENGTH: 10,
+  /** Maximum proposition statement length (characters) */
+  MAX_LENGTH: 1000,
+} as const;
+
+/**
+ * Topic slug constraints.
+ *
+ * @remarks
+ * Slugs must be readable and fit within URL constraints.
+ * Maximum 250 chars leaves room for path prefixes.
+ */
+export const SLUG_CONSTRAINTS = {
+  /** Minimum slug length (characters) */
+  MIN_LENGTH: 3,
+  /** Maximum slug length (characters) */
+  MAX_LENGTH: 250,
+} as const;

--- a/services/discussion-service/src/discussions/discussions.service.ts
+++ b/services/discussion-service/src/discussions/discussions.service.ts
@@ -29,6 +29,7 @@ import {
   PaginatedResponseDto,
 } from '../dto/pagination.dto.js';
 import { getGravatarUrl } from '../dto/user-summary.dto.js';
+import { RESPONSE_CONSTRAINTS } from '../constants/index.js';
 
 export interface ListDiscussionsQuery extends PaginationQueryDto {
   topicId?: string;
@@ -101,8 +102,10 @@ export class DiscussionsService {
     }> = [];
 
     if (dto.initialResponse.citations && dto.initialResponse.citations.length > 0) {
-      if (dto.initialResponse.citations.length > 10) {
-        throw new BadRequestException('Maximum 10 citations allowed per response');
+      if (dto.initialResponse.citations.length > RESPONSE_CONSTRAINTS.MAX_CITATIONS) {
+        throw new BadRequestException(
+          `Maximum ${RESPONSE_CONSTRAINTS.MAX_CITATIONS} citations allowed per response`,
+        );
       }
 
       for (const citation of dto.initialResponse.citations) {

--- a/services/discussion-service/src/responses/responses.service.ts
+++ b/services/discussion-service/src/responses/responses.service.ts
@@ -21,6 +21,7 @@ import type { ResponseDto, CitedSourceDto, UserSummaryDto } from './dto/response
 import { getGravatarUrl } from '../dto/user-summary.dto.js';
 import { DiscussionLogger } from '../utils/logger.js';
 import { validateCitationUrl } from '../utils/ssrf-validator.js';
+import { RESPONSE_CONSTRAINTS } from '../constants/index.js';
 
 /**
  * T053 [US3] - Threaded response with nested replies
@@ -125,12 +126,19 @@ export class ResponsesService {
     createResponseDto: CreateResponseDto,
   ): Promise<ResponseDto> {
     // Validate input
-    if (!createResponseDto.content || createResponseDto.content.trim().length < 10) {
-      throw new BadRequestException('Response content must be at least 10 characters');
+    if (
+      !createResponseDto.content ||
+      createResponseDto.content.trim().length < RESPONSE_CONSTRAINTS.MIN_LENGTH
+    ) {
+      throw new BadRequestException(
+        `Response content must be at least ${RESPONSE_CONSTRAINTS.MIN_LENGTH} characters`,
+      );
     }
 
-    if (createResponseDto.content.length > 10000) {
-      throw new BadRequestException('Response content must not exceed 10000 characters');
+    if (createResponseDto.content.length > RESPONSE_CONSTRAINTS.MAX_LENGTH) {
+      throw new BadRequestException(
+        `Response content must not exceed ${RESPONSE_CONSTRAINTS.MAX_LENGTH} characters`,
+      );
     }
 
     // Verify topic exists and is active or seeding
@@ -341,12 +349,19 @@ export class ResponsesService {
 
     // Validate content if provided
     if (updateResponseDto.content !== undefined) {
-      if (!updateResponseDto.content || updateResponseDto.content.trim().length < 10) {
-        throw new BadRequestException('Response content must be at least 10 characters');
+      if (
+        !updateResponseDto.content ||
+        updateResponseDto.content.trim().length < RESPONSE_CONSTRAINTS.MIN_LENGTH
+      ) {
+        throw new BadRequestException(
+          `Response content must be at least ${RESPONSE_CONSTRAINTS.MIN_LENGTH} characters`,
+        );
       }
 
-      if (updateResponseDto.content.length > 10000) {
-        throw new BadRequestException('Response content must not exceed 10000 characters');
+      if (updateResponseDto.content.length > RESPONSE_CONSTRAINTS.MAX_LENGTH) {
+        throw new BadRequestException(
+          `Response content must not exceed ${RESPONSE_CONSTRAINTS.MAX_LENGTH} characters`,
+        );
       }
     }
 
@@ -572,8 +587,10 @@ export class ResponsesService {
     }> = [];
 
     if (dto.citations && dto.citations.length > 0) {
-      if (dto.citations.length > 10) {
-        throw new BadRequestException('Maximum 10 citations allowed per response');
+      if (dto.citations.length > RESPONSE_CONSTRAINTS.MAX_CITATIONS) {
+        throw new BadRequestException(
+          `Maximum ${RESPONSE_CONSTRAINTS.MAX_CITATIONS} citations allowed per response`,
+        );
       }
 
       for (const citation of dto.citations) {

--- a/services/discussion-service/src/search/search.service.ts
+++ b/services/discussion-service/src/search/search.service.ts
@@ -19,6 +19,7 @@ import {
   ResponseSearchResultDto,
   SearchResultItemType,
 } from './dto/unified-search-results.dto.js';
+import { SEARCH_DISPLAY } from '../constants/index.js';
 
 /**
  * Service for unified search across topics and responses
@@ -203,7 +204,8 @@ export class SearchService {
         createdAt: topic.createdAt,
         title: topic.title,
         description:
-          topic.description.substring(0, 200) + (topic.description.length > 200 ? '...' : ''),
+          topic.description.substring(0, SEARCH_DISPLAY.DESCRIPTION_TRUNCATE_LENGTH) +
+          (topic.description.length > SEARCH_DISPLAY.DESCRIPTION_TRUNCATE_LENGTH ? '...' : ''),
         slug: topic.slug,
         status: topic.status,
         responseCount: topic.responseCount,
@@ -259,7 +261,9 @@ export class SearchService {
         id: r.id,
         score: r.rank,
         createdAt: r.createdAt,
-        content: r.content.substring(0, 300) + (r.content.length > 300 ? '...' : ''),
+        content:
+          r.content.substring(0, SEARCH_DISPLAY.CONTENT_TRUNCATE_LENGTH) +
+          (r.content.length > SEARCH_DISPLAY.CONTENT_TRUNCATE_LENGTH ? '...' : ''),
         highlightedContent: r.highlightedContent,
         authorId: r.authorId,
         topicId: r.topicId,

--- a/services/discussion-service/src/topics/slug-generator.service.ts
+++ b/services/discussion-service/src/topics/slug-generator.service.ts
@@ -5,6 +5,7 @@
 
 import { Injectable, Logger, Inject } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
+import { SLUG_CONSTRAINTS } from '../constants/index.js';
 
 /**
  * Service for generating unique URL-friendly slugs from topic titles
@@ -105,9 +106,9 @@ export class SlugGeneratorService {
     const hashSuffix = this.generateHashSuffix(title + Date.now());
     let slug = `${baseSlug}-${hashSuffix}`;
 
-    // Ensure slug is within length limit (250 chars from schema)
-    if (slug.length > 250) {
-      const maxBaseLength = 250 - hashSuffix.length - 1; // -1 for hyphen
+    // Ensure slug is within length limit
+    if (slug.length > SLUG_CONSTRAINTS.MAX_LENGTH) {
+      const maxBaseLength = SLUG_CONSTRAINTS.MAX_LENGTH - hashSuffix.length - 1; // -1 for hyphen
       slug = `${baseSlug.substring(0, maxBaseLength)}-${hashSuffix}`;
     }
 
@@ -189,10 +190,10 @@ export class SlugGeneratorService {
     }
 
     // Check length
-    if (slug.length < 3 || slug.length > 250) {
+    if (slug.length < SLUG_CONSTRAINTS.MIN_LENGTH || slug.length > SLUG_CONSTRAINTS.MAX_LENGTH) {
       return {
         valid: false,
-        error: 'Slug must be between 3 and 250 characters',
+        error: `Slug must be between ${SLUG_CONSTRAINTS.MIN_LENGTH} and ${SLUG_CONSTRAINTS.MAX_LENGTH} characters`,
       };
     }
 

--- a/services/discussion-service/src/topics/topics.service.ts
+++ b/services/discussion-service/src/topics/topics.service.ts
@@ -28,6 +28,7 @@ import { TopicsEditService } from './topics-edit.service.js';
 import { PropositionsService } from '../propositions/propositions.service.js';
 import { ActivityClientService } from '../clients/activity-client.service.js';
 import { Prisma } from '@prisma/client';
+import { CACHE_TTL } from '../constants/index.js';
 
 @Injectable()
 export class TopicsService implements OnModuleInit {
@@ -222,8 +223,8 @@ export class TopicsService implements OnModuleInit {
       },
     };
 
-    // Cache result with 5min TTL (300000ms)
-    await this.cacheManager?.set(cacheKey, result, 300000);
+    // Cache result with 5min TTL
+    await this.cacheManager?.set(cacheKey, result, CACHE_TTL.TOPICS_LIST_MS);
 
     return result;
   }
@@ -593,7 +594,7 @@ export class TopicsService implements OnModuleInit {
     };
 
     // Cache the result with a 1-hour TTL
-    await this.cacheManager?.set(cacheKey, result, 3600000);
+    await this.cacheManager?.set(cacheKey, result, CACHE_TTL.TOPIC_DETAIL_MS);
 
     return result;
   }

--- a/services/moderation-service/src/constants/index.ts
+++ b/services/moderation-service/src/constants/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2026 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Content screening constraints.
+ *
+ * @remarks
+ * Maximum content length prevents abuse and ensures reasonable processing time.
+ */
+export const CONTENT_SCREENING = {
+  /** Maximum content length for screening (characters) */
+  MAX_LENGTH: 10000,
+} as const;
+
+/**
+ * Appeal request constraints.
+ *
+ * @remarks
+ * Minimum length ensures appellants provide meaningful context.
+ * Maximum length prevents abuse while allowing detailed explanations.
+ */
+export const APPEAL_CONSTRAINTS = {
+  /** Minimum appeal reason length (characters) */
+  REASON_MIN_LENGTH: 20,
+  /** Maximum appeal reason length (characters) */
+  REASON_MAX_LENGTH: 5000,
+  /** Minimum moderator reasoning length (characters) */
+  DECISION_REASONING_MIN_LENGTH: 20,
+  /** Maximum moderator reasoning length (characters) */
+  DECISION_REASONING_MAX_LENGTH: 2000,
+} as const;
+
+/**
+ * Moderation action constraints.
+ *
+ * @remarks
+ * Similar to appeals, reasoning must be substantial but bounded.
+ */
+export const ACTION_CONSTRAINTS = {
+  /** Minimum reasoning length for moderation actions (characters) */
+  REASONING_MIN_LENGTH: 20,
+  /** Maximum reasoning length for moderation actions (characters) */
+  REASONING_MAX_LENGTH: 2000,
+  /** Minimum reason length for reports (characters) */
+  REPORT_REASON_MIN_LENGTH: 20,
+  /** Maximum reason length for reports (characters) */
+  REPORT_REASON_MAX_LENGTH: 5000,
+} as const;

--- a/services/moderation-service/src/controllers/moderation.controller.ts
+++ b/services/moderation-service/src/controllers/moderation.controller.ts
@@ -37,6 +37,7 @@ import type {
   ReportContentType,
 } from '../dto/report.dto.js';
 import type { SafetyReportReason, SafetyReportStatus, ReviewPriority } from '@prisma/client';
+import { CONTENT_SCREENING } from '../constants/index.js';
 import type {
   CreateActionRequest,
   ApproveActionRequest,
@@ -89,8 +90,10 @@ export class ModerationController {
       throw new BadRequestException('content cannot be empty');
     }
 
-    if (request.content.length > 10000) {
-      throw new BadRequestException('content exceeds maximum length of 10000');
+    if (request.content.length > CONTENT_SCREENING.MAX_LENGTH) {
+      throw new BadRequestException(
+        `content exceeds maximum length of ${CONTENT_SCREENING.MAX_LENGTH}`,
+      );
     }
 
     const screening_result = await this.screeningService.screenContent(

--- a/services/moderation-service/src/services/appeal.service.ts
+++ b/services/moderation-service/src/services/appeal.service.ts
@@ -15,6 +15,7 @@ import type {
   PendingAppealResponse,
   ListAppealResponse,
 } from '../dto/appeal.dto.js';
+import { APPEAL_CONSTRAINTS } from '../constants/index.js';
 
 /**
  * AppealService handles moderation appeal management including:
@@ -42,12 +43,16 @@ export class AppealService {
       throw new BadRequestException('reason is required');
     }
 
-    if (request.reason.length < 20) {
-      throw new BadRequestException('Appeal reason must be at least 20 characters long');
+    if (request.reason.length < APPEAL_CONSTRAINTS.REASON_MIN_LENGTH) {
+      throw new BadRequestException(
+        `Appeal reason must be at least ${APPEAL_CONSTRAINTS.REASON_MIN_LENGTH} characters long`,
+      );
     }
 
-    if (request.reason.length > 5000) {
-      throw new BadRequestException('Appeal reason cannot exceed 5000 characters');
+    if (request.reason.length > APPEAL_CONSTRAINTS.REASON_MAX_LENGTH) {
+      throw new BadRequestException(
+        `Appeal reason cannot exceed ${APPEAL_CONSTRAINTS.REASON_MAX_LENGTH} characters`,
+      );
     }
 
     const action = await this.prisma.moderationAction.findUnique({
@@ -238,14 +243,16 @@ export class AppealService {
       throw new BadRequestException('reasoning is required');
     }
 
-    if (request.reasoning.length < 20) {
+    if (request.reasoning.length < APPEAL_CONSTRAINTS.DECISION_REASONING_MIN_LENGTH) {
       throw new BadRequestException(
-        'Appeal decision reasoning must be at least 20 characters long',
+        `Appeal decision reasoning must be at least ${APPEAL_CONSTRAINTS.DECISION_REASONING_MIN_LENGTH} characters long`,
       );
     }
 
-    if (request.reasoning.length > 2000) {
-      throw new BadRequestException('Appeal decision reasoning cannot exceed 2000 characters');
+    if (request.reasoning.length > APPEAL_CONSTRAINTS.DECISION_REASONING_MAX_LENGTH) {
+      throw new BadRequestException(
+        `Appeal decision reasoning cannot exceed ${APPEAL_CONSTRAINTS.DECISION_REASONING_MAX_LENGTH} characters`,
+      );
     }
 
     const appeal = await this.prisma.appeal.findUnique({

--- a/services/moderation-service/src/services/moderation-actions.service.ts
+++ b/services/moderation-service/src/services/moderation-actions.service.ts
@@ -28,6 +28,7 @@ import type {
   PendingAppealResponse,
   ListAppealResponse,
 } from '../dto/appeal.dto.js';
+import { ACTION_CONSTRAINTS, APPEAL_CONSTRAINTS } from '../constants/index.js';
 
 // Re-export DTOs for backward compatibility
 export type {
@@ -124,8 +125,10 @@ export class ModerationActionsService {
     request: CreateActionRequest,
     moderatorId: string,
   ): Promise<ModerationActionResponse> {
-    if (request.reasoning.length < 20) {
-      throw new BadRequestException('Reasoning must be at least 20 characters long');
+    if (request.reasoning.length < ACTION_CONSTRAINTS.REASONING_MIN_LENGTH) {
+      throw new BadRequestException(
+        `Reasoning must be at least ${ACTION_CONSTRAINTS.REASONING_MIN_LENGTH} characters long`,
+      );
     }
 
     const severity = this.mapActionToSeverity(request.actionType);
@@ -378,12 +381,16 @@ export class ModerationActionsService {
       throw new BadRequestException('reason is required');
     }
 
-    if (request.reason.length < 20) {
-      throw new BadRequestException('Appeal reason must be at least 20 characters long');
+    if (request.reason.length < APPEAL_CONSTRAINTS.REASON_MIN_LENGTH) {
+      throw new BadRequestException(
+        `Appeal reason must be at least ${APPEAL_CONSTRAINTS.REASON_MIN_LENGTH} characters long`,
+      );
     }
 
-    if (request.reason.length > 5000) {
-      throw new BadRequestException('Appeal reason cannot exceed 5000 characters');
+    if (request.reason.length > APPEAL_CONSTRAINTS.REASON_MAX_LENGTH) {
+      throw new BadRequestException(
+        `Appeal reason cannot exceed ${APPEAL_CONSTRAINTS.REASON_MAX_LENGTH} characters`,
+      );
     }
 
     const action = await this.prisma.moderationAction.findUnique({
@@ -550,14 +557,16 @@ export class ModerationActionsService {
       throw new BadRequestException('reasoning is required');
     }
 
-    if (request.reasoning.length < 20) {
+    if (request.reasoning.length < APPEAL_CONSTRAINTS.DECISION_REASONING_MIN_LENGTH) {
       throw new BadRequestException(
-        'Appeal decision reasoning must be at least 20 characters long',
+        `Appeal decision reasoning must be at least ${APPEAL_CONSTRAINTS.DECISION_REASONING_MIN_LENGTH} characters long`,
       );
     }
 
-    if (request.reasoning.length > 2000) {
-      throw new BadRequestException('Appeal decision reasoning cannot exceed 2000 characters');
+    if (request.reasoning.length > APPEAL_CONSTRAINTS.DECISION_REASONING_MAX_LENGTH) {
+      throw new BadRequestException(
+        `Appeal decision reasoning cannot exceed ${APPEAL_CONSTRAINTS.DECISION_REASONING_MAX_LENGTH} characters`,
+      );
     }
 
     const appeal = await this.prisma.appeal.findUnique({


### PR DESCRIPTION
## Summary

Resolves #1166

- Create centralized constants files for discussion-service and moderation-service
- Replace hardcoded magic numbers with named constants for improved maintainability
- All unit tests pass (79/79)

**Created constants files:**

| Service | Constants |
|---------|-----------|
| discussion-service | `CACHE_TTL`, `RESPONSE_CONSTRAINTS`, `SEARCH_DISPLAY`, `PROPOSITION_CONSTRAINTS`, `SLUG_CONSTRAINTS` |
| moderation-service | `CONTENT_SCREENING`, `APPEAL_CONSTRAINTS`, `ACTION_CONSTRAINTS` |

**Files updated:**
- `topics.service.ts` - cache TTLs (5min list, 1hr detail)
- `responses.service.ts` - content length validation (10-10000 chars)
- `discussions.service.ts` - citation limits
- `search.service.ts` - truncation lengths (200/300 chars)
- `slug-generator.service.ts` - slug validation (3-250 chars)
- `moderation.controller.ts` - content screening (10000 max)
- `appeal.service.ts` - appeal validation (20-5000 chars)
- `moderation-actions.service.ts` - action/appeal validation

## Test plan

- [x] All 79 unit tests pass
- [x] TypeScript typecheck passes
- [x] Pre-commit hooks pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.ai/code)