### PR TITLE
docs: add error handling patterns and JSDoc standards (#1168)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -657,6 +657,173 @@ function DiscussionPage() {
 - Preview feedback (composer → metadata panel)
 - Topic selection (left panel → center panel)
 
+### Error Handling Patterns (Backend Services)
+
+The backend services use three primary error handling patterns. Understanding when to use each pattern ensures consistent, predictable behavior across the codebase.
+
+**1. Throw Immediately (Default for Public APIs)**
+
+Use when the caller MUST handle the error case. This is the default pattern for operations where failure is exceptional and requires immediate attention.
+
+```typescript
+// Method naming: get*() - throws if not found
+async getUserById(id: string): Promise<User> {
+  const user = await this.userRepository.findOne({ where: { id } });
+  if (!user) {
+    throw new NotFoundException(`User with ID ${id} not found`);
+  }
+  return user;
+}
+```
+
+- **When to use**: Required resource lookups, validation failures, authorization checks
+- **Caller expectation**: Must handle the exception or let it propagate to error middleware
+
+**2. Return Null/Empty (Query Operations)**
+
+Use when not finding data is a valid outcome, not an error. Common for search, lookup, and optional relationship queries.
+
+```typescript
+// Method naming: find*() - returns null/undefined if not found
+async findUserByEmail(email: string): Promise<User | null> {
+  return this.userRepository.findOne({ where: { email } });
+}
+
+// Method naming: list*() or get*s() - returns empty array if none found
+async listUsersByRole(role: string): Promise<User[]> {
+  return this.userRepository.find({ where: { role } });
+}
+```
+
+- **When to use**: Optional resource lookups, search queries, relationship traversal
+- **Caller expectation**: Check for null/empty before using the result
+
+**3. Fire-and-Forget (Background/Optional Operations)**
+
+Use when operation failure should not affect the main flow. Common for analytics, notifications, and audit logging.
+
+```typescript
+// Method naming: try*() - logs errors, never throws
+async tryUpdateActivityFeed(userId: string, action: string): Promise<void> {
+  try {
+    await this.activityService.record(userId, action);
+  } catch (error) {
+    this.logger.warn(`Failed to update activity feed: ${error.message}`, {
+      userId,
+      action,
+    });
+    // Swallow error - don't affect main operation
+  }
+}
+```
+
+- **When to use**: Analytics, notifications, audit logging, cache updates
+- **Caller expectation**: Operation is best-effort; failure is logged but not propagated
+
+**Pattern Selection Guide**
+
+| Scenario                               | Pattern         | Method Prefix   | Returns                    |
+| -------------------------------------- | --------------- | --------------- | -------------------------- |
+| Required resource lookup               | Throw           | `get*`          | Entity or throws           |
+| Optional resource lookup               | Return null     | `find*`         | Entity \| null             |
+| Collection query                       | Return empty    | `list*`/`get*s` | Array (may be empty)       |
+| Side effect (analytics, notifications) | Fire-and-forget | `try*`          | void                       |
+| Batch operations with partial success  | Return partial  | varies          | Array with status per item |
+
+**Current Codebase Notes**
+
+The existing codebase has some inconsistencies with these patterns:
+
+- Some `find*` methods at service level throw instead of returning null
+- No `try*` methods exist yet (fire-and-forget uses inline try/catch)
+- UUID validation throws in some places, returns false in others
+
+New code should follow these conventions. Existing code can be migrated gradually as files are touched.
+
+### JSDoc Documentation Standards
+
+All public methods in backend services should include JSDoc documentation with the following tags.
+
+**Required Tags for Public Methods**
+
+```typescript
+/**
+ * Brief one-line description of what the method does.
+ *
+ * @param id - The user's unique identifier (UUID format)
+ * @param options - Optional query parameters
+ * @returns The user entity with profile data populated
+ * @throws {NotFoundException} When user with given ID doesn't exist
+ * @throws {ForbiddenException} When caller lacks permission to view user
+ */
+async getUserById(id: string, options?: QueryOptions): Promise<User> {
+  // implementation
+}
+```
+
+**Tag Reference**
+
+| Tag         | Required      | Description                                 |
+| ----------- | ------------- | ------------------------------------------- |
+| Description | Yes           | First line, no tag needed                   |
+| `@param`    | Yes           | Each parameter with type hint and meaning   |
+| `@returns`  | Yes           | Return type and what it represents          |
+| `@throws`   | If applicable | Each exception type with condition          |
+| `@remarks`  | Optional      | Additional context, caveats, or usage notes |
+| `@example`  | Optional      | Code example for complex methods            |
+
+**@throws Format**
+
+Always specify the exception class and the condition that triggers it:
+
+```typescript
+// Good - specific condition
+@throws {NotFoundException} When user with given ID doesn't exist
+
+// Good - multiple conditions for same exception type
+@throws {BadRequestException} When email format is invalid
+@throws {BadRequestException} When password doesn't meet requirements
+
+// Avoid - too vague
+@throws {Error} When something goes wrong
+```
+
+**When to Skip JSDoc**
+
+- Private methods (unless complex logic warrants documentation)
+- Simple getters/setters with obvious purpose
+- Methods where the signature is completely self-documenting
+- Test files
+
+**Example: Full Documentation**
+
+````typescript
+/**
+ * Creates a new user account with email verification.
+ *
+ * @remarks
+ * The user will receive a verification email after creation.
+ * Account remains inactive until email is verified.
+ *
+ * @param dto - User registration data
+ * @returns The created user (without password hash)
+ * @throws {ConflictException} When email is already registered
+ * @throws {BadRequestException} When password doesn't meet requirements
+ *
+ * @example
+ * ```typescript
+ * const user = await usersService.createUser({
+ *   email: 'user@example.com',
+ *   password: 'SecurePass123!',
+ *   displayName: 'John Doe',
+ * });
+ * ```
+ */
+async createUser(dto: CreateUserDto): Promise<User> {
+  // implementation
+}
+````
+
 ## Speckit Workflow
 
 The project uses a structured feature development process through Claude Code slash commands:

--- a/docs/patterns/error-handling.md
+++ b/docs/patterns/error-handling.md
@@ -1,0 +1,438 @@
+# Error Handling Patterns Reference
+
+This document provides concrete examples and migration guidance for error handling patterns in reasonBridge backend services.
+
+## Quick Reference
+
+| Pattern           | Method Prefix   | Returns          | Use Case                     |
+| ----------------- | --------------- | ---------------- | ---------------------------- |
+| Throw Immediately | `get*`          | Entity or throws | Required lookups, validation |
+| Return Null       | `find*`         | Entity \| null   | Optional lookups             |
+| Return Empty      | `list*`/`get*s` | Array            | Collection queries           |
+| Fire-and-Forget   | `try*`          | void             | Analytics, notifications     |
+
+## Pattern 1: Throw Immediately
+
+### When to Use
+
+- Required resource lookups where absence is an error
+- Validation failures
+- Authorization checks
+- Operations that must succeed for the flow to continue
+
+### Code Examples
+
+**User Service - Required Lookup**
+
+```typescript
+// services/user-service/src/users/users.service.ts
+
+/**
+ * Retrieves a user by their unique identifier.
+ *
+ * @param id - The user's UUID
+ * @returns The user entity
+ * @throws {NotFoundException} When user with given ID doesn't exist
+ */
+async getUserById(id: string): Promise<User> {
+  if (!isValidUUID(id)) {
+    throw new BadRequestException('Invalid user ID format');
+  }
+
+  const user = await this.userRepository.findOne({ where: { id } });
+  if (!user) {
+    throw new NotFoundException(`User with ID ${id} not found`);
+  }
+  return user;
+}
+```
+
+**Discussion Service - Authorization Check**
+
+```typescript
+// services/discussion-service/src/topics/topics.service.ts
+
+/**
+ * Updates a topic's details.
+ *
+ * @param id - The topic's UUID
+ * @param dto - Update data
+ * @param userId - The requesting user's ID
+ * @returns The updated topic
+ * @throws {NotFoundException} When topic doesn't exist
+ * @throws {ForbiddenException} When user isn't the topic creator
+ */
+async updateTopic(id: string, dto: UpdateTopicDto, userId: string): Promise<Topic> {
+  const topic = await this.getTopicById(id); // Throws if not found
+
+  if (topic.creatorId !== userId) {
+    throw new ForbiddenException('Only the topic creator can update this topic');
+  }
+
+  return this.topicRepository.save({ ...topic, ...dto });
+}
+```
+
+### Controller Integration
+
+Controllers should let exceptions propagate to NestJS exception filters:
+
+```typescript
+@Get(':id')
+async getUser(@Param('id') id: string): Promise<UserResponseDto> {
+  // Let NotFoundException propagate - NestJS handles 404 response
+  const user = await this.usersService.getUserById(id);
+  return this.mapToDto(user);
+}
+```
+
+## Pattern 2: Return Null/Empty
+
+### When to Use
+
+- Optional resource lookups (email lookup for login)
+- Search queries
+- Relationship traversal (user's optional profile)
+- Conditional operations (find or create)
+
+### Code Examples
+
+**User Service - Optional Lookup**
+
+```typescript
+// services/user-service/src/users/users.service.ts
+
+/**
+ * Finds a user by email address.
+ *
+ * @param email - The email to search for
+ * @returns The user if found, null otherwise
+ */
+async findUserByEmail(email: string): Promise<User | null> {
+  return this.userRepository.findOne({
+    where: { email: email.toLowerCase() },
+  });
+}
+
+// Caller handles the null case
+async login(email: string, password: string): Promise<AuthResponse> {
+  const user = await this.findUserByEmail(email);
+  if (!user) {
+    throw new UnauthorizedException('Invalid credentials');
+  }
+  // Continue with password verification...
+}
+```
+
+**Discussion Service - Collection Query**
+
+```typescript
+// services/discussion-service/src/responses/responses.service.ts
+
+/**
+ * Lists all responses for a topic.
+ *
+ * @param topicId - The topic's UUID
+ * @param options - Pagination and sorting options
+ * @returns Array of responses (empty if none exist)
+ */
+async listResponsesByTopic(
+  topicId: string,
+  options?: PaginationOptions,
+): Promise<Response[]> {
+  return this.responseRepository.find({
+    where: { topicId },
+    order: { createdAt: 'DESC' },
+    take: options?.limit ?? 50,
+    skip: options?.offset ?? 0,
+  });
+}
+```
+
+**Find or Create Pattern**
+
+```typescript
+/**
+ * Finds an existing session or creates a new one.
+ *
+ * @param userId - The user's UUID
+ * @returns The existing or newly created session
+ */
+async findOrCreateSession(userId: string): Promise<Session> {
+  let session = await this.findActiveSession(userId);
+
+  if (!session) {
+    session = await this.createSession(userId);
+  }
+
+  return session;
+}
+```
+
+## Pattern 3: Fire-and-Forget
+
+### When to Use
+
+- Analytics and telemetry
+- Notification sending
+- Audit logging
+- Cache updates
+- Activity feed updates
+
+### Code Examples
+
+**Activity Service - Best Effort Recording**
+
+```typescript
+// services/activity-service/src/activity/activity.service.ts
+
+/**
+ * Attempts to record a user activity. Failures are logged but not propagated.
+ *
+ * @param userId - The user who performed the action
+ * @param action - The action type
+ * @param metadata - Additional context
+ */
+async tryRecordActivity(
+  userId: string,
+  action: string,
+  metadata?: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await this.activityRepository.save({
+      userId,
+      action,
+      metadata,
+      timestamp: new Date(),
+    });
+  } catch (error) {
+    this.logger.warn('Failed to record activity', {
+      userId,
+      action,
+      error: error.message,
+    });
+    // Don't throw - caller shouldn't fail because activity logging failed
+  }
+}
+```
+
+**Notification Service - Non-blocking Send**
+
+```typescript
+// services/notification-service/src/notifications/notifications.service.ts
+
+/**
+ * Attempts to send a notification. Failures are queued for retry.
+ *
+ * @param userId - The recipient's UUID
+ * @param notification - The notification content
+ */
+async trySendNotification(
+  userId: string,
+  notification: NotificationPayload,
+): Promise<void> {
+  try {
+    await this.notificationGateway.send(userId, notification);
+  } catch (error) {
+    this.logger.warn('Failed to send notification, queuing for retry', {
+      userId,
+      type: notification.type,
+      error: error.message,
+    });
+
+    // Queue for retry instead of failing
+    await this.retryQueue.add({ userId, notification });
+  }
+}
+```
+
+### Integration in Main Flow
+
+```typescript
+async createResponse(dto: CreateResponseDto, userId: string): Promise<Response> {
+  const response = await this.responseRepository.save({
+    ...dto,
+    authorId: userId,
+  });
+
+  // Fire-and-forget: Don't await, don't let failures affect the response
+  this.tryRecordActivity(userId, 'RESPONSE_CREATED', { responseId: response.id });
+  this.trySendNotification(dto.topicCreatorId, {
+    type: 'NEW_RESPONSE',
+    topicId: dto.topicId,
+  });
+
+  return response;
+}
+```
+
+## Migration Guide
+
+### Identifying Code to Migrate
+
+**Find methods that throw but should return null:**
+
+```bash
+# Look for find* methods that throw NotFoundException
+grep -rn "async find" services/*/src/**/*.service.ts | head -20
+```
+
+**Find fire-and-forget candidates:**
+
+```bash
+# Look for try/catch blocks that only log
+grep -rn "catch.*error" services/*/src/**/*.service.ts -A 3 | grep -B 1 "logger"
+```
+
+### Step-by-Step Migration
+
+1. **Identify the method's contract**
+   - Is the caller expecting the method to throw on not-found?
+   - Are there multiple callers with different expectations?
+
+2. **Update the method signature**
+
+   ```typescript
+   // Before
+   async findUser(id: string): Promise<User>
+
+   // After
+   async findUser(id: string): Promise<User | null>
+   ```
+
+3. **Update JSDoc**
+
+   ```typescript
+   /**
+    * @returns The user if found, null otherwise
+    */
+   ```
+
+4. **Update all callers**
+
+   ```typescript
+   // Before
+   const user = await this.findUser(id);
+
+   // After
+   const user = await this.findUser(id);
+   if (!user) {
+     throw new NotFoundException('User not found');
+   }
+   ```
+
+5. **Add tests for null case**
+   ```typescript
+   it('should return null when user not found', async () => {
+     const result = await service.findUser('nonexistent-id');
+     expect(result).toBeNull();
+   });
+   ```
+
+### Handling Dual Requirements
+
+When both throwing and returning patterns are needed:
+
+```typescript
+/**
+ * Finds a user by ID, returns null if not found.
+ */
+async findUserById(id: string): Promise<User | null> {
+  return this.userRepository.findOne({ where: { id } });
+}
+
+/**
+ * Gets a user by ID, throws if not found.
+ */
+async getUserById(id: string): Promise<User> {
+  const user = await this.findUserById(id);
+  if (!user) {
+    throw new NotFoundException(`User ${id} not found`);
+  }
+  return user;
+}
+```
+
+## PR Review Checklist
+
+When reviewing PRs that add or modify service methods:
+
+- [ ] Method prefix matches return behavior (`get*` throws, `find*` returns null)
+- [ ] JSDoc includes `@throws` for all exception cases
+- [ ] JSDoc includes `@returns` describing null/empty cases
+- [ ] Fire-and-forget methods are prefixed with `try*`
+- [ ] Fire-and-forget methods log errors but don't propagate them
+- [ ] Collection queries return empty arrays, not null
+- [ ] Tests cover error/null/empty cases
+
+## Common Anti-Patterns
+
+### Anti-Pattern: Silent Failure Without Logging
+
+```typescript
+// BAD - Swallows error without any indication
+async updateCache(key: string, value: unknown): Promise<void> {
+  try {
+    await this.redis.set(key, value);
+  } catch {
+    // Silent failure - impossible to diagnose issues
+  }
+}
+
+// GOOD - Logs the failure for observability
+async tryUpdateCache(key: string, value: unknown): Promise<void> {
+  try {
+    await this.redis.set(key, value);
+  } catch (error) {
+    this.logger.warn('Cache update failed', { key, error: error.message });
+  }
+}
+```
+
+### Anti-Pattern: Inconsistent Null Handling
+
+```typescript
+// BAD - Returns null in some cases, throws in others
+async findUser(id: string): Promise<User | null> {
+  if (!isValidUUID(id)) {
+    throw new BadRequestException('Invalid ID'); // Throws here
+  }
+  return this.userRepository.findOne({ where: { id } }); // Returns null here
+}
+
+// GOOD - Consistent behavior
+async findUser(id: string): Promise<User | null> {
+  if (!isValidUUID(id)) {
+    return null; // Invalid ID means no user found
+  }
+  return this.userRepository.findOne({ where: { id } });
+}
+
+// OR - If validation should throw, use get* naming
+async getUser(id: string): Promise<User> {
+  if (!isValidUUID(id)) {
+    throw new BadRequestException('Invalid ID');
+  }
+  const user = await this.userRepository.findOne({ where: { id } });
+  if (!user) {
+    throw new NotFoundException('User not found');
+  }
+  return user;
+}
+```
+
+### Anti-Pattern: Generic Exception Messages
+
+```typescript
+// BAD - Unhelpful error message
+throw new NotFoundException('Not found');
+
+// GOOD - Specific, actionable message
+throw new NotFoundException(`Topic with ID ${topicId} not found`);
+```
+
+## See Also
+
+- [CLAUDE.md - Implementation Patterns](../../CLAUDE.md#error-handling-patterns-backend-services)
+- [CLAUDE.md - JSDoc Standards](../../CLAUDE.md#jsdoc-documentation-standards)
+- [NestJS Exception Filters](https://docs.nestjs.com/exception-filters)


### PR DESCRIPTION
## Summary
- Add Error Handling Patterns section to CLAUDE.md documenting get*/find*/try* conventions
- Add JSDoc Documentation Standards section with @throws/@returns guidance
- Create `docs/patterns/error-handling.md` with concrete examples and migration guide

## Test plan
- [x] Verify lint passes
- [x] Verify formatting passes (prettier)
- [x] Documentation-only change, no code tests needed

Closes #1168

🤖 Generated with [Claude Code](https://claude.com/claude-code)