### PR TITLE
fix(tests): remove --workspace flag for vitest 4.x contract tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:unit:coverage": "vitest run --coverage --passWithNoTests",
     "test:integration": "vitest run --config vitest.integration.config.ts --passWithNoTests",
     "test:e2e": "pnpm --filter frontend test:e2e",
-    "test:contract": "vitest run --config vitest.contract.config.ts --workspace vitest.contract.workspace.ts --passWithNoTests",
+    "test:contract": "vitest run --config vitest.contract.config.ts --passWithNoTests",
     "lint": "eslint . && pnpm --filter @reason-bridge/frontend lint",
     "lint:fix": "eslint . --fix && pnpm --filter @reason-bridge/frontend lint:fix",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md,yaml,yml}\"",


### PR DESCRIPTION
## Summary
- Remove deprecated `--workspace` CLI flag from contract tests command
- Vitest 4.x removed this flag; workspace config is now handled via config file

## Problem
Contract tests were failing in CI with:
```
CACError: Unknown option `--workspace`
```

This caused build #540 on main to be marked as UNSTABLE.

## Solution
Remove `--workspace vitest.contract.workspace.ts` from the `test:contract` script. The workspace file only wraps the contract config, so we can use the config directly.

## Test plan
- [x] Verified contract tests pass locally: `pnpm test:contract` (22 tests pass)
- [ ] CI should pass after merge

🤖 Generated with [Claude Code](https://claude.ai/code)