### PR TITLE
refactor(services): standardize error handling method naming conventions

### DIFF
--- a/services/ai-service/src/__tests__/ai-inflammatory-detection.test.ts
+++ b/services/ai-service/src/__tests__/ai-inflammatory-detection.test.ts
@@ -40,7 +40,7 @@ const createMockSemanticCache = () => ({
 
 // Mock the Redis cache
 const createMockRedisCache = () => ({
-  getFeedback: vi.fn().mockResolvedValue(null),
+  findFeedback: vi.fn().mockResolvedValue(null),
   setFeedback: vi.fn().mockResolvedValue(undefined),
 });
 

--- a/services/ai-service/src/cache/__tests__/embedding.service.spec.ts
+++ b/services/ai-service/src/cache/__tests__/embedding.service.spec.ts
@@ -38,12 +38,12 @@ describe('EmbeddingService', () => {
     service = module.get<EmbeddingService>(EmbeddingService);
   });
 
-  describe('getEmbedding', () => {
+  describe('findEmbedding', () => {
     it('should return cached embedding if available', async () => {
       const cachedEmbedding = [0.1, 0.2, 0.3];
       mockCacheManager.get.mockResolvedValue(cachedEmbedding);
 
-      const result = await service.getEmbedding('test content');
+      const result = await service.findEmbedding('test content');
 
       expect(result).toEqual(cachedEmbedding);
       expect(mockOpenAI.embeddings.create).not.toHaveBeenCalled();
@@ -56,7 +56,7 @@ describe('EmbeddingService', () => {
         data: [{ embedding }],
       });
 
-      const result = await service.getEmbedding('test content');
+      const result = await service.findEmbedding('test content');
 
       expect(result).toEqual(embedding);
       expect(mockOpenAI.embeddings.create).toHaveBeenCalledWith({
@@ -72,7 +72,7 @@ describe('EmbeddingService', () => {
         data: [{ embedding: [0.1] }],
       });
 
-      await service.getEmbedding('test content');
+      await service.findEmbedding('test content');
 
       expect(mockCacheManager.get).toHaveBeenCalledWith(
         expect.stringMatching(/^feedback:embedding:[a-f0-9]{64}$/),
@@ -85,7 +85,7 @@ describe('EmbeddingService', () => {
         data: [{ embedding: [0.1, 0.2] }],
       });
 
-      await service.getEmbedding('test content');
+      await service.findEmbedding('test content');
 
       // 7 days in milliseconds = 604800 * 1000
       expect(mockCacheManager.set).toHaveBeenCalledWith(
@@ -101,18 +101,18 @@ describe('EmbeddingService', () => {
         data: [],
       });
 
-      await expect(service.getEmbedding('test content')).rejects.toThrow(
+      await expect(service.findEmbedding('test content')).rejects.toThrow(
         'No embedding returned from OpenAI',
       );
     });
   });
 
-  describe('getCachedEmbedding', () => {
+  describe('findCachedEmbedding', () => {
     it('should return cached embedding without generating new one', async () => {
       const cachedEmbedding = [0.1, 0.2, 0.3];
       mockCacheManager.get.mockResolvedValue(cachedEmbedding);
 
-      const result = await service.getCachedEmbedding('test content');
+      const result = await service.findCachedEmbedding('test content');
 
       expect(result).toEqual(cachedEmbedding);
       expect(mockOpenAI.embeddings.create).not.toHaveBeenCalled();
@@ -121,7 +121,7 @@ describe('EmbeddingService', () => {
     it('should return null when no cached embedding exists', async () => {
       mockCacheManager.get.mockResolvedValue(null);
 
-      const result = await service.getCachedEmbedding('test content');
+      const result = await service.findCachedEmbedding('test content');
 
       expect(result).toBeNull();
       expect(mockOpenAI.embeddings.create).not.toHaveBeenCalled();

--- a/services/ai-service/src/cache/__tests__/redis-cache.service.spec.ts
+++ b/services/ai-service/src/cache/__tests__/redis-cache.service.spec.ts
@@ -22,7 +22,7 @@ describe('RedisCacheService', () => {
     service = module.get<RedisCacheService>(RedisCacheService);
   });
 
-  describe('getFeedback', () => {
+  describe('findFeedback', () => {
     it('should return cached feedback for content hash', async () => {
       const cached = {
         type: FeedbackType.FALLACY,
@@ -32,7 +32,7 @@ describe('RedisCacheService', () => {
       };
       mockCacheManager.get.mockResolvedValue(cached);
 
-      const result = await service.getFeedback('abc123');
+      const result = await service.findFeedback('abc123');
 
       expect(result).toEqual(cached);
       expect(mockCacheManager.get).toHaveBeenCalledWith('feedback:exact:abc123');
@@ -41,7 +41,7 @@ describe('RedisCacheService', () => {
     it('should return null on cache miss', async () => {
       mockCacheManager.get.mockResolvedValue(null);
 
-      const result = await service.getFeedback('abc123');
+      const result = await service.findFeedback('abc123');
 
       expect(result).toBeNull();
     });
@@ -49,7 +49,7 @@ describe('RedisCacheService', () => {
     it('should return null on cache error and not throw', async () => {
       mockCacheManager.get.mockRejectedValue(new Error('Redis connection failed'));
 
-      const result = await service.getFeedback('abc123');
+      const result = await service.findFeedback('abc123');
 
       expect(result).toBeNull();
     });

--- a/services/ai-service/src/cache/__tests__/semantic-cache.service.spec.ts
+++ b/services/ai-service/src/cache/__tests__/semantic-cache.service.spec.ts
@@ -8,14 +8,14 @@ import { FeedbackType } from '@prisma/client';
 describe('SemanticCacheService', () => {
   let service: SemanticCacheService;
   let mockEmbeddingService: {
-    getEmbedding: ReturnType<typeof vi.fn>;
+    findEmbedding: ReturnType<typeof vi.fn>;
   };
   let mockQdrantService: {
     searchSimilar: ReturnType<typeof vi.fn>;
     store: ReturnType<typeof vi.fn>;
   };
   let mockRedisCacheService: {
-    getFeedback: ReturnType<typeof vi.fn>;
+    findFeedback: ReturnType<typeof vi.fn>;
     setFeedback: ReturnType<typeof vi.fn>;
   };
 
@@ -29,7 +29,7 @@ describe('SemanticCacheService', () => {
 
   beforeEach(() => {
     mockEmbeddingService = {
-      getEmbedding: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+      findEmbedding: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
     };
 
     mockQdrantService = {
@@ -38,7 +38,7 @@ describe('SemanticCacheService', () => {
     };
 
     mockRedisCacheService = {
-      getFeedback: vi.fn().mockResolvedValue(null),
+      findFeedback: vi.fn().mockResolvedValue(null),
       setFeedback: vi.fn().mockResolvedValue(undefined),
     };
 
@@ -52,18 +52,18 @@ describe('SemanticCacheService', () => {
 
   describe('getOrAnalyze', () => {
     it('should return Redis cached result on exact match', async () => {
-      mockRedisCacheService.getFeedback.mockResolvedValue(mockAnalysisResult);
+      mockRedisCacheService.findFeedback.mockResolvedValue(mockAnalysisResult);
 
       const analyzeFunc = vi.fn();
       const result = await service.getOrAnalyze('test content', analyzeFunc);
 
       expect(result).toEqual(mockAnalysisResult);
       expect(analyzeFunc).not.toHaveBeenCalled();
-      expect(mockEmbeddingService.getEmbedding).not.toHaveBeenCalled();
+      expect(mockEmbeddingService.findEmbedding).not.toHaveBeenCalled();
     });
 
     it('should return Qdrant cached result on similarity match', async () => {
-      mockRedisCacheService.getFeedback.mockResolvedValue(null);
+      mockRedisCacheService.findFeedback.mockResolvedValue(null);
       mockQdrantService.searchSimilar.mockResolvedValue({
         result: mockAnalysisResult,
         similarity: 0.97,
@@ -77,7 +77,7 @@ describe('SemanticCacheService', () => {
     });
 
     it('should call analyzer and cache result on cache miss', async () => {
-      mockRedisCacheService.getFeedback.mockResolvedValue(null);
+      mockRedisCacheService.findFeedback.mockResolvedValue(null);
       mockQdrantService.searchSimilar.mockResolvedValue(null);
 
       const analyzeFunc = vi.fn().mockResolvedValue(mockAnalysisResult);
@@ -92,8 +92,8 @@ describe('SemanticCacheService', () => {
     });
 
     it('should handle embedding service failure gracefully', async () => {
-      mockRedisCacheService.getFeedback.mockResolvedValue(null);
-      mockEmbeddingService.getEmbedding.mockRejectedValue(new Error('OpenAI error'));
+      mockRedisCacheService.findFeedback.mockResolvedValue(null);
+      mockEmbeddingService.findEmbedding.mockRejectedValue(new Error('OpenAI error'));
 
       const analyzeFunc = vi.fn().mockResolvedValue(mockAnalysisResult);
       const result = await service.getOrAnalyze('test content', analyzeFunc);
@@ -103,7 +103,7 @@ describe('SemanticCacheService', () => {
     });
 
     it('should handle Qdrant failure gracefully', async () => {
-      mockRedisCacheService.getFeedback.mockResolvedValue(null);
+      mockRedisCacheService.findFeedback.mockResolvedValue(null);
       mockQdrantService.searchSimilar.mockRejectedValue(new Error('Qdrant error'));
 
       const analyzeFunc = vi.fn().mockResolvedValue(mockAnalysisResult);
@@ -114,7 +114,7 @@ describe('SemanticCacheService', () => {
     });
 
     it('should also cache Qdrant hit in Redis for faster future lookups', async () => {
-      mockRedisCacheService.getFeedback.mockResolvedValue(null);
+      mockRedisCacheService.findFeedback.mockResolvedValue(null);
       mockQdrantService.searchSimilar.mockResolvedValue({
         result: mockAnalysisResult,
         similarity: 0.96,
@@ -130,7 +130,7 @@ describe('SemanticCacheService', () => {
 
   describe('lookup', () => {
     it('should return redis hit when content is in Redis', async () => {
-      mockRedisCacheService.getFeedback.mockResolvedValue(mockAnalysisResult);
+      mockRedisCacheService.findFeedback.mockResolvedValue(mockAnalysisResult);
 
       const result = await service.lookup('test content');
 
@@ -142,7 +142,7 @@ describe('SemanticCacheService', () => {
     });
 
     it('should return qdrant hit when content is similar in Qdrant', async () => {
-      mockRedisCacheService.getFeedback.mockResolvedValue(null);
+      mockRedisCacheService.findFeedback.mockResolvedValue(null);
       mockQdrantService.searchSimilar.mockResolvedValue({
         result: mockAnalysisResult,
         similarity: 0.98,
@@ -159,7 +159,7 @@ describe('SemanticCacheService', () => {
     });
 
     it('should return cache miss when content not found', async () => {
-      mockRedisCacheService.getFeedback.mockResolvedValue(null);
+      mockRedisCacheService.findFeedback.mockResolvedValue(null);
       mockQdrantService.searchSimilar.mockResolvedValue(null);
 
       const result = await service.lookup('test content');

--- a/services/ai-service/src/cache/embedding.service.ts
+++ b/services/ai-service/src/cache/embedding.service.ts
@@ -38,10 +38,12 @@ export class EmbeddingService {
   }
 
   /**
-   * Get embedding for content, using cache when available.
-   * Returns null if OpenAI is not configured.
+   * Find embedding for content, using cache when available.
+   *
+   * @param content - The text content to get embeddings for
+   * @returns The embedding vector if available, null if OpenAI is not configured
    */
-  async getEmbedding(content: string): Promise<number[] | null> {
+  async findEmbedding(content: string): Promise<number[] | null> {
     // Return null if OpenAI is not available
     if (!this.isAvailable || !this.openai) {
       this.logger.debug('OpenAI not available, skipping embedding generation');
@@ -77,9 +79,12 @@ export class EmbeddingService {
   }
 
   /**
-   * Get cached embedding without generating new one
+   * Find a cached embedding without generating a new one.
+   *
+   * @param content - The text content to look up
+   * @returns The cached embedding if found, null otherwise
    */
-  async getCachedEmbedding(content: string): Promise<number[] | null> {
+  async findCachedEmbedding(content: string): Promise<number[] | null> {
     const contentHash = computeContentHash(content);
     const cacheKey = `${EMBEDDING_CACHE_PREFIX}${contentHash}`;
     const cached = await this.cache.get<number[]>(cacheKey);

--- a/services/ai-service/src/cache/redis-cache.service.ts
+++ b/services/ai-service/src/cache/redis-cache.service.ts
@@ -33,9 +33,9 @@ export class RedisCacheService {
    * Get cached feedback by content hash.
    *
    * @param contentHash - SHA-256 hash of the normalized content
-   * @returns Cached AnalysisResult or null if not found
+   * @returns Cached AnalysisResult if found, null otherwise
    */
-  async getFeedback(contentHash: string): Promise<AnalysisResult | null> {
+  async findFeedback(contentHash: string): Promise<AnalysisResult | null> {
     const cacheKey = `${FEEDBACK_CACHE_PREFIX}${contentHash}`;
     try {
       const cached = await this.cache.get<AnalysisResult>(cacheKey);

--- a/services/ai-service/src/cache/semantic-cache.service.ts
+++ b/services/ai-service/src/cache/semantic-cache.service.ts
@@ -56,7 +56,7 @@ export class SemanticCacheService {
     const contentHash = computeContentHash(content);
 
     // 1. Check Redis for exact match (fastest path)
-    const redisResult = await this.redisCacheService.getFeedback(contentHash);
+    const redisResult = await this.redisCacheService.findFeedback(contentHash);
     if (redisResult) {
       this.logger.debug('Cache hit: Redis exact match');
       return redisResult;
@@ -65,7 +65,7 @@ export class SemanticCacheService {
     // 2. Try Qdrant similarity search (only if embeddings are available)
     let embedding: number[] | null = null;
     try {
-      embedding = await this.embeddingService.getEmbedding(content);
+      embedding = await this.embeddingService.findEmbedding(content);
       if (embedding) {
         const qdrantResult = await this.qdrantService.searchSimilar(
           embedding,
@@ -103,14 +103,14 @@ export class SemanticCacheService {
     const contentHash = computeContentHash(content);
 
     // Check Redis
-    const redisResult = await this.redisCacheService.getFeedback(contentHash);
+    const redisResult = await this.redisCacheService.findFeedback(contentHash);
     if (redisResult) {
       return { hit: true, source: 'redis', result: redisResult };
     }
 
     // Check Qdrant (only if embeddings are available)
     try {
-      const embedding = await this.embeddingService.getEmbedding(content);
+      const embedding = await this.embeddingService.findEmbedding(content);
       if (embedding) {
         const qdrantResult = await this.qdrantService.searchSimilar(
           embedding,
@@ -166,7 +166,7 @@ export class SemanticCacheService {
   ): Promise<void> {
     try {
       // Get or generate embedding
-      const vectorEmbedding = embedding ?? (await this.embeddingService.getEmbedding(content));
+      const vectorEmbedding = embedding ?? (await this.embeddingService.findEmbedding(content));
 
       // Skip Qdrant storage if embeddings are not available
       if (!vectorEmbedding) {

--- a/services/ai-service/src/feedback/__tests__/feedback.service.spec.ts
+++ b/services/ai-service/src/feedback/__tests__/feedback.service.spec.ts
@@ -52,7 +52,7 @@ describe('FeedbackService', () => {
       complete: vi.fn().mockResolvedValue(''),
     };
     mockRedisCacheService = {
-      getFeedback: vi.fn().mockResolvedValue(null),
+      findFeedback: vi.fn().mockResolvedValue(null),
       setFeedback: vi.fn().mockResolvedValue(undefined),
     };
 
@@ -158,13 +158,13 @@ describe('FeedbackService', () => {
         reasoning: 'From cache',
         confidenceScore: 0.9,
       };
-      mockRedisCacheService.getFeedback = vi.fn().mockResolvedValue(cachedResult);
+      mockRedisCacheService.findFeedback = vi.fn().mockResolvedValue(cachedResult);
 
       const result = await service.previewFeedback({
         content: 'Cached content',
       });
 
-      expect(mockRedisCacheService.getFeedback).toHaveBeenCalled();
+      expect(mockRedisCacheService.findFeedback).toHaveBeenCalled();
       expect(mockAnalyzerService.analyzeContentFull).not.toHaveBeenCalled();
       expect(result.feedback.length).toBe(1);
       expect(result.feedback[0]?.suggestionText).toBe('Cached result');
@@ -182,7 +182,7 @@ describe('FeedbackService', () => {
     });
 
     it('should gracefully handle Redis cache errors', async () => {
-      mockRedisCacheService.getFeedback = vi.fn().mockRejectedValue(new Error('Redis error'));
+      mockRedisCacheService.findFeedback = vi.fn().mockRejectedValue(new Error('Redis error'));
 
       const result = await service.previewFeedback({
         content: 'Test content',

--- a/services/ai-service/src/feedback/feedback.service.ts
+++ b/services/ai-service/src/feedback/feedback.service.ts
@@ -157,7 +157,7 @@ export class FeedbackService {
     // Try Redis cache first for fast response
     const contentHash = computeContentHash(dto.content);
     try {
-      const cached = await this.redisCache?.getFeedback(contentHash);
+      const cached = await this.redisCache?.findFeedback(contentHash);
       if (cached) {
         // Cache hit - use cached result (wrapped in array for consistency)
         analysisResults = [cached];
@@ -242,7 +242,7 @@ export class FeedbackService {
     try {
       // Try Redis cache first
       const contentHash = computeContentHash(`ai:${dto.content}`);
-      const cached = await this.redisCache?.getFeedback(contentHash);
+      const cached = await this.redisCache?.findFeedback(contentHash);
 
       let analysisResults: AnalysisResult[];
 

--- a/services/ai-service/src/services/topic-duplicate-detector.service.test.ts
+++ b/services/ai-service/src/services/topic-duplicate-detector.service.test.ts
@@ -8,8 +8,8 @@ import { TopicDuplicateDetectorService } from './topic-duplicate-detector.servic
 import type { DuplicateCandidate } from './topic-duplicate-detector.service.js';
 
 const createMockEmbeddingService = () => ({
-  getEmbedding: vi.fn(),
-  getCachedEmbedding: vi.fn(),
+  findEmbedding: vi.fn(),
+  findCachedEmbedding: vi.fn(),
 });
 
 describe('TopicDuplicateDetectorService', () => {
@@ -26,7 +26,7 @@ describe('TopicDuplicateDetectorService', () => {
     it('should return similarity score when embeddings are available', async () => {
       // Mock embeddings - identical vectors should have similarity ~1.0
       const embedding = [0.1, 0.2, 0.3, 0.4, 0.5];
-      mockEmbeddingService.getEmbedding.mockResolvedValue(embedding);
+      mockEmbeddingService.findEmbedding.mockResolvedValue(embedding);
 
       const result = await service.computeSemanticSimilarity(
         'Climate change',
@@ -36,11 +36,11 @@ describe('TopicDuplicateDetectorService', () => {
       );
 
       expect(result).toBe(1.0);
-      expect(mockEmbeddingService.getEmbedding).toHaveBeenCalledTimes(2);
+      expect(mockEmbeddingService.findEmbedding).toHaveBeenCalledTimes(2);
     });
 
     it('should return null when embeddings are unavailable', async () => {
-      mockEmbeddingService.getEmbedding.mockResolvedValue(null);
+      mockEmbeddingService.findEmbedding.mockResolvedValue(null);
 
       const result = await service.computeSemanticSimilarity(
         'Climate change',
@@ -57,7 +57,7 @@ describe('TopicDuplicateDetectorService', () => {
       const embedding1 = [1.0, 0.0, 0.0];
       const embedding2 = [0.707, 0.707, 0.0]; // 45 degrees apart, cos(45) ≈ 0.707
 
-      mockEmbeddingService.getEmbedding
+      mockEmbeddingService.findEmbedding
         .mockResolvedValueOnce(embedding1)
         .mockResolvedValueOnce(embedding2);
 
@@ -75,7 +75,7 @@ describe('TopicDuplicateDetectorService', () => {
       const embedding1 = [1.0, 0.0, 0.0];
       const embedding2 = [0.0, 1.0, 0.0]; // Orthogonal
 
-      mockEmbeddingService.getEmbedding
+      mockEmbeddingService.findEmbedding
         .mockResolvedValueOnce(embedding1)
         .mockResolvedValueOnce(embedding2);
 
@@ -111,7 +111,7 @@ describe('TopicDuplicateDetectorService', () => {
 
       // Mock high semantic similarity
       const embedding = [0.1, 0.2, 0.3, 0.4, 0.5];
-      mockEmbeddingService.getEmbedding.mockResolvedValue(embedding);
+      mockEmbeddingService.findEmbedding.mockResolvedValue(embedding);
 
       const result = await service.analyzeCandidates(
         'Climate Change Discussion',
@@ -135,7 +135,7 @@ describe('TopicDuplicateDetectorService', () => {
         },
       ];
 
-      mockEmbeddingService.getEmbedding.mockResolvedValue(null);
+      mockEmbeddingService.findEmbedding.mockResolvedValue(null);
 
       const result = await service.analyzeCandidates(
         'Healthcare Reform',
@@ -163,7 +163,7 @@ describe('TopicDuplicateDetectorService', () => {
       const embedding1 = [1.0, 0.0];
       const embedding2 = [0.6, 0.8]; // cos similarity ≈ 0.6
 
-      mockEmbeddingService.getEmbedding
+      mockEmbeddingService.findEmbedding
         .mockResolvedValueOnce(embedding1)
         .mockResolvedValueOnce(embedding2);
 
@@ -184,7 +184,7 @@ describe('TopicDuplicateDetectorService', () => {
       ];
 
       const embedding = [0.5, 0.5, 0.5];
-      mockEmbeddingService.getEmbedding.mockResolvedValue(embedding);
+      mockEmbeddingService.findEmbedding.mockResolvedValue(embedding);
 
       const result = await service.analyzeCandidates(
         'Identical Topic',
@@ -210,7 +210,7 @@ describe('TopicDuplicateDetectorService', () => {
       const embedding1 = [1.0, 0.0, 0.0];
       const embedding2 = [0.0, 0.0, 1.0];
 
-      mockEmbeddingService.getEmbedding
+      mockEmbeddingService.findEmbedding
         .mockResolvedValueOnce(embedding1)
         .mockResolvedValueOnce(embedding2);
 
@@ -227,7 +227,7 @@ describe('TopicDuplicateDetectorService', () => {
       ];
 
       const embedding = [0.5, 0.5];
-      mockEmbeddingService.getEmbedding.mockResolvedValue(embedding);
+      mockEmbeddingService.findEmbedding.mockResolvedValue(embedding);
 
       const result = await service.analyzeCandidates('Test Topic', 'Test description', candidates);
 
@@ -248,7 +248,7 @@ describe('TopicDuplicateDetectorService', () => {
       ];
 
       const embedding = [0.5, 0.5];
-      mockEmbeddingService.getEmbedding.mockResolvedValue(embedding);
+      mockEmbeddingService.findEmbedding.mockResolvedValue(embedding);
 
       const result = await service.analyzeCandidates('New Topic', 'New description', candidates);
 
@@ -258,7 +258,7 @@ describe('TopicDuplicateDetectorService', () => {
 
   describe('isSemanticAnalysisAvailable', () => {
     it('should return true when embedding service is available', async () => {
-      mockEmbeddingService.getEmbedding.mockResolvedValue([0.1, 0.2, 0.3]);
+      mockEmbeddingService.findEmbedding.mockResolvedValue([0.1, 0.2, 0.3]);
 
       const result = await service.isSemanticAnalysisAvailable();
 
@@ -266,7 +266,7 @@ describe('TopicDuplicateDetectorService', () => {
     });
 
     it('should return false when embedding service is unavailable', async () => {
-      mockEmbeddingService.getEmbedding.mockResolvedValue(null);
+      mockEmbeddingService.findEmbedding.mockResolvedValue(null);
 
       const result = await service.isSemanticAnalysisAvailable();
 

--- a/services/ai-service/src/services/topic-duplicate-detector.service.ts
+++ b/services/ai-service/src/services/topic-duplicate-detector.service.ts
@@ -117,8 +117,8 @@ export class TopicDuplicateDetectorService {
     const textB = this.combineTopicText(titleB, descriptionB);
 
     const [embeddingA, embeddingB] = await Promise.all([
-      this.embeddingService.getEmbedding(textA),
-      this.embeddingService.getEmbedding(textB),
+      this.embeddingService.findEmbedding(textA),
+      this.embeddingService.findEmbedding(textB),
     ]);
 
     if (!embeddingA || !embeddingB) {
@@ -229,7 +229,7 @@ export class TopicDuplicateDetectorService {
    */
   async isSemanticAnalysisAvailable(): Promise<boolean> {
     // Try to get an embedding for a test string
-    const testEmbedding = await this.embeddingService.getEmbedding('test');
+    const testEmbedding = await this.embeddingService.findEmbedding('test');
     return testEmbedding !== null;
   }
 }

--- a/services/ai-service/tests/integration/confidence-tracking.spec.ts
+++ b/services/ai-service/tests/integration/confidence-tracking.spec.ts
@@ -89,7 +89,7 @@ describe('Confidence Metadata Storage', () => {
       isReady: vi.fn().mockResolvedValue(false),
     };
     mockRedisCache = {
-      getFeedback: vi.fn().mockResolvedValue(null),
+      findFeedback: vi.fn().mockResolvedValue(null),
       setFeedback: vi.fn().mockResolvedValue(undefined),
     };
 

--- a/services/ai-service/tests/unit/confidence-threshold.spec.ts
+++ b/services/ai-service/tests/unit/confidence-threshold.spec.ts
@@ -42,7 +42,7 @@ describe('Confidence Threshold Enforcement', () => {
       isReady: vi.fn().mockResolvedValue(false),
     };
     mockRedisCache = {
-      getFeedback: vi.fn().mockResolvedValue(null),
+      findFeedback: vi.fn().mockResolvedValue(null),
       setFeedback: vi.fn().mockResolvedValue(undefined),
     };
 

--- a/services/ai-service/tests/unit/silent-logging.spec.ts
+++ b/services/ai-service/tests/unit/silent-logging.spec.ts
@@ -40,7 +40,7 @@ describe('Low-Confidence Silent Logging', () => {
       isReady: vi.fn().mockResolvedValue(false),
     };
     mockRedisCache = {
-      getFeedback: vi.fn().mockResolvedValue(null),
+      findFeedback: vi.fn().mockResolvedValue(null),
       setFeedback: vi.fn().mockResolvedValue(undefined),
     };
 

--- a/services/discussion-service/src/alignments/alignments.controller.test.ts
+++ b/services/discussion-service/src/alignments/alignments.controller.test.ts
@@ -29,7 +29,7 @@ describe('AlignmentsController', () => {
       };
       mockAlignmentsService.findUserAlignment.mockResolvedValue(alignment);
 
-      const result = await controller.findUserAlignment('proposition-1', 'user-1');
+      const result = await controller.getUserAlignment('proposition-1', 'user-1');
 
       expect(result).toEqual(alignment);
       expect(mockAlignmentsService.findUserAlignment).toHaveBeenCalledWith(
@@ -41,7 +41,7 @@ describe('AlignmentsController', () => {
     it('should return null when user has no alignment', async () => {
       mockAlignmentsService.findUserAlignment.mockResolvedValue(null);
 
-      const result = await controller.findUserAlignment('proposition-1', 'user-1');
+      const result = await controller.getUserAlignment('proposition-1', 'user-1');
 
       expect(result).toBeNull();
     });
@@ -49,7 +49,7 @@ describe('AlignmentsController', () => {
     it('should pass correct propositionId and userId', async () => {
       mockAlignmentsService.findUserAlignment.mockResolvedValue(null);
 
-      await controller.findUserAlignment('prop-123', 'user-456');
+      await controller.getUserAlignment('prop-123', 'user-456');
 
       expect(mockAlignmentsService.findUserAlignment).toHaveBeenCalledWith('prop-123', 'user-456');
     });

--- a/services/discussion-service/src/alignments/alignments.controller.test.ts
+++ b/services/discussion-service/src/alignments/alignments.controller.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AlignmentsController } from './alignments.controller.js';
 
 const createMockAlignmentsService = () => ({
-  getUserAlignment: vi.fn(),
+  findUserAlignment: vi.fn(),
   setAlignment: vi.fn(),
   removeAlignment: vi.fn(),
 });
@@ -18,7 +18,7 @@ describe('AlignmentsController', () => {
     controller = new AlignmentsController(mockAlignmentsService as any);
   });
 
-  describe('getUserAlignment', () => {
+  describe('findUserAlignment', () => {
     it('should return user alignment when it exists', async () => {
       const alignment = {
         id: 'alignment-1',
@@ -27,31 +27,31 @@ describe('AlignmentsController', () => {
         position: 'AGREE',
         createdAt: new Date(),
       };
-      mockAlignmentsService.getUserAlignment.mockResolvedValue(alignment);
+      mockAlignmentsService.findUserAlignment.mockResolvedValue(alignment);
 
-      const result = await controller.getUserAlignment('proposition-1', 'user-1');
+      const result = await controller.findUserAlignment('proposition-1', 'user-1');
 
       expect(result).toEqual(alignment);
-      expect(mockAlignmentsService.getUserAlignment).toHaveBeenCalledWith(
+      expect(mockAlignmentsService.findUserAlignment).toHaveBeenCalledWith(
         'proposition-1',
         'user-1',
       );
     });
 
     it('should return null when user has no alignment', async () => {
-      mockAlignmentsService.getUserAlignment.mockResolvedValue(null);
+      mockAlignmentsService.findUserAlignment.mockResolvedValue(null);
 
-      const result = await controller.getUserAlignment('proposition-1', 'user-1');
+      const result = await controller.findUserAlignment('proposition-1', 'user-1');
 
       expect(result).toBeNull();
     });
 
     it('should pass correct propositionId and userId', async () => {
-      mockAlignmentsService.getUserAlignment.mockResolvedValue(null);
+      mockAlignmentsService.findUserAlignment.mockResolvedValue(null);
 
-      await controller.getUserAlignment('prop-123', 'user-456');
+      await controller.findUserAlignment('prop-123', 'user-456');
 
-      expect(mockAlignmentsService.getUserAlignment).toHaveBeenCalledWith('prop-123', 'user-456');
+      expect(mockAlignmentsService.findUserAlignment).toHaveBeenCalledWith('prop-123', 'user-456');
     });
   });
 

--- a/services/discussion-service/src/alignments/alignments.controller.ts
+++ b/services/discussion-service/src/alignments/alignments.controller.ts
@@ -34,7 +34,7 @@ export class AlignmentsController {
     @Param('propositionId') propositionId: string,
     @Headers('x-user-id') userId: string,
   ): Promise<AlignmentDto | null> {
-    return this.alignmentsService.getUserAlignment(propositionId, userId);
+    return this.alignmentsService.findUserAlignment(propositionId, userId);
   }
 
   /**

--- a/services/discussion-service/src/alignments/alignments.service.test.ts
+++ b/services/discussion-service/src/alignments/alignments.service.test.ts
@@ -203,11 +203,11 @@ describe('AlignmentsService', () => {
     });
   });
 
-  describe('getUserAlignment', () => {
+  describe('findUserAlignment', () => {
     it('should return null if alignment does not exist', async () => {
       mockPrisma.alignment.findUnique.mockResolvedValue(null);
 
-      const result = await service.getUserAlignment('proposition-1', 'user-1');
+      const result = await service.findUserAlignment('proposition-1', 'user-1');
 
       expect(result).toBeNull();
     });
@@ -215,7 +215,7 @@ describe('AlignmentsService', () => {
     it('should return alignment DTO if alignment exists', async () => {
       mockPrisma.alignment.findUnique.mockResolvedValue(createMockAlignment());
 
-      const result = await service.getUserAlignment('proposition-1', 'user-1');
+      const result = await service.findUserAlignment('proposition-1', 'user-1');
 
       expect(result).not.toBeNull();
       expect(result?.id).toBe('alignment-1');
@@ -230,7 +230,7 @@ describe('AlignmentsService', () => {
         }),
       );
 
-      const result = await service.getUserAlignment('proposition-1', 'user-1');
+      const result = await service.findUserAlignment('proposition-1', 'user-1');
 
       expect(result?.nuanceExplanation).toBe('My nuanced view...');
     });
@@ -238,7 +238,7 @@ describe('AlignmentsService', () => {
     it('should not include nuanceExplanation when not present', async () => {
       mockPrisma.alignment.findUnique.mockResolvedValue(createMockAlignment());
 
-      const result = await service.getUserAlignment('proposition-1', 'user-1');
+      const result = await service.findUserAlignment('proposition-1', 'user-1');
 
       expect(result?.nuanceExplanation).toBeUndefined();
     });
@@ -246,7 +246,7 @@ describe('AlignmentsService', () => {
     it('should query with correct composite key', async () => {
       mockPrisma.alignment.findUnique.mockResolvedValue(null);
 
-      await service.getUserAlignment('proposition-1', 'user-1');
+      await service.findUserAlignment('proposition-1', 'user-1');
 
       expect(mockPrisma.alignment.findUnique).toHaveBeenCalledWith({
         where: {

--- a/services/discussion-service/src/alignments/alignments.service.ts
+++ b/services/discussion-service/src/alignments/alignments.service.ts
@@ -108,9 +108,13 @@ export class AlignmentsService {
   }
 
   /**
-   * Get user's alignment on a proposition (if exists)
+   * Find a user's alignment on a proposition.
+   *
+   * @param propositionId - The proposition's unique identifier
+   * @param userId - The user's unique identifier
+   * @returns AlignmentDto if found, null if user has no alignment on this proposition
    */
-  async getUserAlignment(propositionId: string, userId: string): Promise<AlignmentDto | null> {
+  async findUserAlignment(propositionId: string, userId: string): Promise<AlignmentDto | null> {
     const alignment = await this.prisma.alignment.findUnique({
       where: {
         userId_propositionId: {

--- a/services/discussion-service/src/read-state/read-state.controller.ts
+++ b/services/discussion-service/src/read-state/read-state.controller.ts
@@ -52,6 +52,6 @@ export class ReadStateController {
     if (!userId) {
       return null;
     }
-    return this.readStateService.getReadState(userId, topicId);
+    return this.readStateService.findReadState(userId, topicId);
   }
 }

--- a/services/discussion-service/src/read-state/read-state.service.ts
+++ b/services/discussion-service/src/read-state/read-state.service.ts
@@ -83,10 +83,10 @@ export class ReadStateService {
    * Get the current read state for a user in a topic
    * @param userId - The ID of the user
    * @param topicId - The ID of the topic
-   * @returns The read state or null if not found
-   * @throws NotFoundException if the topic doesn't exist
+   * @returns The read state if found, null if user has not read this topic
+   * @throws {NotFoundException} When the topic doesn't exist
    */
-  async getReadState(userId: string, topicId: string): Promise<ReadStateDto | null> {
+  async findReadState(userId: string, topicId: string): Promise<ReadStateDto | null> {
     // Verify topic exists
     const topic = await this.prisma.discussionTopic.findUnique({
       where: { id: topicId },

--- a/services/discussion-service/src/topics/topic-links.controller.ts
+++ b/services/discussion-service/src/topics/topic-links.controller.ts
@@ -97,7 +97,7 @@ export class TopicLinksController {
     @Param('topicId') topicId: string,
     @Param('linkId') linkId: string,
   ): Promise<TopicLinkResponseDto> {
-    const link = await this.topicLinksService.getLinkById(linkId);
+    const link = await this.topicLinksService.findLinkById(linkId);
 
     if (!link) {
       throw new NotFoundException(`Topic link ${linkId} not found`);
@@ -136,7 +136,7 @@ export class TopicLinksController {
     }
 
     // Verify link exists and belongs to topic
-    const existingLink = await this.topicLinksService.getLinkById(linkId);
+    const existingLink = await this.topicLinksService.findLinkById(linkId);
     if (!existingLink) {
       throw new NotFoundException(`Topic link ${linkId} not found`);
     }
@@ -160,7 +160,7 @@ export class TopicLinksController {
     @Param('linkId') linkId: string,
   ): Promise<TopicLinkResponseDto> {
     // Verify link exists and belongs to topic
-    const existingLink = await this.topicLinksService.getLinkById(linkId);
+    const existingLink = await this.topicLinksService.findLinkById(linkId);
     if (!existingLink) {
       throw new NotFoundException(`Topic link ${linkId} not found`);
     }

--- a/services/discussion-service/src/topics/topic-links.service.test.ts
+++ b/services/discussion-service/src/topics/topic-links.service.test.ts
@@ -278,12 +278,12 @@ describe('TopicLinksService', () => {
     });
   });
 
-  describe('getLinkById', () => {
+  describe('findLinkById', () => {
     it('should return a link by ID', async () => {
       const link = createMockLink();
       mockPrisma.topicLink.findUnique.mockResolvedValue(link);
 
-      const result = await service.getLinkById('link-1');
+      const result = await service.findLinkById('link-1');
 
       expect(result).not.toBeNull();
       expect(result?.id).toBe('link-1');
@@ -292,7 +292,7 @@ describe('TopicLinksService', () => {
     it('should return null when link does not exist', async () => {
       mockPrisma.topicLink.findUnique.mockResolvedValue(null);
 
-      const result = await service.getLinkById('nonexistent-link');
+      const result = await service.findLinkById('nonexistent-link');
 
       expect(result).toBeNull();
     });

--- a/services/discussion-service/src/topics/topic-links.service.ts
+++ b/services/discussion-service/src/topics/topic-links.service.ts
@@ -231,12 +231,12 @@ export class TopicLinksService {
   }
 
   /**
-   * Get a specific link by ID
+   * Find a specific link by ID.
    *
-   * @param linkId - ID of the link
-   * @returns Topic link or null
+   * @param linkId - The link's unique identifier
+   * @returns TopicLinkResponseDto if found, null if link doesn't exist
    */
-  async getLinkById(linkId: string): Promise<TopicLinkResponseDto | null> {
+  async findLinkById(linkId: string): Promise<TopicLinkResponseDto | null> {
     const link = await this.prisma.topicLink.findUnique({
       where: { id: linkId },
       include: {

--- a/services/discussion-service/src/topics/topics-edit.service.ts
+++ b/services/discussion-service/src/topics/topics-edit.service.ts
@@ -160,12 +160,13 @@ export class TopicsEditService {
 
   /**
    * Get the most recent edit for a topic
-   * T012: Helper method for displaying latest change
+   * Find the most recent edit for a topic.
+   * T012: Helper method for displaying latest change.
    *
-   * @param topicId - Topic ID
-   * @returns Most recent edit record or null if no edits
+   * @param topicId - The topic's unique identifier
+   * @returns The most recent edit record if found, null if no edits exist
    */
-  async getLatestEdit(topicId: string): Promise<TopicEditRecord | null> {
+  async findLatestEdit(topicId: string): Promise<TopicEditRecord | null> {
     try {
       const latestEdit = await this.prisma.topicEdit.findFirst({
         where: { topicId },

--- a/services/fact-check-service/src/cache/__tests__/fact-check-cache.service.test.ts
+++ b/services/fact-check-service/src/cache/__tests__/fact-check-cache.service.test.ts
@@ -141,12 +141,12 @@ describe('FactCheckCacheService', () => {
     });
   });
 
-  describe('getById', () => {
+  describe('findById', () => {
     it('should return cached result on hit', async () => {
       const cachedResult = createSampleResult();
       mockCacheManager.get.mockResolvedValue(cachedResult);
 
-      const result = await service.getById('123e4567-e89b-12d3-a456-426614174000');
+      const result = await service.findById('123e4567-e89b-12d3-a456-426614174000');
 
       expect(mockCacheManager.get).toHaveBeenCalledWith(
         'fact-check:id:123e4567-e89b-12d3-a456-426614174000',
@@ -157,7 +157,7 @@ describe('FactCheckCacheService', () => {
     it('should return null on cache miss', async () => {
       mockCacheManager.get.mockResolvedValue(null);
 
-      const result = await service.getById('123e4567-e89b-12d3-a456-426614174000');
+      const result = await service.findById('123e4567-e89b-12d3-a456-426614174000');
 
       expect(result).toBeNull();
     });
@@ -165,7 +165,7 @@ describe('FactCheckCacheService', () => {
     it('should return null on cache error (graceful degradation)', async () => {
       mockCacheManager.get.mockRejectedValue(new Error('Redis connection failed'));
 
-      const result = await service.getById('123e4567-e89b-12d3-a456-426614174000');
+      const result = await service.findById('123e4567-e89b-12d3-a456-426614174000');
 
       expect(result).toBeNull();
     });

--- a/services/fact-check-service/src/cache/fact-check-cache.service.ts
+++ b/services/fact-check-service/src/cache/fact-check-cache.service.ts
@@ -110,12 +110,12 @@ export class FactCheckCacheService {
   }
 
   /**
-   * Get cached fact-check result by its ID
+   * Find a cached fact-check result by its ID.
    *
    * @param id - Result ID (UUID)
-   * @returns Cached result or null if not found/error
+   * @returns Cached result if found, null if not found or on error
    */
-  async getById(id: string): Promise<FactCheckResultDto | null> {
+  async findById(id: string): Promise<FactCheckResultDto | null> {
     try {
       const cacheKey = this.buildIdCacheKey(id);
       const cached = await this.cacheManager.get<FactCheckResultDto>(cacheKey);

--- a/services/fact-check-service/src/controllers/__tests__/fact-check.controller.test.ts
+++ b/services/fact-check-service/src/controllers/__tests__/fact-check.controller.test.ts
@@ -17,13 +17,13 @@ describe('FactCheckController', () => {
   let controller: FactCheckController;
   let mockFactCheckService: {
     checkClaims: ReturnType<typeof vi.fn>;
-    getResultById: ReturnType<typeof vi.fn>;
+    findResultById: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
     mockFactCheckService = {
       checkClaims: vi.fn(),
-      getResultById: vi.fn(),
+      findResultById: vi.fn(),
     };
     controller = new FactCheckController(mockFactCheckService as unknown as FactCheckService);
   });
@@ -223,12 +223,12 @@ describe('FactCheckController', () => {
     };
 
     it('should return fact-check result successfully', async () => {
-      mockFactCheckService.getResultById.mockResolvedValue(mockResult);
+      mockFactCheckService.findResultById.mockResolvedValue(mockResult);
 
       const result = await controller.getResult(validUuid);
 
       expect(result).toEqual(mockResult);
-      expect(mockFactCheckService.getResultById).toHaveBeenCalledWith(validUuid);
+      expect(mockFactCheckService.findResultById).toHaveBeenCalledWith(validUuid);
     });
 
     it('should throw BadRequestException for invalid UUID format', async () => {
@@ -243,14 +243,14 @@ describe('FactCheckController', () => {
     it('should accept valid UUID v1 format', async () => {
       // UUID v1 format is also accepted
       const uuidV1 = '123e4567-e89b-12d3-8456-426614174000';
-      mockFactCheckService.getResultById.mockResolvedValue(mockResult);
+      mockFactCheckService.findResultById.mockResolvedValue(mockResult);
 
       const result = await controller.getResult(uuidV1);
       expect(result).toEqual(mockResult);
     });
 
     it('should throw NotFoundException when result not found', async () => {
-      mockFactCheckService.getResultById.mockResolvedValue(null);
+      mockFactCheckService.findResultById.mockResolvedValue(null);
 
       await expect(controller.getResult(validUuid)).rejects.toThrow(NotFoundException);
       await expect(controller.getResult(validUuid)).rejects.toThrow(
@@ -259,7 +259,7 @@ describe('FactCheckController', () => {
     });
 
     it('should accept various valid UUID v4 formats', async () => {
-      mockFactCheckService.getResultById.mockResolvedValue(mockResult);
+      mockFactCheckService.findResultById.mockResolvedValue(mockResult);
 
       // Lowercase
       await expect(

--- a/services/fact-check-service/src/controllers/fact-check.controller.ts
+++ b/services/fact-check-service/src/controllers/fact-check.controller.ts
@@ -129,7 +129,7 @@ export class FactCheckController {
 
     this.logger.log(`Retrieving fact-check result: ${id}`);
 
-    const result = await this.factCheckService.getResultById(id);
+    const result = await this.factCheckService.findResultById(id);
 
     if (!result) {
       throw new NotFoundException(`Fact-check result not found: ${id}`);

--- a/services/fact-check-service/src/services/__tests__/fact-check.service.test.ts
+++ b/services/fact-check-service/src/services/__tests__/fact-check.service.test.ts
@@ -296,7 +296,7 @@ describe('FactCheckService', () => {
     });
   });
 
-  describe('getResultById', () => {
+  describe('findResultById', () => {
     const mockResult: FactCheckResultDto = {
       id: '123e4567-e89b-12d3-a456-426614174000',
       claimText: 'Test claim',
@@ -322,7 +322,7 @@ describe('FactCheckService', () => {
       // Service without cache
       const serviceWithoutCache = new FactCheckService([mockClient as unknown as IFactCheckClient]);
 
-      const result = await serviceWithoutCache.getResultById(
+      const result = await serviceWithoutCache.findResultById(
         '123e4567-e89b-12d3-a456-426614174000',
       );
 
@@ -331,7 +331,7 @@ describe('FactCheckService', () => {
 
     it('should return cached result when found', async () => {
       const mockCacheService = {
-        getById: vi.fn().mockResolvedValue(mockResult),
+        findById: vi.fn().mockResolvedValue(mockResult),
         setById: vi.fn(),
         get: vi.fn(),
         set: vi.fn(),
@@ -343,15 +343,17 @@ describe('FactCheckService', () => {
         mockCacheService as unknown as FactCheckCacheService,
       );
 
-      const result = await serviceWithCache.getResultById('123e4567-e89b-12d3-a456-426614174000');
+      const result = await serviceWithCache.findResultById('123e4567-e89b-12d3-a456-426614174000');
 
       expect(result).toEqual(mockResult);
-      expect(mockCacheService.getById).toHaveBeenCalledWith('123e4567-e89b-12d3-a456-426614174000');
+      expect(mockCacheService.findById).toHaveBeenCalledWith(
+        '123e4567-e89b-12d3-a456-426614174000',
+      );
     });
 
     it('should return null when result not found in cache', async () => {
       const mockCacheService = {
-        getById: vi.fn().mockResolvedValue(null),
+        findById: vi.fn().mockResolvedValue(null),
         setById: vi.fn(),
         get: vi.fn(),
         set: vi.fn(),
@@ -363,7 +365,7 @@ describe('FactCheckService', () => {
         mockCacheService as unknown as FactCheckCacheService,
       );
 
-      const result = await serviceWithCache.getResultById('123e4567-e89b-12d3-a456-426614174000');
+      const result = await serviceWithCache.findResultById('123e4567-e89b-12d3-a456-426614174000');
 
       expect(result).toBeNull();
     });

--- a/services/fact-check-service/src/services/fact-check.service.ts
+++ b/services/fact-check-service/src/services/fact-check.service.ts
@@ -181,18 +181,19 @@ export class FactCheckService {
   /**
    * Get a fact-check result by its ID
    *
-   * T256: GET /fact-check/:id endpoint implementation
+   * Find a fact-check result by ID.
+   * T256: GET /fact-check/:id endpoint implementation.
    *
    * @param id - Result ID (UUID)
-   * @returns The fact-check result or null if not found
+   * @returns The fact-check result if found, null otherwise
    */
-  async getResultById(id: string): Promise<FactCheckResultDto | null> {
+  async findResultById(id: string): Promise<FactCheckResultDto | null> {
     if (!this.cacheService) {
       this.logger.warn('Cache service not available for ID lookup');
       return null;
     }
 
-    return this.cacheService.getById(id);
+    return this.cacheService.findById(id);
   }
 
   /**

--- a/services/moderation-service/src/__tests__/integration/appeal-process.integration.test.ts
+++ b/services/moderation-service/src/__tests__/integration/appeal-process.integration.test.ts
@@ -758,7 +758,7 @@ describe('Appeal Process Integration Tests', () => {
 
       mockPrisma.appeal.findUnique.mockResolvedValue(appealWithAction);
 
-      const result = await appealService.getAppealById(testAppealId);
+      const result = await appealService.findAppealById(testAppealId);
 
       expect(result).not.toBeNull();
       expect(result?.id).toBe(testAppealId);
@@ -784,7 +784,7 @@ describe('Appeal Process Integration Tests', () => {
     it('should return null for non-existent appeal', async () => {
       mockPrisma.appeal.findUnique.mockResolvedValue(null);
 
-      const result = await appealService.getAppealById('nonexistent-appeal');
+      const result = await appealService.findAppealById('nonexistent-appeal');
 
       expect(result).toBeNull();
     });

--- a/services/moderation-service/src/controllers/moderation.controller.ts
+++ b/services/moderation-service/src/controllers/moderation.controller.ts
@@ -440,7 +440,7 @@ export class ModerationController {
 
   @Get('safety-reports/:reportId')
   async getSafetyReport(@Param('reportId') reportId: string): Promise<SafetyReportResponse> {
-    const report = await this.safetyReportService.getReport(reportId);
+    const report = await this.safetyReportService.findReport(reportId);
     if (!report) {
       throw new BadRequestException('Safety report not found');
     }

--- a/services/moderation-service/src/services/__tests__/appeal.service.spec.ts
+++ b/services/moderation-service/src/services/__tests__/appeal.service.spec.ts
@@ -613,11 +613,11 @@ describe('AppealService', () => {
     });
   });
 
-  describe('getAppealById', () => {
+  describe('findAppealById', () => {
     it('should return null if appeal does not exist', async () => {
       mockPrisma.appeal.findUnique.mockResolvedValue(null);
 
-      const result = await service.getAppealById('nonexistent');
+      const result = await service.findAppealById('nonexistent');
 
       expect(result).toBeNull();
     });
@@ -651,7 +651,7 @@ describe('AppealService', () => {
         },
       });
 
-      const result = await service.getAppealById('appeal-1');
+      const result = await service.findAppealById('appeal-1');
 
       expect(result).not.toBeNull();
       expect(result?.id).toBe('appeal-1');

--- a/services/moderation-service/src/services/__tests__/safety-report.service.test.ts
+++ b/services/moderation-service/src/services/__tests__/safety-report.service.test.ts
@@ -160,11 +160,11 @@ describe('SafetyReportService', () => {
     });
   });
 
-  describe('getReport', () => {
+  describe('findReport', () => {
     it('should return a report by ID', async () => {
       prismaService.safetyReport.findUnique.mockResolvedValue(mockReport);
 
-      const result = await service.getReport('report-123');
+      const result = await service.findReport('report-123');
 
       expect(prismaService.safetyReport.findUnique).toHaveBeenCalledWith({
         where: { id: 'report-123' },
@@ -175,7 +175,7 @@ describe('SafetyReportService', () => {
     it('should return null if report not found', async () => {
       prismaService.safetyReport.findUnique.mockResolvedValue(null);
 
-      const result = await service.getReport('nonexistent');
+      const result = await service.findReport('nonexistent');
 
       expect(result).toBeNull();
     });

--- a/services/moderation-service/src/services/appeal.service.ts
+++ b/services/moderation-service/src/services/appeal.service.ts
@@ -337,9 +337,12 @@ export class AppealService {
   }
 
   /**
-   * Get appeal by ID
+   * Find an appeal by ID.
+   *
+   * @param appealId - The appeal's unique identifier
+   * @returns The appeal if found, null otherwise
    */
-  async getAppealById(appealId: string): Promise<PendingAppealResponse | null> {
+  async findAppealById(appealId: string): Promise<PendingAppealResponse | null> {
     const appeal = await this.prisma.appeal.findUnique({
       where: { id: appealId },
       include: {

--- a/services/moderation-service/src/services/safety-report.service.ts
+++ b/services/moderation-service/src/services/safety-report.service.ts
@@ -164,9 +164,12 @@ export class SafetyReportService {
   }
 
   /**
-   * Gets a safety report by ID
+   * Find a safety report by ID.
+   *
+   * @param reportId - The report's unique identifier
+   * @returns The safety report if found, null otherwise
    */
-  async getReport(reportId: string): Promise<SafetyReportResponse | null> {
+  async findReport(reportId: string): Promise<SafetyReportResponse | null> {
     const report = await this.prisma.safetyReport.findUnique({
       where: { id: reportId },
     });

--- a/services/notification-service/src/services/parent-notification.service.ts
+++ b/services/notification-service/src/services/parent-notification.service.ts
@@ -145,7 +145,7 @@ export class ParentNotificationService {
 
     try {
       // Get parent contact information
-      const parentContact = await this.getParentContact(request.childId);
+      const parentContact = await this.findParentContact(request.childId);
 
       if (!parentContact) {
         this.logger.warn(
@@ -283,9 +283,12 @@ export class ParentNotificationService {
   }
 
   /**
-   * Get parent contact information for a child
+   * Find parent contact information for a child.
+   *
+   * @param childId - The child user's unique identifier
+   * @returns Parent contact info if found, null otherwise
    */
-  private async getParentContact(childId: string): Promise<ParentContact | null> {
+  private async findParentContact(childId: string): Promise<ParentContact | null> {
     const child = await this.prisma.user.findUnique({
       where: { id: childId },
       select: {

--- a/services/user-service/src/access-control/__tests__/tier.guard.test.ts
+++ b/services/user-service/src/access-control/__tests__/tier.guard.test.ts
@@ -205,7 +205,7 @@ describe('TierGuard', () => {
     canAccessTopic: ReturnType<typeof vi.fn>;
     hasProvisionalAccess: ReturnType<typeof vi.fn>;
     getUserRank: ReturnType<typeof vi.fn>;
-    getUserExpertise: ReturnType<typeof vi.fn>;
+    findUserExpertise: ReturnType<typeof vi.fn>;
     getTopic: ReturnType<typeof vi.fn>;
   };
   let mockReflector: Reflector;
@@ -218,7 +218,7 @@ describe('TierGuard', () => {
       canAccessTopic: vi.fn(),
       hasProvisionalAccess: vi.fn(),
       getUserRank: vi.fn(),
-      getUserExpertise: vi.fn(),
+      findUserExpertise: vi.fn(),
       getTopic: vi.fn(),
     };
 

--- a/services/user-service/src/access-control/access-control.service.ts
+++ b/services/user-service/src/access-control/access-control.service.ts
@@ -312,13 +312,13 @@ export class AccessControlService {
   }
 
   /**
-   * Get a user's expertise for a specific tag
+   * Find a user's expertise for a specific tag.
    *
    * @param userId - The user's unique identifier (cognitoSub)
    * @param tagId - The tag's unique identifier
-   * @returns The user's expertise or null if not found
+   * @returns The user's expertise if found, null otherwise
    */
-  async getUserExpertise(
+  async findUserExpertise(
     userId: string,
     tagId: string,
   ): Promise<{ expertiseLevel: ExpertiseLevel } | null> {

--- a/services/user-service/src/access-control/tier.guard.ts
+++ b/services/user-service/src/access-control/tier.guard.ts
@@ -103,7 +103,7 @@ export class TierGuard implements CanActivate {
 
     // If decorator expertise requirement exists, check it
     if (requiredExpertise) {
-      const expertise = await this.accessControlService.getUserExpertise(
+      const expertise = await this.accessControlService.findUserExpertise(
         userId,
         requiredExpertise.tagId,
       );

--- a/services/user-service/src/expertise/__tests__/expertise.controller.test.ts
+++ b/services/user-service/src/expertise/__tests__/expertise.controller.test.ts
@@ -92,7 +92,7 @@ describe('ExpertiseController', () => {
       ];
       mockExpertiseService.getAllUserExpertise.mockResolvedValue(mockExpertises);
 
-      const result = await controller.findUserExpertise('user-123');
+      const result = await controller.getUserExpertise('user-123');
 
       expect(result).toHaveLength(3);
       expect(result[0].tagName).toBe('Science');
@@ -104,7 +104,7 @@ describe('ExpertiseController', () => {
     it('should return empty array when user has no expertise', async () => {
       mockExpertiseService.getAllUserExpertise.mockResolvedValue([]);
 
-      const result = await controller.findUserExpertise('user-new');
+      const result = await controller.getUserExpertise('user-new');
 
       expect(result).toEqual([]);
       expect(mockExpertiseService.getAllUserExpertise).toHaveBeenCalledWith('user-new');
@@ -119,7 +119,7 @@ describe('ExpertiseController', () => {
       ];
       mockExpertiseService.getAllUserExpertise.mockResolvedValue(mockExpertises);
 
-      const result = await controller.findUserExpertise('user-123');
+      const result = await controller.getUserExpertise('user-123');
 
       expect(result[0].expertiseScore).toBe(0.85);
       expect(result[0].expertiseLevel).toBe(ExpertiseLevel.EXPERT);
@@ -130,7 +130,7 @@ describe('ExpertiseController', () => {
         new Error('Database connection failed'),
       );
 
-      await expect(controller.findUserExpertise('user-123')).rejects.toThrow(
+      await expect(controller.getUserExpertise('user-123')).rejects.toThrow(
         'Database connection failed',
       );
     });
@@ -146,7 +146,7 @@ describe('ExpertiseController', () => {
       });
       mockExpertiseService.findUserExpertise.mockResolvedValue(mockExpertise);
 
-      const result = await controller.findUserExpertiseByTag('user-456', 'tag-789');
+      const result = await controller.getUserExpertiseByTag('user-456', 'tag-789');
 
       expect(result).toBeDefined();
       expect(result.userId).toBe('user-456');
@@ -159,9 +159,9 @@ describe('ExpertiseController', () => {
     it('should return 404 when expertise not found', async () => {
       mockExpertiseService.findUserExpertise.mockResolvedValue(null);
 
-      await expect(
-        controller.findUserExpertiseByTag('user-123', 'nonexistent-tag'),
-      ).rejects.toThrow(NotFoundException);
+      await expect(controller.getUserExpertiseByTag('user-123', 'nonexistent-tag')).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('should return full expertise details including response count and quality', async () => {
@@ -172,7 +172,7 @@ describe('ExpertiseController', () => {
       });
       mockExpertiseService.findUserExpertise.mockResolvedValue(mockExpertise);
 
-      const result = await controller.findUserExpertiseByTag('user-123', 'tag-456');
+      const result = await controller.getUserExpertiseByTag('user-123', 'tag-456');
 
       expect(result.responseCount).toBe(150);
       expect(result.avgQualityScore).toBe(0.85);
@@ -182,7 +182,7 @@ describe('ExpertiseController', () => {
     it('should propagate service errors', async () => {
       mockExpertiseService.findUserExpertise.mockRejectedValue(new Error('Service unavailable'));
 
-      await expect(controller.findUserExpertiseByTag('user-123', 'tag-456')).rejects.toThrow(
+      await expect(controller.getUserExpertiseByTag('user-123', 'tag-456')).rejects.toThrow(
         'Service unavailable',
       );
     });
@@ -312,7 +312,7 @@ describe('ExpertiseController', () => {
       mockExpertiseService.findUserExpertise.mockResolvedValue(null);
 
       try {
-        await controller.findUserExpertiseByTag('user-123', 'missing-tag');
+        await controller.getUserExpertiseByTag('user-123', 'missing-tag');
         expect.fail('Should have thrown NotFoundException');
       } catch (error) {
         expect(error).toBeInstanceOf(NotFoundException);
@@ -326,9 +326,9 @@ describe('ExpertiseController', () => {
 
       // Simulate concurrent requests
       const promises = [
-        controller.findUserExpertiseByTag('user-1', 'tag-1'),
-        controller.findUserExpertiseByTag('user-2', 'tag-2'),
-        controller.findUserExpertiseByTag('user-3', 'tag-3'),
+        controller.getUserExpertiseByTag('user-1', 'tag-1'),
+        controller.getUserExpertiseByTag('user-2', 'tag-2'),
+        controller.getUserExpertiseByTag('user-3', 'tag-3'),
       ];
 
       const results = await Promise.all(promises);

--- a/services/user-service/src/expertise/__tests__/expertise.controller.test.ts
+++ b/services/user-service/src/expertise/__tests__/expertise.controller.test.ts
@@ -68,7 +68,7 @@ const createMockTopicExpertiseDto = (
  */
 const createMockExpertiseService = () => ({
   getAllUserExpertise: vi.fn(),
-  getUserExpertise: vi.fn(),
+  findUserExpertise: vi.fn(),
   getExpertiseLeaderboard: vi.fn(),
   recalculateExpertise: vi.fn(),
 });
@@ -92,7 +92,7 @@ describe('ExpertiseController', () => {
       ];
       mockExpertiseService.getAllUserExpertise.mockResolvedValue(mockExpertises);
 
-      const result = await controller.getUserExpertise('user-123');
+      const result = await controller.findUserExpertise('user-123');
 
       expect(result).toHaveLength(3);
       expect(result[0].tagName).toBe('Science');
@@ -104,7 +104,7 @@ describe('ExpertiseController', () => {
     it('should return empty array when user has no expertise', async () => {
       mockExpertiseService.getAllUserExpertise.mockResolvedValue([]);
 
-      const result = await controller.getUserExpertise('user-new');
+      const result = await controller.findUserExpertise('user-new');
 
       expect(result).toEqual([]);
       expect(mockExpertiseService.getAllUserExpertise).toHaveBeenCalledWith('user-new');
@@ -119,7 +119,7 @@ describe('ExpertiseController', () => {
       ];
       mockExpertiseService.getAllUserExpertise.mockResolvedValue(mockExpertises);
 
-      const result = await controller.getUserExpertise('user-123');
+      const result = await controller.findUserExpertise('user-123');
 
       expect(result[0].expertiseScore).toBe(0.85);
       expect(result[0].expertiseLevel).toBe(ExpertiseLevel.EXPERT);
@@ -130,7 +130,7 @@ describe('ExpertiseController', () => {
         new Error('Database connection failed'),
       );
 
-      await expect(controller.getUserExpertise('user-123')).rejects.toThrow(
+      await expect(controller.findUserExpertise('user-123')).rejects.toThrow(
         'Database connection failed',
       );
     });
@@ -144,24 +144,24 @@ describe('ExpertiseController', () => {
         tagName: 'Machine Learning',
         expertiseScore: 0.72,
       });
-      mockExpertiseService.getUserExpertise.mockResolvedValue(mockExpertise);
+      mockExpertiseService.findUserExpertise.mockResolvedValue(mockExpertise);
 
-      const result = await controller.getUserExpertiseByTag('user-456', 'tag-789');
+      const result = await controller.findUserExpertiseByTag('user-456', 'tag-789');
 
       expect(result).toBeDefined();
       expect(result.userId).toBe('user-456');
       expect(result.tagId).toBe('tag-789');
       expect(result.tagName).toBe('Machine Learning');
       expect(result.expertiseScore).toBe(0.72);
-      expect(mockExpertiseService.getUserExpertise).toHaveBeenCalledWith('user-456', 'tag-789');
+      expect(mockExpertiseService.findUserExpertise).toHaveBeenCalledWith('user-456', 'tag-789');
     });
 
     it('should return 404 when expertise not found', async () => {
-      mockExpertiseService.getUserExpertise.mockResolvedValue(null);
+      mockExpertiseService.findUserExpertise.mockResolvedValue(null);
 
-      await expect(controller.getUserExpertiseByTag('user-123', 'nonexistent-tag')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        controller.findUserExpertiseByTag('user-123', 'nonexistent-tag'),
+      ).rejects.toThrow(NotFoundException);
     });
 
     it('should return full expertise details including response count and quality', async () => {
@@ -170,9 +170,9 @@ describe('ExpertiseController', () => {
         avgQualityScore: 0.85,
         credentialBoost: 0.2,
       });
-      mockExpertiseService.getUserExpertise.mockResolvedValue(mockExpertise);
+      mockExpertiseService.findUserExpertise.mockResolvedValue(mockExpertise);
 
-      const result = await controller.getUserExpertiseByTag('user-123', 'tag-456');
+      const result = await controller.findUserExpertiseByTag('user-123', 'tag-456');
 
       expect(result.responseCount).toBe(150);
       expect(result.avgQualityScore).toBe(0.85);
@@ -180,9 +180,9 @@ describe('ExpertiseController', () => {
     });
 
     it('should propagate service errors', async () => {
-      mockExpertiseService.getUserExpertise.mockRejectedValue(new Error('Service unavailable'));
+      mockExpertiseService.findUserExpertise.mockRejectedValue(new Error('Service unavailable'));
 
-      await expect(controller.getUserExpertiseByTag('user-123', 'tag-456')).rejects.toThrow(
+      await expect(controller.findUserExpertiseByTag('user-123', 'tag-456')).rejects.toThrow(
         'Service unavailable',
       );
     });
@@ -309,10 +309,10 @@ describe('ExpertiseController', () => {
 
   describe('Error handling', () => {
     it('should propagate NotFoundException with correct message for missing expertise', async () => {
-      mockExpertiseService.getUserExpertise.mockResolvedValue(null);
+      mockExpertiseService.findUserExpertise.mockResolvedValue(null);
 
       try {
-        await controller.getUserExpertiseByTag('user-123', 'missing-tag');
+        await controller.findUserExpertiseByTag('user-123', 'missing-tag');
         expect.fail('Should have thrown NotFoundException');
       } catch (error) {
         expect(error).toBeInstanceOf(NotFoundException);
@@ -322,19 +322,19 @@ describe('ExpertiseController', () => {
 
     it('should handle concurrent requests gracefully', async () => {
       const mockExpertise = createMockTopicExpertiseDto();
-      mockExpertiseService.getUserExpertise.mockResolvedValue(mockExpertise);
+      mockExpertiseService.findUserExpertise.mockResolvedValue(mockExpertise);
 
       // Simulate concurrent requests
       const promises = [
-        controller.getUserExpertiseByTag('user-1', 'tag-1'),
-        controller.getUserExpertiseByTag('user-2', 'tag-2'),
-        controller.getUserExpertiseByTag('user-3', 'tag-3'),
+        controller.findUserExpertiseByTag('user-1', 'tag-1'),
+        controller.findUserExpertiseByTag('user-2', 'tag-2'),
+        controller.findUserExpertiseByTag('user-3', 'tag-3'),
       ];
 
       const results = await Promise.all(promises);
 
       expect(results).toHaveLength(3);
-      expect(mockExpertiseService.getUserExpertise).toHaveBeenCalledTimes(3);
+      expect(mockExpertiseService.findUserExpertise).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/services/user-service/src/expertise/__tests__/expertise.service.test.ts
+++ b/services/user-service/src/expertise/__tests__/expertise.service.test.ts
@@ -195,14 +195,14 @@ describe('ExpertiseService', () => {
     service = new ExpertiseService(mockPrisma as unknown as PrismaService, mockExpertiseCalculator);
   });
 
-  describe('getUserExpertise', () => {
+  describe('findUserExpertise', () => {
     it('should return expertise for a specific tag when it exists', async () => {
       const mockTag = createMockTag();
       const mockExpertise = createMockTopicExpertise({ tag: mockTag });
 
       mockPrisma.topicExpertise.findFirst.mockResolvedValue(mockExpertise);
 
-      const result = await service.getUserExpertise('user-123', 'tag-123');
+      const result = await service.findUserExpertise('user-123', 'tag-123');
 
       expect(result).not.toBeNull();
       expect(result?.userId).toBe('user-123');
@@ -215,7 +215,7 @@ describe('ExpertiseService', () => {
     it('should return null when expertise does not exist', async () => {
       mockPrisma.topicExpertise.findFirst.mockResolvedValue(null);
 
-      const result = await service.getUserExpertise('user-123', 'tag-456');
+      const result = await service.findUserExpertise('user-123', 'tag-456');
 
       expect(result).toBeNull();
     });
@@ -232,7 +232,7 @@ describe('ExpertiseService', () => {
 
       mockPrisma.topicExpertise.findFirst.mockResolvedValue(mockExpertise);
 
-      const result = await service.getUserExpertise('user-123', 'tag-123');
+      const result = await service.findUserExpertise('user-123', 'tag-123');
 
       expect(result?.progressToNextLevel).toBe(20);
     });
@@ -247,7 +247,7 @@ describe('ExpertiseService', () => {
 
       mockPrisma.topicExpertise.findFirst.mockResolvedValue(mockExpertise);
 
-      const result = await service.getUserExpertise('user-123', 'tag-123');
+      const result = await service.findUserExpertise('user-123', 'tag-123');
 
       expect(result?.progressToNextLevel).toBe(100);
     });
@@ -654,7 +654,7 @@ describe('ExpertiseService', () => {
 
       mockPrisma.topicExpertise.findFirst.mockResolvedValue(mockExpertise);
 
-      const result = await service.getUserExpertise('user-123', 'tag-123');
+      const result = await service.findUserExpertise('user-123', 'tag-123');
 
       expect(result?.progressToNextLevel).toBe(40);
     });
@@ -668,7 +668,7 @@ describe('ExpertiseService', () => {
 
       mockPrisma.topicExpertise.findFirst.mockResolvedValue(mockExpertise);
 
-      const result = await service.getUserExpertise('user-123', 'tag-123');
+      const result = await service.findUserExpertise('user-123', 'tag-123');
 
       expect(result?.responseCount).toBe(42);
     });
@@ -682,7 +682,7 @@ describe('ExpertiseService', () => {
 
       mockPrisma.topicExpertise.findFirst.mockResolvedValue(mockExpertise);
 
-      const result = await service.getUserExpertise('user-123', 'tag-123');
+      const result = await service.findUserExpertise('user-123', 'tag-123');
 
       expect(result?.avgQualityScore).toBeCloseTo(0.85, 2);
     });
@@ -696,7 +696,7 @@ describe('ExpertiseService', () => {
 
       mockPrisma.topicExpertise.findFirst.mockResolvedValue(mockExpertise);
 
-      const result = await service.getUserExpertise('user-123', 'tag-123');
+      const result = await service.findUserExpertise('user-123', 'tag-123');
 
       expect(result?.credentialBoost).toBeCloseTo(0.3, 2);
     });

--- a/services/user-service/src/expertise/expertise.controller.ts
+++ b/services/user-service/src/expertise/expertise.controller.ts
@@ -102,7 +102,7 @@ export class ExpertiseController {
   ): Promise<TopicExpertiseDto> {
     this.logger.debug(`Fetching expertise for user: ${userId}, tag: ${tagId}`);
 
-    const expertise = await this.expertiseService.getUserExpertise(userId, tagId);
+    const expertise = await this.expertiseService.findUserExpertise(userId, tagId);
 
     if (!expertise) {
       throw new NotFoundException(`Expertise not found for user ${userId} in tag ${tagId}`);

--- a/services/user-service/src/expertise/expertise.service.ts
+++ b/services/user-service/src/expertise/expertise.service.ts
@@ -32,13 +32,13 @@ export class ExpertiseService {
   ) {}
 
   /**
-   * Get a user's expertise for a specific topic tag
+   * Find a user's expertise for a specific topic tag.
    *
    * @param userId - The user's unique identifier
    * @param tagId - The topic tag's unique identifier
-   * @returns TopicExpertiseDto or null if no expertise record exists
+   * @returns TopicExpertiseDto if found, null if no expertise record exists
    */
-  async getUserExpertise(userId: string, tagId: string): Promise<TopicExpertiseDto | null> {
+  async findUserExpertise(userId: string, tagId: string): Promise<TopicExpertiseDto | null> {
     const expertise = await this.prisma.topicExpertise.findFirst({
       where: { userId, tagId },
       include: { tag: true },

--- a/services/user-service/src/upload/upload.service.test.ts
+++ b/services/user-service/src/upload/upload.service.test.ts
@@ -27,7 +27,7 @@ describe('UploadService', () => {
     } as unknown as S3Service;
 
     mockUsersService = {
-      getAvatarHash: vi.fn(),
+      findAvatarHash: vi.fn(),
       updateAvatarUrls: vi.fn(),
     } as unknown as UsersService;
 
@@ -69,7 +69,7 @@ describe('UploadService', () => {
         },
       };
 
-      mockUsersService.getAvatarHash.mockResolvedValue(null);
+      mockUsersService.findAvatarHash.mockResolvedValue(null);
       mockImageProcessor.processAvatar.mockResolvedValue(mockVariants);
       mockS3Service.uploadAvatarVariants.mockResolvedValue(mockAvatarUrls);
       mockUsersService.updateAvatarUrls.mockResolvedValue(undefined);
@@ -99,7 +99,7 @@ describe('UploadService', () => {
         { size: 'small', format: 'webp', buffer: Buffer.from('s'), width: 32, height: 32 },
       ];
 
-      mockUsersService.getAvatarHash.mockResolvedValue(null);
+      mockUsersService.findAvatarHash.mockResolvedValue(null);
       mockImageProcessor.processAvatar.mockResolvedValue(mockVariants);
       mockS3Service.uploadAvatarVariants.mockResolvedValue({
         small: { webp: 'url', jpg: 'url' },
@@ -128,7 +128,7 @@ describe('UploadService', () => {
         { size: 'small', format: 'webp', buffer: Buffer.from('s'), width: 32, height: 32 },
       ];
 
-      mockUsersService.getAvatarHash.mockResolvedValue(oldHash);
+      mockUsersService.findAvatarHash.mockResolvedValue(oldHash);
       mockImageProcessor.processAvatar.mockResolvedValue(mockVariants);
       mockS3Service.uploadAvatarVariants.mockResolvedValue({
         small: { webp: 'url', jpg: 'url' },
@@ -156,7 +156,7 @@ describe('UploadService', () => {
         { size: 'small', format: 'webp', buffer: Buffer.from('s'), width: 32, height: 32 },
       ];
 
-      mockUsersService.getAvatarHash.mockResolvedValue(hash);
+      mockUsersService.findAvatarHash.mockResolvedValue(hash);
       mockImageProcessor.processAvatar.mockResolvedValue(mockVariants);
       mockS3Service.uploadAvatarVariants.mockResolvedValue({
         small: { webp: 'url', jpg: 'url' },
@@ -185,7 +185,7 @@ describe('UploadService', () => {
         { size: 'small', format: 'webp', buffer: Buffer.from('s'), width: 32, height: 32 },
       ];
 
-      mockUsersService.getAvatarHash.mockResolvedValue(null);
+      mockUsersService.findAvatarHash.mockResolvedValue(null);
       mockImageProcessor.processAvatar.mockResolvedValue(mockVariants);
       mockS3Service.uploadAvatarVariants.mockResolvedValue({
         small: { webp: 'url', jpg: 'url' },
@@ -218,7 +218,7 @@ describe('UploadService', () => {
         large: { webp: 'url', jpg: 'url' },
       };
 
-      mockUsersService.getAvatarHash.mockResolvedValue(oldHash);
+      mockUsersService.findAvatarHash.mockResolvedValue(oldHash);
       mockImageProcessor.processAvatar.mockResolvedValue(mockVariants);
       mockS3Service.uploadAvatarVariants.mockResolvedValue(mockAvatarUrls);
       mockUsersService.updateAvatarUrls.mockResolvedValue(undefined);
@@ -264,7 +264,7 @@ describe('UploadService', () => {
       const file = Buffer.from('test');
       const mimeType = 'image/jpeg';
 
-      mockUsersService.getAvatarHash.mockResolvedValue(null);
+      mockUsersService.findAvatarHash.mockResolvedValue(null);
       mockImageProcessor.processAvatar.mockResolvedValue([]);
       mockS3Service.uploadAvatarVariants.mockResolvedValue({
         small: { webp: 'url', jpg: 'url' },
@@ -281,7 +281,7 @@ describe('UploadService', () => {
       const file = Buffer.from('test');
       const mimeType = 'image/png';
 
-      mockUsersService.getAvatarHash.mockResolvedValue(null);
+      mockUsersService.findAvatarHash.mockResolvedValue(null);
       mockImageProcessor.processAvatar.mockResolvedValue([]);
       mockS3Service.uploadAvatarVariants.mockResolvedValue({
         small: { webp: 'url', jpg: 'url' },
@@ -298,7 +298,7 @@ describe('UploadService', () => {
       const file = Buffer.from('test');
       const mimeType = 'image/webp';
 
-      mockUsersService.getAvatarHash.mockResolvedValue(null);
+      mockUsersService.findAvatarHash.mockResolvedValue(null);
       mockImageProcessor.processAvatar.mockResolvedValue([]);
       mockS3Service.uploadAvatarVariants.mockResolvedValue({
         small: { webp: 'url', jpg: 'url' },
@@ -315,7 +315,7 @@ describe('UploadService', () => {
       const file = Buffer.from('test');
       const mimeType = 'image/gif';
 
-      mockUsersService.getAvatarHash.mockResolvedValue(null);
+      mockUsersService.findAvatarHash.mockResolvedValue(null);
       mockImageProcessor.processAvatar.mockResolvedValue([]);
       mockS3Service.uploadAvatarVariants.mockResolvedValue({
         small: { webp: 'url', jpg: 'url' },

--- a/services/user-service/src/upload/upload.service.ts
+++ b/services/user-service/src/upload/upload.service.ts
@@ -43,7 +43,7 @@ export class UploadService {
       this.validateMimeType(mimeType);
 
       // 2. Get old hash for cleanup (before processing)
-      const oldHash = await this.usersService.getAvatarHash(userId);
+      const oldHash = await this.usersService.findAvatarHash(userId);
 
       // 3. Generate new hash from file content
       const newHash = this.generateHash(file);
@@ -81,7 +81,7 @@ export class UploadService {
 
     try {
       // Get the current avatar S3 key
-      const s3Key = await this.usersService.getAvatarS3Key(userId);
+      const s3Key = await this.usersService.findAvatarS3Key(userId);
 
       if (s3Key) {
         // Delete from S3

--- a/services/user-service/src/users/users.service.test.ts
+++ b/services/user-service/src/users/users.service.test.ts
@@ -123,7 +123,7 @@ describe('UsersService', () => {
     });
   });
 
-  describe('getAvatarHash', () => {
+  describe('findAvatarHash', () => {
     it('should return avatarHash for user', async () => {
       const userId = '550e8400-e29b-41d4-a716-446655440000';
       (mockPrismaService.user.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -131,7 +131,7 @@ describe('UsersService', () => {
         avatarHash: 'abc12345',
       });
 
-      const result = await service.getAvatarHash(userId);
+      const result = await service.findAvatarHash(userId);
 
       expect(result).toBe('abc12345');
       expect(mockPrismaService.user.findUnique).toHaveBeenCalledWith({
@@ -147,7 +147,7 @@ describe('UsersService', () => {
         avatarHash: null,
       });
 
-      const result = await service.getAvatarHash(userId);
+      const result = await service.findAvatarHash(userId);
 
       expect(result).toBeNull();
     });
@@ -156,13 +156,13 @@ describe('UsersService', () => {
       const userId = '550e8400-e29b-41d4-a716-446655440000';
       (mockPrismaService.user.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
-      const result = await service.getAvatarHash(userId);
+      const result = await service.findAvatarHash(userId);
 
       expect(result).toBeNull();
     });
 
     it('should throw BadRequestException for invalid userId', async () => {
-      await expect(service.getAvatarHash('invalid-uuid')).rejects.toThrow(BadRequestException);
+      await expect(service.findAvatarHash('invalid-uuid')).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/services/user-service/src/users/users.service.ts
+++ b/services/user-service/src/users/users.service.ts
@@ -402,11 +402,13 @@ export class UsersService {
   }
 
   /**
-   * Get a user's current avatar S3 key (for deletion before replacing)
+   * Find a user's current avatar S3 key (for deletion before replacing).
+   *
    * @param userId - The user's UUID
-   * @returns The S3 key or null if no avatar exists
+   * @returns The S3 key if found, null if no avatar exists
+   * @throws {BadRequestException} When userId is not a valid UUID
    */
-  async getAvatarS3Key(userId: string): Promise<string | null> {
+  async findAvatarS3Key(userId: string): Promise<string | null> {
     if (!isValidUUID(userId)) {
       throw new BadRequestException(`Invalid user ID format: expected UUID`);
     }
@@ -827,12 +829,13 @@ export class UsersService {
   }
 
   /**
-   * Get user's avatar hash for S3 folder management
-   * @param userId - User ID
-   * @returns Avatar hash or null if not set
-   * @throws BadRequestException if userId is not a valid UUID
+   * Find a user's avatar hash for S3 folder management.
+   *
+   * @param userId - The user's UUID
+   * @returns Avatar hash if found, null if not set
+   * @throws {BadRequestException} When userId is not a valid UUID
    */
-  async getAvatarHash(userId: string): Promise<string | null> {
+  async findAvatarHash(userId: string): Promise<string | null> {
     if (!isValidUUID(userId)) {
       throw new BadRequestException(`Invalid user ID format: expected UUID`);
     }


### PR DESCRIPTION
## Summary

- Apply naming conventions from CLAUDE.md error handling patterns across 6 backend services
- Rename 15 methods from `get*` to `find*` prefix for methods that return `null` when not found
- Add JSDoc documentation to all renamed methods indicating return behavior

## Methods Renamed

| Service | Old Name | New Name |
|---------|----------|----------|
| user-service | `getUserExpertise` | `findUserExpertise` |
| user-service | `getAvatarS3Key` | `findAvatarS3Key` |
| user-service | `getAvatarHash` | `findAvatarHash` |
| discussion-service | `getUserAlignment` | `findUserAlignment` |
| discussion-service | `getReadState` | `findReadState` |
| discussion-service | `getLinkById` | `findLinkById` |
| discussion-service | `getLatestEdit` | `findLatestEdit` |
| ai-service | `getEmbedding` | `findEmbedding` |
| ai-service | `getCachedEmbedding` | `findCachedEmbedding` |
| ai-service | `getFeedback` | `findFeedback` |
| fact-check-service | `getById` | `findById` |
| fact-check-service | `getResultById` | `findResultById` |
| moderation-service | `getAppealById` | `findAppealById` |
| moderation-service | `getReport` | `findReport` |
| notification-service | `getParentContact` | `findParentContact` |

## Naming Convention Reference

| Pattern | Returns | When to Use |
|---------|---------|-------------|
| `get*()` | Entity or throws | Required resource lookups |
| `find*()` | Entity \| null | Optional resource lookups |
| `try*()` | void | Fire-and-forget (analytics, notifications) |

## Test plan

- [x] All 6 service TypeScript compilations pass
- [x] moderation-service: 265 tests pass
- [x] notification-service: 138 tests pass
- [x] fact-check-service: 89 tests pass
- [x] All pre-commit hooks pass

Resolves #1168

🤖 Generated with [Claude Code](https://claude.ai/code)