### PR TITLE
ci: add workflow to delete branches after PR merge

### DIFF
--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -1,0 +1,23 @@
+name: Delete merged branch
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  delete-branch:
+    if: github.event.pull_request.merged == true
+    runs-on: [self-hosted, linux]
+    steps:
+      - name: Delete head branch
+        uses: octokit/request-action@v2.x
+        with:
+          route: DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          branch: ${{ github.event.pull_request.head.ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to auto-delete branches after PR merge
- Fixes issue where auto-merge via github-actions[bot] bypasses GitHub's "automatically delete head branches" setting

## Test plan
- [x] Workflow triggers on `pull_request: closed` events
- [x] Only runs when PR is merged (`github.event.pull_request.merged == true`)
- [ ] Verify branch deletion after this PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)