### PR TITLE
fix(e2e): improve test selectors and accessibility

### DIFF
--- a/frontend/e2e/user-registration-login-flow.spec.ts
+++ b/frontend/e2e/user-registration-login-flow.spec.ts
@@ -331,10 +331,10 @@ test.describe('User Registration and Login Flow', () => {
     });
     await expect(registrationHeading).toBeVisible({ timeout: 10000 });
 
-    // Find and click "Sign in" button on signup page (it's a button, not a link)
-    const loginButton = page.getByRole('button', { name: /sign in/i });
-    await expect(loginButton).toBeVisible();
-    await loginButton.click();
+    // Find and click "Sign in" link on signup page
+    const loginLink = page.getByRole('link', { name: /sign in/i });
+    await expect(loginLink).toBeVisible();
+    await loginLink.click();
 
     // Should navigate back to landing page where login is a modal
     await expect(page).toHaveURL(/\/$|\/login/);

--- a/frontend/src/components/notifications/NotificationDropdown.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown.tsx
@@ -47,6 +47,7 @@ export function NotificationDropdown() {
           )}
         </div>
       }
+      ariaLabel="Notifications"
       isOpen={isOpen}
       onOpenChange={setIsOpen}
       align="right"

--- a/frontend/src/components/ui/Dropdown.tsx
+++ b/frontend/src/components/ui/Dropdown.tsx
@@ -20,6 +20,8 @@ interface DropdownProps {
   className?: string;
   /** Whether to close on click outside */
   closeOnClickOutside?: boolean;
+  /** Accessible label for the trigger button (required when trigger is icon-only) */
+  ariaLabel?: string;
 }
 
 /**
@@ -36,6 +38,7 @@ export function Dropdown({
   onOpenChange,
   className = '',
   closeOnClickOutside = true,
+  ariaLabel,
 }: DropdownProps) {
   const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -93,6 +96,7 @@ export function Dropdown({
         className="flex items-center justify-center min-h-[44px] min-w-[44px] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
         aria-expanded={isOpen}
         aria-haspopup="true"
+        aria-label={ariaLabel}
       >
         {trigger}
       </button>


### PR DESCRIPTION
## Summary

- Fixed selector issue in `user-registration-login-flow.spec.ts` - changed button to link role for "Sign in" navigation
- Fixed accessibility violation in `Dropdown` component - added `ariaLabel` prop for icon-only triggers
- Applied accessibility fix to `NotificationDropdown` component

## Test Results

**Before fixes:**
- `user-registration-login-flow.spec.ts`: 15 failed, 15 skipped, 90 passed
- `accessibility.spec.ts`: 3 failed (button-name violation), 24 passed

**After fixes:**
- `user-registration-login-flow.spec.ts`: 12 failed (require backend), 15 skipped, 93 passed ✅
- `accessibility.spec.ts`: 0 failed, 27 passed ✅

The remaining failures require the E2E Docker environment with running backend services (registration/login API).

## Changes

1. **Selector Fix** (`user-registration-login-flow.spec.ts`):
   - The "Sign in" element on the signup page is a `<Link>` component, not a button
   - Changed `getByRole('button', { name: /sign in/i })` to `getByRole('link', { name: /sign in/i })`

2. **Accessibility Fix** (`Dropdown.tsx`, `NotificationDropdown.tsx`):
   - Added `ariaLabel` prop to Dropdown component interface
   - Applied to button element for icon-only triggers
   - NotificationDropdown now passes `ariaLabel="Notifications"`
   - Fixes axe-core `button-name` violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)