### PR TITLE
fix(e2e): correct registration flow and response selectors

### DIFF
--- a/frontend/e2e/complete-verification-flow.spec.ts
+++ b/frontend/e2e/complete-verification-flow.spec.ts
@@ -36,7 +36,7 @@ test.describe('Complete Verification Flow', () => {
 
   // Helper function to register, login, and navigate
   const registerAndLogin = async (page: Page) => {
-    // Navigate to registration page
+    // Step 1: Navigate to registration page and register
     await page.goto('/register');
     await page.waitForLoadState('domcontentloaded');
 
@@ -55,6 +55,26 @@ test.describe('Complete Verification Flow', () => {
 
     // Wait for navigation away from /register (registration success)
     await page.waitForURL(/^(?!.*\/register).*$/, { timeout: 10000 });
+
+    // Step 2: Login with newly created credentials
+    // Registration doesn't auto-login - we need to explicitly log in
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Open login modal
+    await page.getByRole('button', { name: /log in/i }).click();
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+
+    // Fill login form
+    const dialog = page.getByRole('dialog');
+    await dialog.getByLabel(/email/i).fill(testUser.email);
+    await dialog.getByLabel('Password', { exact: true }).fill(testUser.password);
+
+    // Submit login
+    await dialog.getByRole('button', { name: /^log in$/i }).click();
+
+    // Wait for login modal to close
+    await expect(dialog).not.toBeVisible({ timeout: 15000 });
 
     // Wait for authentication state to stabilize
     // Note: Don't use networkidle as WebSocket keeps network active

--- a/frontend/e2e/fact-check-flow.spec.ts
+++ b/frontend/e2e/fact-check-flow.spec.ts
@@ -33,7 +33,7 @@ test.describe('Fact-Check Feature', () => {
 
   test('should display fact-check button on response', async ({ page }) => {
     // Wait for responses to load
-    const response = page.locator('[data-testid="response-card"]').first();
+    const response = page.locator('[data-testid="response-item"]').first();
     await expect(response).toBeVisible({ timeout: 10000 });
 
     // Find the fact-check button
@@ -54,7 +54,7 @@ test.describe('Fact-Check Feature', () => {
 
   test('should show loading state when requesting fact-check', async ({ page }) => {
     // Wait for responses to load
-    const response = page.locator('[data-testid="response-card"]').first();
+    const response = page.locator('[data-testid="response-item"]').first();
     await expect(response).toBeVisible({ timeout: 10000 });
 
     // Find and click the fact-check button
@@ -79,7 +79,7 @@ test.describe('Fact-Check Feature', () => {
 
   test('should display fact-check results after request', async ({ page }) => {
     // Wait for responses to load
-    const response = page.locator('[data-testid="response-card"]').first();
+    const response = page.locator('[data-testid="response-item"]').first();
     await expect(response).toBeVisible({ timeout: 10000 });
 
     // Find and click the fact-check button
@@ -106,7 +106,7 @@ test.describe('Fact-Check Feature', () => {
 
   test('should display fact-check badge when results exist', async ({ page }) => {
     // Wait for responses to load
-    const response = page.locator('[data-testid="response-card"]').first();
+    const response = page.locator('[data-testid="response-item"]').first();
     await expect(response).toBeVisible({ timeout: 10000 });
 
     // Look for fact-check badge (may already exist if previously checked)
@@ -124,7 +124,7 @@ test.describe('Fact-Check Feature', () => {
 
   test('should display source information in results', async ({ page }) => {
     // Wait for responses to load
-    const response = page.locator('[data-testid="response-card"]').first();
+    const response = page.locator('[data-testid="response-item"]').first();
     await expect(response).toBeVisible({ timeout: 10000 });
 
     // Find and click the fact-check button
@@ -161,7 +161,7 @@ test.describe('Fact-Check Feature', () => {
 
   test('should show credibility score indicator', async ({ page }) => {
     // Wait for responses to load
-    const response = page.locator('[data-testid="response-card"]').first();
+    const response = page.locator('[data-testid="response-item"]').first();
     await expect(response).toBeVisible({ timeout: 10000 });
 
     // Find and click the fact-check button
@@ -188,7 +188,7 @@ test.describe('Fact-Check Feature', () => {
     // Navigate to a response that may have conflicting fact-check results
 
     // Wait for responses to load
-    const responses = page.locator('[data-testid="response-card"]');
+    const responses = page.locator('[data-testid="response-item"]');
     await expect(responses.first()).toBeVisible({ timeout: 10000 });
 
     // Look for any existing conflict indicator
@@ -211,7 +211,7 @@ test.describe('Fact-Check Feature', () => {
 
   test('should display "Related Context" label per FR-012b', async ({ page }) => {
     // Wait for responses to load
-    const response = page.locator('[data-testid="response-card"]').first();
+    const response = page.locator('[data-testid="response-item"]').first();
     await expect(response).toBeVisible({ timeout: 10000 });
 
     // Find and click the fact-check button
@@ -241,7 +241,7 @@ test.describe('Fact-Check Feature', () => {
 
   test('should be accessible with keyboard navigation', async ({ page }) => {
     // Wait for responses to load
-    const response = page.locator('[data-testid="response-card"]').first();
+    const response = page.locator('[data-testid="response-item"]').first();
     await expect(response).toBeVisible({ timeout: 10000 });
 
     // Find the fact-check button


### PR DESCRIPTION
## Summary
- Fixed `complete-verification-flow.spec.ts` registration helper to add explicit login step after registration (registration does not auto-login - requires email verification first)
- Fixed `fact-check-flow.spec.ts` selector mismatch - changed `response-card` to `response-item` to match actual component data-testid

## Root Causes
1. **Registration doesn't auto-login**: The `/auth/register` endpoint returns `RegisterResponseDto` without tokens. Users must verify email first, then login separately.
2. **Selector mismatch**: The discussions page renders `ResponseItem` components with `data-testid="response-item"`, not `ResponseCard`.

## Test plan
- [ ] Jenkins E2E tests pass (previously 82 failing tests)
- [ ] complete-verification-flow tests wait for Profile link after explicit login
- [ ] fact-check-flow tests correctly locate response items

🤖 Generated with [Claude Code](https://claude.com/claude-code)