### PR TITLE
fix(e2e): add healthcheck to api-gateway to prevent race conditions

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -154,6 +154,12 @@ services:
         condition: service_healthy
       discussion-service:
         condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
     mem_limit: 128m
     networks:
       - reasonbridge-e2e
@@ -428,7 +434,7 @@ services:
       start_period: 10s
     depends_on:
       api-gateway:
-        condition: service_started
+        condition: service_healthy
     mem_limit: 64m
     networks:
       - reasonbridge-e2e


### PR DESCRIPTION
## Summary
- Added healthcheck to api-gateway service (curl /health endpoint)
- Changed frontend's dependency from `service_started` to `service_healthy`

## Problem
The frontend service was starting as soon as api-gateway's container started, not when its HTTP server was ready. This caused E2E tests to fail because API requests returned errors during api-gateway's initialization period.

The E2E tests couldn't find seeded demo users like "Alice Anderson" because:
1. Frontend starts when api-gateway container starts (not when ready)
2. E2E tests begin immediately
3. API requests fail during api-gateway's startup period
4. Tests timeout waiting for content that never loads

## Solution
Add a healthcheck to api-gateway that verifies the HTTP server is ready before allowing frontend to start. This creates a proper dependency chain:

```
db-seed completes → backend services healthy → api-gateway healthy → frontend starts → E2E tests run
```

## Test plan
- [ ] E2E tests pass (75 previously failing tests should now pass)
- [ ] Profile pages correctly show demo users (Alice Anderson, Mod Martinez, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)