### PR TITLE
fix(frontend): mobile discussion/layout audit fixes (2026-07-10)

### DIFF
--- a/frontend/src/components/discussion-layout/ConversationPanel.tsx
+++ b/frontend/src/components/discussion-layout/ConversationPanel.tsx
@@ -68,7 +68,7 @@ export function ConversationPanel({
   // CRITICAL: All hooks must be called BEFORE any conditional returns
   // React Error #310 occurs when hooks are called conditionally
   const responseListContainerRef = useRef<HTMLDivElement>(null);
-  const { toggleLeftPanelOverlay } = useDiscussionLayout();
+  const { toggleLeftPanelOverlay, hasLeftPanel } = useDiscussionLayout();
   const breakpoint = useBreakpoint();
   const { subscribe } = useWebSocket();
   const { user } = useAuth();
@@ -84,7 +84,11 @@ export function ConversationPanel({
   // Measured height of the response list container for virtual scrolling
   const [measuredHeight, setMeasuredHeight] = useState<number>(0);
 
-  const showHamburgerMenu = breakpoint === 'tablet' || breakpoint === 'mobile';
+  // Only offer the topic-navigation hamburger when a left panel actually exists.
+  // On the discussion page the layout renders with no left panel, so the button would
+  // toggle a non-existent overlay and do nothing when tapped (#1376).
+  const showHamburgerMenu =
+    hasLeftPanel === true && (breakpoint === 'tablet' || breakpoint === 'mobile');
 
   // Measure the actual available height for the response list container
   // Using ResizeObserver to handle dynamic resizing (window resize, panel resize, etc.)
@@ -271,7 +275,7 @@ export function ConversationPanel({
             <button
               type="button"
               onClick={toggleLeftPanelOverlay}
-              className="shrink-0 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors lg:hidden"
+              className="shrink-0 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors xl:hidden"
               aria-label="Open topic navigation"
             >
               <svg
@@ -324,7 +328,7 @@ export function ConversationPanel({
               <button
                 type="button"
                 onClick={() => setIsEditModalOpen(true)}
-                className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
                 aria-label="Edit topic"
                 title="Edit topic"
               >
@@ -492,7 +496,7 @@ export function ConversationPanel({
             <button
               type="button"
               onClick={handleDismissStatusChange}
-              className="p-1 rounded-lg hover:bg-black/5 dark:hover:bg-white/10 transition-colors"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg hover:bg-black/5 dark:hover:bg-white/10 transition-colors"
               aria-label="Dismiss notification"
             >
               <svg

--- a/frontend/src/components/discussion-layout/DiscussionLayout.tsx
+++ b/frontend/src/components/discussion-layout/DiscussionLayout.tsx
@@ -98,6 +98,10 @@ export function DiscussionLayout({
   const breakpoint = useBreakpoint();
   const [isLeftPanelOverlayOpen, setIsLeftPanelOverlayOpen] = useState(false);
 
+  // A left panel only exists when it isn't hidden AND content was actually provided.
+  // The overlay/hamburger/swipe affordances are meaningless without it (#1376).
+  const hasLeftPanel = !hideSidebar && leftPanel != null;
+
   // Close overlay when breakpoint changes to desktop
   useEffect(() => {
     if (breakpoint === 'desktop') {
@@ -119,7 +123,11 @@ export function DiscussionLayout({
   // Swipe gesture handlers (mobile/tablet only)
   const swipeHandlers = useSwipeable({
     onSwipedRight: () => {
-      if ((breakpoint === 'tablet' || breakpoint === 'mobile') && !isLeftPanelOverlayOpen) {
+      if (
+        hasLeftPanel &&
+        (breakpoint === 'tablet' || breakpoint === 'mobile') &&
+        !isLeftPanelOverlayOpen
+      ) {
         setIsLeftPanelOverlayOpen(true);
       }
     },
@@ -145,6 +153,7 @@ export function DiscussionLayout({
       setPanelWidth,
       togglePanel,
       setActiveTopic,
+      hasLeftPanel,
       isLeftPanelOverlayOpen,
       toggleLeftPanelOverlay: handleToggleLeftPanelOverlay,
       closeLeftPanelOverlay: handleCloseLeftPanelOverlay,
@@ -157,6 +166,7 @@ export function DiscussionLayout({
       setPanelWidth,
       togglePanel,
       setActiveTopic,
+      hasLeftPanel,
       isLeftPanelOverlayOpen,
       handleToggleLeftPanelOverlay,
       handleCloseLeftPanelOverlay,

--- a/frontend/src/components/layouts/MobileDrawer.tsx
+++ b/frontend/src/components/layouts/MobileDrawer.tsx
@@ -8,6 +8,8 @@ import { createPortal } from 'react-dom';
 import { Link } from 'react-router-dom';
 import { TopicNavigationContent } from '../topics/TopicNavigationContent';
 import { useSidebar } from '../../hooks/useSidebar';
+import { useScrollLock } from '../../hooks/useScrollLock';
+import { useElementHeight } from '../../hooks/useElementHeight';
 import { useAuth } from '../../hooks/useAuth';
 import { useWebSocket } from '../../hooks/useWebSocket';
 import { useTopicNavigation } from '../../hooks/useTopicNavigation';
@@ -41,6 +43,9 @@ export function MobileDrawer() {
   const drawerRef = useRef<HTMLElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const [unreadMap, setUnreadMap] = useState<Map<string, boolean>>(new Map());
+  // Live-measured height for the topic virtual list (stays correct after rotation /
+  // keyboard viewport shrink — see #1383).
+  const [topicListRef, topicListHeight] = useElementHeight<HTMLDivElement>(400);
 
   // Fetch topics when in topics mode and drawer is open
   // When not in topics mode or drawer is closed, pass undefined to skip fetching
@@ -113,18 +118,8 @@ export function MobileDrawer() {
     return () => document.removeEventListener('keydown', handleEscape);
   }, [isMobileOpen, closeMobile]);
 
-  // Lock body scroll when drawer is open
-  useEffect(() => {
-    if (isMobileOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
-
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, [isMobileOpen]);
+  // Lock body scroll when drawer is open (reference-counted — see #1378).
+  useScrollLock(isMobileOpen);
 
   // Focus trap: Keep focus within drawer when open
   useEffect(() => {
@@ -243,14 +238,14 @@ export function MobileDrawer() {
             <CompactSiteNav onNavigate={closeMobile} />
 
             {/* Topic Navigation Content */}
-            <div className="flex-1 overflow-hidden">
+            <div ref={topicListRef} className="flex-1 overflow-hidden">
               <TopicNavigationContent
                 topics={topics}
                 unreadMap={unreadMap}
                 isLoading={isLoading}
                 error={errorMessage}
                 onRetry={() => refetch()}
-                height={typeof window !== 'undefined' ? window.innerHeight - 180 : 400}
+                height={topicListHeight}
                 onTopicSelect={handleTopicSelect}
               />
             </div>

--- a/frontend/src/components/layouts/Sidebar.tsx
+++ b/frontend/src/components/layouts/Sidebar.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { useWebSocket } from '../../hooks/useWebSocket';
 import { useTopicNavigation } from '../../hooks/useTopicNavigation';
 import { useTopics } from '../../lib/useTopics';
+import { useElementHeight } from '../../hooks/useElementHeight';
 import Avatar from '../ui/Avatar';
 import { Navigation } from './Navigation';
 import { CompactSiteNav } from './CompactSiteNav';
@@ -39,6 +40,9 @@ export function Sidebar() {
   const { activeTopicId } = useTopicNavigation();
   const { subscribe } = useWebSocket();
   const [unreadMap, setUnreadMap] = useState<Map<string, boolean>>(new Map());
+  // Live-measured height for the topic virtual list (stays correct after rotation /
+  // keyboard viewport shrink — see #1383).
+  const [topicListRef, topicListHeight] = useElementHeight<HTMLDivElement>(600);
 
   // Fetch topics when in topics mode
   // When not in topics mode, pass undefined to skip fetching
@@ -125,14 +129,14 @@ export function Sidebar() {
 
         {/* Topic Navigation Content - hidden when collapsed */}
         {!isCollapsed && (
-          <div className="flex-1 overflow-hidden">
+          <div ref={topicListRef} className="flex-1 overflow-hidden">
             <TopicNavigationContent
               topics={topics}
               unreadMap={unreadMap}
               isLoading={isLoading}
               error={errorMessage}
               onRetry={() => refetch()}
-              height={typeof window !== 'undefined' ? window.innerHeight - 120 : 600}
+              height={topicListHeight}
             />
           </div>
         )}

--- a/frontend/src/components/responses/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/responses/DeleteConfirmDialog.tsx
@@ -6,6 +6,7 @@
 import React, { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import Button from '../ui/Button';
+import { useScrollLock } from '../../hooks/useScrollLock';
 
 export interface DeleteConfirmDialogProps {
   isOpen: boolean;
@@ -65,16 +66,8 @@ const DeleteConfirmDialog: React.FC<DeleteConfirmDialogProps> = ({
     return () => document.removeEventListener('keydown', handleEscape);
   }, [isOpen, isDeleting, onCancel]);
 
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, [isOpen]);
+  // Reference-counted lock so a still-open drawer/modal keeps scroll locked (#1378).
+  useScrollLock(isOpen);
 
   if (!isOpen) return null;
 

--- a/frontend/src/components/responses/ReportDialog.tsx
+++ b/frontend/src/components/responses/ReportDialog.tsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import Button from '../ui/Button';
 import { useRequireAuth } from '../../hooks/useRequireAuth';
+import { useScrollLock } from '../../hooks/useScrollLock';
 
 export type ReportReason = 'SPAM' | 'HARASSMENT' | 'MISINFORMATION' | 'HATE_SPEECH' | 'OTHER';
 
@@ -80,16 +81,8 @@ const ReportDialog: React.FC<ReportDialogProps> = ({
     return () => document.removeEventListener('keydown', handleEscape);
   }, [isOpen, isSubmitting, onClose]);
 
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, [isOpen]);
+  // Reference-counted lock so a still-open drawer/modal keeps scroll locked (#1378).
+  useScrollLock(isOpen);
 
   const handleSubmit = () => {
     requireAuth(async () => {

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useEffect, useRef } from 'react';
+import { useScrollLock } from '../../hooks/useScrollLock';
 
 export interface ModalProps {
   /**
@@ -85,18 +86,9 @@ const Modal: React.FC<ModalProps> = ({
     return () => document.removeEventListener('keydown', handleEscape);
   }, [isOpen, closeOnEscape, onClose]);
 
-  // Prevent body scroll when modal is open
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'unset';
-    }
-
-    return () => {
-      document.body.style.overflow = 'unset';
-    };
-  }, [isOpen]);
+  // Prevent body scroll when modal is open (reference-counted so overlapping
+  // overlays don't clobber each other's lock — see #1378).
+  useScrollLock(isOpen);
 
   // Focus trap
   useEffect(() => {

--- a/frontend/src/contexts/DiscussionLayoutContext.tsx
+++ b/frontend/src/contexts/DiscussionLayoutContext.tsx
@@ -40,6 +40,13 @@ interface DiscussionLayoutContextValue {
   setPanelWidth: (panel: 'left' | 'right', width: number) => void;
   togglePanel: (panel: 'left' | 'right') => void;
   setActiveTopic: (topicId: string | null) => void;
+  /**
+   * Whether a left (topic-navigation) panel actually exists in this layout instance.
+   * False when the layout is rendered with `hideSidebar` and no `leftPanel` (e.g. the
+   * discussion page, where the unified sidebar owns navigation). Consumers use this to
+   * avoid rendering a hamburger/overlay control that toggles a non-existent panel (#1376).
+   */
+  hasLeftPanel?: boolean;
   /** Whether left panel overlay is open (tablet/mobile only) */
   isLeftPanelOverlayOpen?: boolean;
   /** Toggle left panel overlay (tablet/mobile only) */

--- a/frontend/src/hooks/__tests__/useMediaQuery.test.ts
+++ b/frontend/src/hooks/__tests__/useMediaQuery.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMediaQuery } from '../useMediaQuery';
+
+type Listener = (event: MediaQueryListEvent) => void;
+
+function installMatchMedia(matches: boolean) {
+  const listeners = new Set<Listener>();
+  const mql = {
+    matches,
+    media: '',
+    addEventListener: (_: string, cb: Listener) => listeners.add(cb),
+    removeEventListener: (_: string, cb: Listener) => listeners.delete(cb),
+    addListener: (cb: Listener) => listeners.add(cb),
+    removeListener: (cb: Listener) => listeners.delete(cb),
+    dispatchEvent: () => true,
+  };
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockReturnValue(mql),
+  });
+  return {
+    emit: (next: boolean) => {
+      mql.matches = next;
+      listeners.forEach((cb) => cb({ matches: next } as MediaQueryListEvent));
+    },
+  };
+}
+
+describe('useMediaQuery', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the real match value on the FIRST render (no deferred false frame) — #1382', () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useMediaQuery('(max-width: 767px)'));
+    // Synchronous init: a phone must not see a `false` (desktop) frame first.
+    expect(result.current).toBe(true);
+  });
+
+  it('reflects subsequent media changes', () => {
+    const { emit } = installMatchMedia(false);
+    const { result } = renderHook(() => useMediaQuery('(max-width: 767px)'));
+    expect(result.current).toBe(false);
+
+    act(() => emit(true));
+    expect(result.current).toBe(true);
+  });
+
+  describe('SSR / no matchMedia', () => {
+    beforeEach(() => {
+      // Simulate a non-browser environment where matchMedia is absent.
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: undefined,
+      });
+    });
+
+    it('falls back to false without throwing', () => {
+      const { result } = renderHook(() => useMediaQuery('(max-width: 767px)'));
+      expect(result.current).toBe(false);
+    });
+  });
+});

--- a/frontend/src/hooks/__tests__/useScrollLock.test.ts
+++ b/frontend/src/hooks/__tests__/useScrollLock.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import {
+  useScrollLock,
+  lockBodyScroll,
+  unlockBodyScroll,
+  __resetScrollLockForTests,
+} from '../useScrollLock';
+
+describe('useScrollLock (reference-counted body scroll lock)', () => {
+  beforeEach(() => {
+    __resetScrollLockForTests();
+    document.body.style.overflow = '';
+  });
+
+  it('locks on mount and restores the original value on unmount', () => {
+    const { unmount } = renderHook(() => useScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unmount();
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('does not lock when inactive', () => {
+    renderHook(() => useScrollLock(false));
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('preserves a pre-existing inline overflow value (no clobber to "" / "unset")', () => {
+    document.body.style.overflow = 'scroll';
+    const { unmount } = renderHook(() => useScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unmount();
+    expect(document.body.style.overflow).toBe('scroll');
+  });
+
+  it('keeps the lock while any overlay remains open (the #1378 regression)', () => {
+    // Two overlays open concurrently.
+    lockBodyScroll();
+    lockBodyScroll();
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // First overlay closes — background must STAY locked.
+    unlockBodyScroll();
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // Second overlay closes — now the original value is restored.
+    unlockBodyScroll();
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('never drives the counter negative on an extra unlock', () => {
+    lockBodyScroll();
+    unlockBodyScroll();
+    unlockBodyScroll(); // stray unlock — must be a no-op
+    lockBodyScroll();
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+});

--- a/frontend/src/hooks/useElementHeight.ts
+++ b/frontend/src/hooks/useElementHeight.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useLayoutEffect, useRef, useState } from 'react';
+
+/**
+ * Measure a container's live pixel height via ResizeObserver.
+ *
+ * @remarks
+ * Virtual lists need an explicit pixel height. Deriving it once from
+ * `window.innerHeight - <magic offset>` at render time goes stale after rotation or a
+ * keyboard-driven viewport shrink (`interactive-widget=resizes-content`), because there
+ * is no resize subscription driving a re-measure (see issue #1383). This hook mirrors the
+ * ResizeObserver pattern already used by ConversationPanel: attach the returned `ref` to
+ * the flex container that should be measured and pass `height` to the virtual list.
+ *
+ * @param fallback - Height used until the first measurement (and under SSR).
+ * @returns A tuple of `[ref, height]`.
+ */
+export function useElementHeight<T extends HTMLElement = HTMLDivElement>(
+  fallback = 400,
+): [React.RefObject<T | null>, number] {
+  const ref = useRef<T>(null);
+  const [height, setHeight] = useState<number>(fallback);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return undefined;
+
+    const update = () => {
+      const measured = el.getBoundingClientRect().height;
+      // Ignore transient zero-height frames (e.g. while hidden) to keep the fallback.
+      if (measured > 0) setHeight(measured);
+    };
+
+    update();
+
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, height];
+}

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -20,17 +20,32 @@ import { useState, useEffect } from 'react';
  * ```
  */
 export function useMediaQuery(query: string): boolean {
-  // Initialize with false to avoid hydration mismatch (SSR compatibility)
-  const [matches, setMatches] = useState<boolean>(false);
+  // Initialize synchronously from the real match so the first committed frame is correct.
+  // This is a client-only SPA (no SSR/hydration), so the previous deferred `setTimeout(0)`
+  // default of `false` produced a one-frame desktop layout on phones (#1382). Mirrors
+  // useBreakpoint, which already initializes synchronously from window.innerWidth.
+  const [matches, setMatches] = useState<boolean>(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false; // SSR / non-browser fallback
+    }
+    return window.matchMedia(query).matches;
+  });
 
   useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+
     // Create MediaQueryList object
     const mediaQuery = window.matchMedia(query);
 
-    // Set initial value asynchronously to avoid cascading renders
-    const initTimer = setTimeout(() => {
-      setMatches(mediaQuery.matches);
-    }, 0);
+    // Re-sync in case the query changed or the viewport shifted before this effect ran.
+    // Wrapped in a helper + functional no-op form (mirrors useBreakpoint) so it doesn't
+    // trigger a cascading render.
+    const sync = () => {
+      setMatches((prev) => (prev !== mediaQuery.matches ? mediaQuery.matches : prev));
+    };
+    sync();
 
     // Create event listener for changes
     const handleChange = (event: MediaQueryListEvent) => {
@@ -47,7 +62,6 @@ export function useMediaQuery(query: string): boolean {
 
     // Cleanup
     return () => {
-      clearTimeout(initTimer);
       if (mediaQuery.removeEventListener) {
         mediaQuery.removeEventListener('change', handleChange);
       } else {

--- a/frontend/src/hooks/useScrollLock.ts
+++ b/frontend/src/hooks/useScrollLock.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect } from 'react';
+
+/**
+ * Reference-counted body scroll lock.
+ *
+ * @remarks
+ * Multiple overlays (drawer, modal, dialogs) can be open at once. Previously each
+ * component wrote `document.body.style.overflow` directly with no coordination, so the
+ * first overlay to close reset body overflow and re-enabled background scrolling behind
+ * a still-open overlay (see issue #1378). This module serialises all locks through a
+ * single counter:
+ *
+ * - The original inline `overflow` value is captured on the 0 → 1 transition.
+ * - `overflow: hidden` stays applied while any lock is held.
+ * - The captured value is restored only on the 1 → 0 transition, so a pre-existing
+ *   inline value is preserved rather than clobbered with `''`/`'unset'`.
+ */
+
+let lockCount = 0;
+let savedOverflow = '';
+
+/** Acquire a scroll lock. Safe to call when SSR (no document). */
+export function lockBodyScroll(): void {
+  if (typeof document === 'undefined') return;
+  if (lockCount === 0) {
+    savedOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+  }
+  lockCount += 1;
+}
+
+/** Release a previously acquired scroll lock. */
+export function unlockBodyScroll(): void {
+  if (typeof document === 'undefined') return;
+  if (lockCount === 0) return;
+  lockCount -= 1;
+  if (lockCount === 0) {
+    document.body.style.overflow = savedOverflow;
+  }
+}
+
+/**
+ * Lock body scroll while `active` is true; automatically released on unmount or when
+ * `active` becomes false. Reference-counted so concurrent overlays never clobber each
+ * other.
+ *
+ * @param active - Whether this consumer currently wants body scroll locked.
+ */
+export function useScrollLock(active: boolean): void {
+  useEffect(() => {
+    if (!active) return undefined;
+    lockBodyScroll();
+    return () => unlockBodyScroll();
+  }, [active]);
+}
+
+/** Test-only: reset the shared lock state between tests. */
+export function __resetScrollLockForTests(): void {
+  lockCount = 0;
+  savedOverflow = '';
+}

--- a/frontend/src/pages/Topics/TopicDetailPage.tsx
+++ b/frontend/src/pages/Topics/TopicDetailPage.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useParams, Link } from 'react-router-dom';
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTopic } from '../../lib/useTopic';
 import { useCommonGroundAnalysis } from '../../lib/useCommonGroundAnalysis';
@@ -45,6 +45,17 @@ function TopicDetailPage() {
 
   // State for edit modal
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+
+  // Composer section target for the mobile "Join Discussion" CTA (#1380)
+  const composerSectionRef = useRef<HTMLDivElement>(null);
+  const handleJoinDiscussion = useCallback(() => {
+    const section = composerSectionRef.current;
+    if (!section) return;
+    section.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    // Focus the composer input so the keyboard opens and the caret is ready.
+    const field = section.querySelector<HTMLElement>('textarea, [contenteditable="true"], input');
+    field?.focus({ preventScroll: true });
+  }, []);
 
   // State for bridging suggestions (populated from API or derived from analysis)
   const [bridgingSuggestions, setBridgingSuggestions] =
@@ -456,7 +467,7 @@ function TopicDetailPage() {
       )}
 
       {/* Response Composer Section */}
-      <div className="mb-6 md:mb-6 pb-20 md:pb-0">
+      <div ref={composerSectionRef} className="mb-6 md:mb-6 pb-20 md:pb-0">
         <Card variant="default" padding="lg">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
             Share Your Perspective
@@ -472,7 +483,7 @@ function TopicDetailPage() {
 
       {/* Mobile Action Bar - Fixed bottom CTA on mobile */}
       <MobileActionBar>
-        <Button variant="primary" size="lg" fullWidth>
+        <Button variant="primary" size="lg" fullWidth onClick={handleJoinDiscussion}>
           Join Discussion
         </Button>
       </MobileActionBar>

--- a/frontend/src/styles/discussion-layout.css
+++ b/frontend/src/styles/discussion-layout.css
@@ -14,6 +14,10 @@
   grid-template-areas: 'left center right';
   /* Account for header (64px) - use negative margin to counteract parent padding */
   height: calc(100vh - 64px);
+  /* Dynamic viewport unit: on mobile browsers 100vh = largest (URL-bar-collapsed)
+     viewport, so the composer hides behind browser chrome. 100dvh tracks the visible
+     viewport; declared after 100vh as a progressive-enhancement fallback (#1377). */
+  height: calc(100dvh - 64px);
   /* Base: counteract px-4 py-6 */
   margin: -1.5rem -1rem;
   width: calc(100% + 2rem);
@@ -272,6 +276,20 @@
     grid-template-columns: 1fr minmax(280px, 320px);
     grid-template-areas: 'center right';
   }
+
+  /* Touch targets on tablet too (768-1279px is a touch breakpoint per useBreakpoint):
+     mirror the mobile 44px floor so icon buttons aren't sub-target on tablet touch
+     devices (WCAG 2.5.5 / #1381). Bare `a` is intentionally excluded: min-width/height
+     have no effect on non-replaced inline links, so inline anchors are sized at the
+     component level instead. */
+  .discussion-layout[data-breakpoint='tablet'] button,
+  .discussion-layout[data-breakpoint='tablet'] [role='button'],
+  .discussion-layout[data-breakpoint='tablet'] [role='tab'],
+  .discussion-layout[data-breakpoint='tablet'] input[type='checkbox'],
+  .discussion-layout[data-breakpoint='tablet'] input[type='radio'] {
+    min-height: 44px;
+    min-width: 44px;
+  }
 }
 
 /* Lower tablet range polish (768px - 900px) - give more room to center panel */
@@ -309,6 +327,8 @@
     grid-template-areas: 'center';
     /* Mobile uses same calc as base, margin already handled above */
     height: calc(100vh - 64px);
+    /* dvh fallback so the composer isn't hidden behind mobile browser chrome (#1377) */
+    height: calc(100dvh - 64px);
   }
 
   /* Left panel as slide-in overlay on mobile */


### PR DESCRIPTION
## Summary

Batch of verified mobile-frontend defects surfaced by the 2026-07-10 multi-persona audit. All fixes are scoped to the frontend discussion/layout stack.

| Issue | Fix |
|-------|-----|
| #1377 | `.discussion-layout` now declares `height: calc(100dvh - 64px)` after the `100vh` value (progressive fallback) so the composer isn't hidden behind mobile browser chrome when the URL bar is visible. |
| #1378 | Replaced four independent `document.body.style.overflow` writers (MobileDrawer, Modal, ReportDialog, DeleteConfirmDialog) with a shared **reference-counted** `useScrollLock()` hook. Overlapping overlays no longer clobber each other's lock, and a pre-existing inline `overflow` value is restored instead of wiped to `''`/`'unset'`. |
| #1380 | The mobile "Join Discussion" fixed-bottom CTA now scrolls to and focuses the response composer (previously a dead primary button with no handler). |
| #1376 | Added a `hasLeftPanel` flag to `DiscussionLayoutContext`; the `ConversationPanel` hamburger button and swipe-open gesture now only appear when a left panel actually exists (they were dead on the discussion page). Aligned the two hamburger hide classes to `xl:hidden` to match `useBreakpoint`'s 1280px desktop threshold. |
| #1382 | `useMediaQuery` initializes synchronously from `window.matchMedia(query).matches` (mirroring `useBreakpoint`) instead of a deferred `setTimeout(0)` default of `false`, removing the one-frame desktop layout flash on phones. |
| #1383 | Extracted a shared `useElementHeight()` ResizeObserver hook and used it for the `MobileDrawer` and `Sidebar` topic-list heights, replacing `window.innerHeight - N` magic numbers that went stale after rotation / keyboard viewport shrink. |
| #1381 | Extended the 44px touch-target floor to the tablet breakpoint (768–1279px, a touch range) and sized the `ConversationPanel` edit/dismiss icon buttons explicitly at 44px (`h-11 w-11`). |

## Testing

- New `useScrollLock` tests prove the reference-counting semantics (concurrent overlays stay locked until the last one closes; pre-existing value preserved).
- New `useMediaQuery` tests assert the correct value on the **first** render + SSR fallback.
- `717` existing tests across the touched directories (`hooks`, `layouts`, `discussion-layout`, `responses`, `ui`, `pages/Topics`) pass.
- ESLint clean on all changed files; TypeScript introduces zero new errors (2 pre-existing workspace-resolution errors in an untouched file remain).

Fixes #1377
Fixes #1378
Fixes #1380
Fixes #1376
Fixes #1382
Fixes #1383
Fixes #1381

🤖 Generated with [Claude Code](https://claude.com/claude-code)