### PR TITLE
fix(backend): resolve audit findings #1290-#1297

### DIFF
--- a/frontend/src/services/activityFeedService.ts
+++ b/frontend/src/services/activityFeedService.ts
@@ -56,7 +56,10 @@ class ActivityFeedService {
     if (params?.limit) searchParams.append('limit', params.limit.toString());
     if (params?.cursor) searchParams.append('cursor', params.cursor);
 
-    const url = `${API_BASE_URL}/activity-feed${searchParams.toString() ? `?${searchParams}` : ''}`;
+    // The API gateway exposes the activity feed at GET /feed
+    // (services/api-gateway/src/proxy/activity-proxy.controller.ts). The old
+    // /activity-feed path does not exist on the gateway and 404s.
+    const url = `${API_BASE_URL}/feed${searchParams.toString() ? `?${searchParams}` : ''}`;
 
     const response = await fetch(url, {
       method: 'GET',

--- a/packages/db-models/prisma/migrations/20260710_restore_search_trgm_indexes/migration.sql
+++ b/packages/db-models/prisma/migrations/20260710_restore_search_trgm_indexes/migration.sql
@@ -1,0 +1,30 @@
+-- Restore pg_trgm GIN indexes for text search (Issues #1290, #1291)
+--
+-- Migration 20260320232632_add_verification_token_type dropped the search_vector
+-- columns AND the trigram indexes backing text search:
+--   * discussion_topics_title_trgm_idx   (line 82)
+--   * responses_content_trgm_idx         (line 88)
+-- TopicsSearchService and ResponsesSearchService were (re)written to use ILIKE
+-- '%query%' matching, but without a pg_trgm GIN index those leading-wildcard
+-- ILIKE scans degrade to sequential scans on every search/duplicate-detection
+-- query. Recreating the trigram indexes makes the ILIKE scans index-backed
+-- again (pg_trgm GIN indexes accelerate LIKE/ILIKE with wildcards).
+--
+-- A description trigram index is also (re)added so ILIKE on the description
+-- column and the similarity(description, ...) duplicate-detection predicate are
+-- likewise index-supported.
+
+-- Ensure the trigram extension is present (retained by prior migrations, but be
+-- defensive so this migration is self-contained).
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Topics: title + description trigram indexes for search and duplicate detection.
+CREATE INDEX IF NOT EXISTS "discussion_topics_title_trgm_idx"
+  ON "discussion_topics" USING GIN ("title" gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS "discussion_topics_description_trgm_idx"
+  ON "discussion_topics" USING GIN ("description" gin_trgm_ops);
+
+-- Responses: content trigram index for full-text ILIKE search.
+CREATE INDEX IF NOT EXISTS "responses_content_trgm_idx"
+  ON "responses" USING GIN ("content" gin_trgm_ops);

--- a/services/activity-service/src/activity-feed/activity-feed.service.ts
+++ b/services/activity-service/src/activity-feed/activity-feed.service.ts
@@ -21,7 +21,16 @@ export class ActivityFeedService {
    * Get activity feed for a user showing activities from followed users
    */
   async getFeed(userId: string, query: GetFeedQueryDto): Promise<ActivityFeedResponseDto> {
-    const { limit = 20, cursor } = query;
+    const { cursor } = query;
+
+    // Coerce and bound `limit` defensively. The global ValidationPipe normally
+    // transforms it to an integer via GetFeedQueryDto's @Transform/@IsInt, but
+    // guarding here keeps the service correct even when called without the pipe
+    // (internal callers, unit tests). A raw string would otherwise make
+    // `take: limit + 1` concatenate (e.g. "50" + 1 = "501") and break Prisma.
+    const parsedLimit = Number(query.limit);
+    const limit =
+      Number.isFinite(parsedLimit) && parsedLimit > 0 ? Math.min(Math.floor(parsedLimit), 100) : 20;
 
     // Step 1: Get IDs of users the current user follows (limit to 1000 most recent)
     // Note: Limiting follows prevents extremely large IN clauses for power users

--- a/services/activity-service/src/health/health.controller.ts
+++ b/services/activity-service/src/health/health.controller.ts
@@ -3,12 +3,56 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Inject, Logger, ServiceUnavailableException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+const SERVICE_NAME = 'activity-service';
 
 @Controller('health')
 export class HealthController {
+  private readonly logger = new Logger(HealthController.name);
+
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  /**
+   * Liveness probe — reports only that the process is up. Kept dependency-free
+   * so a transient database blip never causes an orchestrator to kill the pod.
+   */
   @Get()
   check() {
-    return { status: 'ok', service: 'activity-service' };
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /** Explicit liveness alias (for probes configured against /health/live). */
+  @Get('live')
+  live() {
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /**
+   * Readiness probe — verifies the service can actually serve traffic by
+   * pinging Postgres. Returns 503 when the database is unreachable so
+   * orchestrators stop routing traffic to a service with a dead connection pool
+   * (a gap that liveness-only health checks could not detect post-startup).
+   */
+  @Get('ready')
+  async ready() {
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+      return {
+        status: 'ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'up' },
+      };
+    } catch (error) {
+      this.logger.error(`Readiness check failed: ${(error as Error).message}`);
+      throw new ServiceUnavailableException({
+        status: 'not_ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'down' },
+      });
+    }
   }
 }

--- a/services/activity-service/src/main.ts
+++ b/services/activity-service/src/main.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
@@ -26,6 +26,22 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api-docs', app, document);
+
+  // Enable request validation with class-transformer (parity with
+  // user-service/discussion-service). Without a global ValidationPipe,
+  // class-validator DTO decorators are never enforced — and GetFeedQueryDto's
+  // @Transform/@IsInt/@Min/@Max would silently not run, leaving `limit` as a
+  // raw string.
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: false,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+    }),
+  );
 
   // Distributed tracing interceptor
   app.useGlobalInterceptors(new TracingInterceptor('activity-service'));

--- a/services/ai-service/src/health/health.controller.ts
+++ b/services/ai-service/src/health/health.controller.ts
@@ -3,16 +3,56 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Inject, Logger, ServiceUnavailableException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+const SERVICE_NAME = 'ai-service';
 
 @Controller('health')
 export class HealthController {
+  private readonly logger = new Logger(HealthController.name);
+
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  /**
+   * Liveness probe — reports only that the process is up. Kept dependency-free
+   * so a transient database blip never causes an orchestrator to kill the pod.
+   */
   @Get()
   check() {
-    return {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-      service: 'ai-service',
-    };
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /** Explicit liveness alias (for probes configured against /health/live). */
+  @Get('live')
+  live() {
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /**
+   * Readiness probe — verifies the service can actually serve traffic by
+   * pinging Postgres. Returns 503 when the database is unreachable so
+   * orchestrators stop routing traffic to a service with a dead connection pool
+   * (a gap that liveness-only health checks could not detect post-startup).
+   */
+  @Get('ready')
+  async ready() {
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+      return {
+        status: 'ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'up' },
+      };
+    } catch (error) {
+      this.logger.error(`Readiness check failed: ${(error as Error).message}`);
+      throw new ServiceUnavailableException({
+        status: 'not_ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'down' },
+      });
+    }
   }
 }

--- a/services/ai-service/src/main.ts
+++ b/services/ai-service/src/main.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
@@ -27,6 +27,20 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api-docs', app, document);
+
+  // Enable request validation with class-transformer (parity with
+  // user-service/discussion-service). Without a global ValidationPipe,
+  // class-validator DTO decorators are never enforced.
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: false,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+    }),
+  );
 
   // Distributed tracing interceptor
   app.useGlobalInterceptors(new TracingInterceptor('ai-service'));

--- a/services/api-gateway/src/filters/proxy-exception.filter.ts
+++ b/services/api-gateway/src/filters/proxy-exception.filter.ts
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Catch,
+  HttpException,
+  HttpStatus,
+  Logger,
+  type ArgumentsHost,
+  type ExceptionFilter,
+} from '@nestjs/common';
+import type { FastifyReply } from 'fastify';
+import { getCurrentRequestContext } from '../middleware/correlation.middleware.js';
+
+/**
+ * Stable JSON error contract returned by the gateway for infrastructure
+ * failures (upstream outages, circuit-breaker open, timeouts, unexpected
+ * errors). Keeping the shape consistent lets clients handle gateway errors
+ * uniformly instead of receiving Nest's default `{ statusCode, message }`.
+ */
+interface GatewayErrorBody {
+  statusCode: number;
+  error: string;
+  message: string;
+  correlationId?: string;
+}
+
+/**
+ * Global exception filter for the API gateway.
+ *
+ * @remarks
+ * Before this filter existed, any error rethrown by ProxyService
+ * (ECONNREFUSED, request timeout, opossum breaker-open) surfaced to clients as
+ * Nest's default `{"statusCode":500,"message":"Internal server error"}`, giving
+ * consumers no way to distinguish an upstream outage from a genuine gateway
+ * bug. This filter maps those failure modes to standard gateway status codes:
+ *
+ * - **Upstream returned a response** (a 5xx that survived retries): forward the
+ *   real upstream status and body verbatim — preserving error transparency.
+ * - **Circuit breaker open**: 503 Service Unavailable.
+ * - **Timeout** (axios or opossum): 504 Gateway Timeout.
+ * - **Network failure** (ECONNREFUSED/ENOTFOUND/ECONNRESET/EPIPE): 502 Bad Gateway.
+ * - **Nest HttpException** (the gateway's own auth/validation/not-found errors):
+ *   preserved with its original status and body.
+ * - **Anything else**: 500 with the stable shape.
+ */
+@Catch()
+export class ProxyExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(ProxyExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const reply = host.switchToHttp().getResponse<FastifyReply>();
+    const correlationId = getCurrentRequestContext()?.correlationId;
+
+    // 1. Gateway's own HttpExceptions (401 from guards, 404 for unknown routes,
+    //    validation errors, etc.) — preserve original status and body.
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus();
+      const body = exception.getResponse();
+      const payload =
+        typeof body === 'object' && body !== null
+          ? { ...(body as Record<string, unknown>), ...(correlationId && { correlationId }) }
+          : { statusCode: status, message: body, ...(correlationId && { correlationId }) };
+      reply.status(status).send(payload);
+      return;
+    }
+
+    // 2. Upstream service actually responded (e.g. a 5xx that survived all
+    //    retries). Forward the real upstream status + body so clients still see
+    //    the underlying error instead of an opaque gateway 5xx.
+    const upstream = (exception as { response?: { status?: number; data?: unknown } }).response;
+    if (upstream && typeof upstream.status === 'number') {
+      this.logger.warn(
+        `Upstream responded with ${upstream.status} after retries` +
+          (correlationId ? ` correlationId=${correlationId}` : ''),
+      );
+      reply.status(upstream.status).send(upstream.data ?? { statusCode: upstream.status });
+      return;
+    }
+
+    // 3. Infrastructure-level failures (no upstream response object).
+    const code = (exception as { code?: string }).code;
+    const message = exception instanceof Error ? exception.message : String(exception);
+
+    let status: number;
+    let error: string;
+    let clientMessage: string;
+
+    if (code === 'EOPENBREAKER' || /breaker is open/i.test(message)) {
+      status = HttpStatus.SERVICE_UNAVAILABLE; // 503
+      error = 'Service Unavailable';
+      clientMessage = 'Upstream service is temporarily unavailable (circuit open). Retry shortly.';
+    } else if (
+      code === 'ETIMEDOUT' ||
+      code === 'ECONNABORTED' ||
+      /timed out|timeout/i.test(message)
+    ) {
+      status = HttpStatus.GATEWAY_TIMEOUT; // 504
+      error = 'Gateway Timeout';
+      clientMessage = 'Upstream service did not respond in time.';
+    } else if (
+      ['ECONNREFUSED', 'ENOTFOUND', 'ECONNRESET', 'EPIPE'].some(
+        (c) => code === c || message.includes(c),
+      )
+    ) {
+      status = HttpStatus.BAD_GATEWAY; // 502
+      error = 'Bad Gateway';
+      clientMessage = 'Upstream service is unavailable.';
+    } else {
+      status = HttpStatus.INTERNAL_SERVER_ERROR; // 500
+      error = 'Internal Server Error';
+      clientMessage = 'An unexpected error occurred.';
+    }
+
+    this.logger.error(
+      `Gateway error → ${status}: ${message}` +
+        (correlationId ? ` correlationId=${correlationId}` : ''),
+    );
+
+    const responseBody: GatewayErrorBody = {
+      statusCode: status,
+      error,
+      message: clientMessage,
+      ...(correlationId && { correlationId }),
+    };
+    reply.status(status).send(responseBody);
+  }
+}

--- a/services/api-gateway/src/health/health.controller.ts
+++ b/services/api-gateway/src/health/health.controller.ts
@@ -44,4 +44,35 @@ export class HealthController {
       service: 'api-gateway',
     };
   }
+
+  /** Explicit liveness alias (for probes configured against /health/live). */
+  @Get('live')
+  @ApiOperation({ summary: 'Liveness probe (process is up)' })
+  @ApiResponse({ status: 200, description: 'Process is alive', type: HealthCheckResponse })
+  live(): HealthCheckResponse {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      service: 'api-gateway',
+    };
+  }
+
+  /**
+   * Readiness probe. The gateway holds no direct datastore connection — it
+   * proxies to downstream services, each of which exposes its own
+   * /health/ready backed by a real Postgres check. So the gateway is ready as
+   * soon as its process can accept connections; downstream availability is
+   * surfaced per-request via the circuit breaker and ProxyExceptionFilter
+   * (502/503), not by failing the gateway's own readiness.
+   */
+  @Get('ready')
+  @ApiOperation({ summary: 'Readiness probe (gateway can accept connections)' })
+  @ApiResponse({ status: 200, description: 'Gateway is ready', type: HealthCheckResponse })
+  ready(): HealthCheckResponse {
+    return {
+      status: 'ready',
+      timestamp: new Date().toISOString(),
+      service: 'api-gateway',
+    };
+  }
 }

--- a/services/api-gateway/src/main.ts
+++ b/services/api-gateway/src/main.ts
@@ -13,6 +13,7 @@ import { SERVICE_PORTS, setupGracefulShutdown } from '@reason-bridge/common';
 import { AppModule } from './app.module.js';
 import { getCorsConfig, getHelmetConfig } from './config/security.config.js';
 import { TracingInterceptor } from './observability/tracing.interceptor.js';
+import { ProxyExceptionFilter } from './filters/proxy-exception.filter.js';
 
 async function bootstrap() {
   const fastifyAdapter = new FastifyAdapter();
@@ -72,6 +73,10 @@ async function bootstrap() {
 
   // Distributed tracing interceptor
   app.useGlobalInterceptors(new TracingInterceptor('api-gateway'));
+
+  // Map upstream outages, circuit-breaker-open, and timeouts to stable
+  // 502/503/504 responses instead of opaque 500s (see ProxyExceptionFilter).
+  app.useGlobalFilters(new ProxyExceptionFilter());
 
   // Setup graceful shutdown handlers
   setupGracefulShutdown(app, { serviceName: 'api-gateway' });

--- a/services/api-gateway/src/proxy/activity-proxy.controller.ts
+++ b/services/api-gateway/src/proxy/activity-proxy.controller.ts
@@ -25,13 +25,23 @@ export class ActivityProxyController {
   async getFeed(
     @Query() query: Record<string, string>,
     @Headers('authorization') authHeader: string | undefined,
+    @Headers('x-user-id') userId: string | undefined,
     @Res() res: FastifyReply,
   ) {
+    // activity-service authenticates solely via the X-User-Id header (set by the
+    // gateway's JwtUserMiddleware from the Bearer token). ProxyService does not
+    // relay inbound headers automatically, so we must forward it explicitly —
+    // otherwise every /feed request reaches the activity-service without an
+    // identity and is rejected with 401. See topics-proxy.controller for the
+    // canonical pattern.
     const response = await this.proxyService.proxyToActivityService({
       method: 'GET',
       path: '/feed',
       query,
-      headers: authHeader ? { Authorization: authHeader } : undefined,
+      headers: {
+        ...(authHeader && { Authorization: authHeader }),
+        ...(userId && { 'X-User-Id': userId }),
+      },
     });
 
     res.status(response.status).send(response.data);

--- a/services/api-gateway/src/proxy/proxy.service.ts
+++ b/services/api-gateway/src/proxy/proxy.service.ts
@@ -251,8 +251,13 @@ export class ProxyService {
       },
       params: request.query,
       timeout, // Request timeout
-      // Don't throw on non-2xx status - let the gateway handle the response
-      validateStatus: () => true,
+      // Reject on upstream 5xx so the failure propagates through withRetry()
+      // and the opossum circuit breaker (both only act on thrown errors).
+      // 4xx responses still resolve and are forwarded to the client verbatim by
+      // the proxy controllers, preserving client-error transparency. Exhausted
+      // 5xx retries throw an AxiosError that the ProxyExceptionFilter maps to a
+      // stable 502/503/504 (or forwards the upstream status/body if present).
+      validateStatus: (status) => status < 500,
     };
 
     // Remove undefined/null headers

--- a/services/contact-service/src/health/health.controller.ts
+++ b/services/contact-service/src/health/health.controller.ts
@@ -3,21 +3,56 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Inject, Logger, ServiceUnavailableException } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+const SERVICE_NAME = 'contact-service';
 
 @ApiTags('Health')
 @Controller('health')
 export class HealthController {
+  private readonly logger = new Logger(HealthController.name);
+
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
   @Get()
-  @ApiOperation({ summary: 'Health check endpoint' })
+  @ApiOperation({ summary: 'Liveness probe (process is up)' })
   check() {
-    return { status: 'ok', service: 'contact-service' };
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
   }
 
+  @Get('live')
+  @ApiOperation({ summary: 'Liveness probe alias' })
+  live() {
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /**
+   * Readiness probe — now performs a real Postgres connectivity check instead of
+   * returning a static `{ status: 'ready' }`. Returns 503 when the database is
+   * unreachable so orchestrators stop routing traffic to a service with a dead
+   * connection pool.
+   */
   @Get('ready')
-  @ApiOperation({ summary: 'Readiness probe' })
-  ready() {
-    return { status: 'ready' };
+  @ApiOperation({ summary: 'Readiness probe (verifies database connectivity)' })
+  async ready() {
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+      return {
+        status: 'ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'up' },
+      };
+    } catch (error) {
+      this.logger.error(`Readiness check failed: ${(error as Error).message}`);
+      throw new ServiceUnavailableException({
+        status: 'not_ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'down' },
+      });
+    }
   }
 }

--- a/services/discussion-service/src/__tests__/responses-search.integration.spec.ts
+++ b/services/discussion-service/src/__tests__/responses-search.integration.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Integration test for response full-text search (Issue #1290).
+ *
+ * Regression guard: migration 20260320232632 dropped the responses
+ * `search_vector` column, but ResponsesSearchService kept querying it, so every
+ * response search silently returned zero results (the error was swallowed
+ * upstream). This test seeds real responses and asserts that search returns
+ * non-empty results against the real database — so any future schema drift that
+ * breaks response search fails CI loudly instead of failing silently.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaModule } from '../prisma/prisma.module';
+import { PrismaService } from '../prisma/prisma.service';
+import { ResponsesSearchService } from '../responses/responses-search.service';
+
+describe('Responses Search Integration Tests (#1290)', () => {
+  let moduleRef: TestingModule;
+  let prisma: PrismaService;
+  let searchService: ResponsesSearchService;
+
+  const testTopicId = '00000000-0000-0000-0000-0000000a1290';
+  const testUserId = '00000000-0000-0000-0000-0000000a1291';
+  let testDiscussionId: string;
+
+  // A distinctive term unlikely to appear in other seeded data.
+  const UNIQUE_TERM = 'zephyrantine';
+
+  beforeAll(async () => {
+    moduleRef = await Test.createTestingModule({
+      imports: [PrismaModule],
+      providers: [ResponsesSearchService],
+    }).compile();
+
+    prisma = moduleRef.get<PrismaService>(PrismaService);
+    searchService = moduleRef.get<ResponsesSearchService>(ResponsesSearchService);
+
+    await prisma.discussionTopic.upsert({
+      where: { id: testTopicId },
+      update: {},
+      create: {
+        id: testTopicId,
+        title: 'Search Test Topic',
+        description: 'Topic for response search integration testing',
+        status: 'ACTIVE',
+        responseCount: 0,
+        participantCount: 0,
+      },
+    });
+
+    await prisma.user.upsert({
+      where: { id: testUserId },
+      update: {},
+      create: {
+        id: testUserId,
+        email: 'search-user@test.com',
+        displayName: 'Search Test User',
+        emailVerified: true,
+        authMethod: 'EMAIL',
+      },
+    });
+
+    const discussion = await prisma.discussion.create({
+      data: {
+        topicId: testTopicId,
+        creatorId: testUserId,
+        title: 'Search integration discussion',
+        status: 'ACTIVE',
+        responseCount: 2,
+        participantCount: 1,
+      },
+    });
+    testDiscussionId = discussion.id;
+
+    await prisma.response.createMany({
+      data: [
+        {
+          topicId: testTopicId,
+          discussionId: testDiscussionId,
+          authorId: testUserId,
+          content: `A matching response about ${UNIQUE_TERM} policy and its effects.`,
+          version: 1,
+          editCount: 0,
+        },
+        {
+          topicId: testTopicId,
+          discussionId: testDiscussionId,
+          authorId: testUserId,
+          content: 'An unrelated response with no matching keyword at all.',
+          version: 1,
+          editCount: 0,
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.response.deleteMany({ where: { discussionId: testDiscussionId } });
+    await prisma.discussion.delete({ where: { id: testDiscussionId } }).catch(() => {});
+    await prisma.discussionTopic.delete({ where: { id: testTopicId } }).catch(() => {});
+    await prisma.user.delete({ where: { id: testUserId } }).catch(() => {});
+    await moduleRef.close();
+  });
+
+  it('fullTextSearch returns non-empty results for seeded content', async () => {
+    const results = await searchService.fullTextSearch(UNIQUE_TERM, { topicId: testTopicId });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]).toHaveProperty('id');
+    expect(results[0]).toHaveProperty('rank');
+  });
+
+  it('searchWithContext returns enriched, highlighted results', async () => {
+    const results = await searchService.searchWithContext(UNIQUE_TERM, { topicId: testTopicId });
+    expect(results.length).toBeGreaterThan(0);
+
+    const [first] = results;
+    expect(first!.topicTitle).toBe('Search Test Topic');
+    expect(first!.topicId).toBe(testTopicId);
+    // Highlighting wraps the matched term in <mark>.
+    expect(first!.highlightedContent).toContain('<mark>');
+    expect(first!.highlightedContent?.toLowerCase()).toContain(UNIQUE_TERM);
+  });
+
+  it('countSearchResults matches only responses containing the term', async () => {
+    const count = await searchService.countSearchResults(UNIQUE_TERM, { topicId: testTopicId });
+    // Exactly one of the two seeded responses contains the unique term.
+    expect(count).toBe(1);
+  });
+
+  it('returns empty (not an error) when nothing matches', async () => {
+    const results = await searchService.fullTextSearch('nonexistentqwerty', {
+      topicId: testTopicId,
+    });
+    expect(results).toEqual([]);
+  });
+});

--- a/services/discussion-service/src/bookmarks/bookmarks.controller.ts
+++ b/services/discussion-service/src/bookmarks/bookmarks.controller.ts
@@ -18,7 +18,11 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { BookmarksService } from './bookmarks.service.js';
-import type { CreateBookmarkDto } from './dto/create-bookmark.dto.js';
+// NOTE: Must be a value import (not `import type`). This class is used as an
+// @Body() parameter type, so `emitDecoratorMetadata` needs the runtime class
+// reference. With verbatimModuleSyntax, `import type` would elide it and tsc
+// would emit `Function` as the paramtype, silently breaking ValidationPipe.
+import { CreateBookmarkDto } from './dto/create-bookmark.dto.js';
 import type { BookmarkDto, BookmarkListDto, BookmarkStatusDto } from './dto/bookmark.dto.js';
 import { JwtAuthGuard, CurrentUser, type JwtPayload } from '../auth/index.js';
 

--- a/services/discussion-service/src/health/health.controller.ts
+++ b/services/discussion-service/src/health/health.controller.ts
@@ -3,16 +3,56 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Inject, Logger, ServiceUnavailableException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+const SERVICE_NAME = 'discussion-service';
 
 @Controller('health')
 export class HealthController {
+  private readonly logger = new Logger(HealthController.name);
+
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  /**
+   * Liveness probe — reports only that the process is up. Kept dependency-free
+   * so a transient database blip never causes an orchestrator to kill the pod.
+   */
   @Get()
   check() {
-    return {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-      service: 'discussion-service',
-    };
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /** Explicit liveness alias (for probes configured against /health/live). */
+  @Get('live')
+  live() {
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /**
+   * Readiness probe — verifies the service can actually serve traffic by
+   * pinging Postgres. Returns 503 when the database is unreachable so
+   * orchestrators stop routing traffic to a service with a dead connection pool
+   * (a gap that liveness-only health checks could not detect post-startup).
+   */
+  @Get('ready')
+  async ready() {
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+      return {
+        status: 'ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'up' },
+      };
+    } catch (error) {
+      this.logger.error(`Readiness check failed: ${(error as Error).message}`);
+      throw new ServiceUnavailableException({
+        status: 'not_ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'down' },
+      });
+    }
   }
 }

--- a/services/discussion-service/src/read-state/read-state.controller.ts
+++ b/services/discussion-service/src/read-state/read-state.controller.ts
@@ -14,7 +14,11 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { ReadStateService } from './read-state.service.js';
-import type { UpdateReadStateDto } from './dto/update-read-state.dto.js';
+// NOTE: Must be a value import (not `import type`). This class is used as an
+// @Body() parameter type, so `emitDecoratorMetadata` needs the runtime class
+// reference. With verbatimModuleSyntax, `import type` would elide it and tsc
+// would emit `Function` as the paramtype, silently breaking ValidationPipe.
+import { UpdateReadStateDto } from './dto/update-read-state.dto.js';
 import type { ReadStateDto } from './dto/read-state.dto.js';
 
 @Controller('topics')

--- a/services/discussion-service/src/responses/responses-search.service.ts
+++ b/services/discussion-service/src/responses/responses-search.service.ts
@@ -36,8 +36,14 @@ export interface ResponseSearchOptions {
  * Service for response search functionality
  * Feature #1040: Full-Text Search for Discussions
  *
- * Uses PostgreSQL tsvector for full-text search on response content.
- * Supports filtering by topic, author, and pagination.
+ * Note: The original tsvector-based search was removed when the responses
+ * `search_vector` column and its GIN index were dropped in migration
+ * 20260320232632_add_verification_token_type. This implementation uses ILIKE
+ * pattern matching on response content instead — consistent with
+ * TopicsSearchService, which was rewritten the same way. ILIKE `%query%` scans
+ * are backed by the `responses_content_trgm_idx` pg_trgm GIN index (recreated
+ * in migration 20260710_restore_search_trgm_indexes), so they do not force a
+ * sequential scan.
  */
 @Injectable()
 export class ResponsesSearchService {
@@ -46,8 +52,8 @@ export class ResponsesSearchService {
   constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
 
   /**
-   * Full-text search using PostgreSQL tsvector
-   * Searches response content and returns ranked results
+   * Full-text search using ILIKE pattern matching on response content.
+   * Returns matching response IDs ordered by recency.
    *
    * @param query - Search query string
    * @param options - Search options (topicId, authorId, limit, offset)
@@ -60,35 +66,16 @@ export class ResponsesSearchService {
     const { topicId, authorId, limit = 20, offset = 0 } = options;
 
     try {
-      // Build dynamic WHERE clause based on options
-      let whereClause = `WHERE r.search_vector @@ plainto_tsquery('english', $1)
-        AND r.status = 'VISIBLE'
-        AND r.deleted_at IS NULL`;
-
-      const params: (string | number)[] = [query];
-      let paramIndex = 2;
-
-      if (topicId) {
-        whereClause += ` AND r.topic_id = $${paramIndex}::uuid`;
-        params.push(topicId);
-        paramIndex++;
-      }
-
-      if (authorId) {
-        whereClause += ` AND r.author_id = $${paramIndex}::uuid`;
-        params.push(authorId);
-        paramIndex++;
-      }
-
+      const { whereClause, params, paramIndex } = this.buildWhereClause(query, topicId, authorId);
       params.push(limit, offset);
 
       const results = await this.prisma.$queryRawUnsafe<Array<{ id: string; rank: number }>>(
         `SELECT
           r.id::text,
-          ts_rank(r.search_vector, plainto_tsquery('english', $1)) as rank
+          1.0::float8 as rank
         FROM responses r
         ${whereClause}
-        ORDER BY rank DESC
+        ORDER BY r.created_at DESC
         LIMIT $${paramIndex}
         OFFSET $${paramIndex + 1}`,
         ...params,
@@ -105,7 +92,7 @@ export class ResponsesSearchService {
 
   /**
    * Search responses with full context (topic info, author, etc.)
-   * Returns enriched results suitable for display
+   * Returns enriched results suitable for display, with a highlighted snippet.
    *
    * @param query - Search query string
    * @param options - Search options
@@ -118,26 +105,7 @@ export class ResponsesSearchService {
     const { topicId, authorId, limit = 20, offset = 0 } = options;
 
     try {
-      // Build dynamic WHERE clause
-      let whereClause = `WHERE r.search_vector @@ plainto_tsquery('english', $1)
-        AND r.status = 'VISIBLE'
-        AND r.deleted_at IS NULL`;
-
-      const params: (string | number)[] = [query];
-      let paramIndex = 2;
-
-      if (topicId) {
-        whereClause += ` AND r.topic_id = $${paramIndex}::uuid`;
-        params.push(topicId);
-        paramIndex++;
-      }
-
-      if (authorId) {
-        whereClause += ` AND r.author_id = $${paramIndex}::uuid`;
-        params.push(authorId);
-        paramIndex++;
-      }
-
+      const { whereClause, params, paramIndex } = this.buildWhereClause(query, topicId, authorId);
       params.push(limit, offset);
 
       const results = await this.prisma.$queryRawUnsafe<
@@ -151,25 +119,22 @@ export class ResponsesSearchService {
           topic_slug: string;
           parent_id: string | null;
           created_at: Date;
-          highlighted_content: string;
         }>
       >(
         `SELECT
           r.id::text,
-          ts_rank(r.search_vector, plainto_tsquery('english', $1)) as rank,
+          1.0::float8 as rank,
           r.content,
           r.author_id::text,
           r.topic_id::text,
           dt.title as topic_title,
           dt.slug as topic_slug,
           r.parent_id::text,
-          r.created_at,
-          ts_headline('english', r.content, plainto_tsquery('english', $1),
-            'StartSel=<mark>, StopSel=</mark>, MaxWords=50, MinWords=20') as highlighted_content
+          r.created_at
         FROM responses r
         JOIN discussion_topics dt ON dt.id = r.topic_id
         ${whereClause}
-        ORDER BY rank DESC
+        ORDER BY r.created_at DESC
         LIMIT $${paramIndex}
         OFFSET $${paramIndex + 1}`,
         ...params,
@@ -187,7 +152,7 @@ export class ResponsesSearchService {
         topicSlug: r.topic_slug,
         parentId: r.parent_id,
         createdAt: r.created_at,
-        highlightedContent: r.highlighted_content,
+        highlightedContent: this.buildHighlight(r.content, query),
       }));
     } catch (error) {
       const err = error as Error;
@@ -210,23 +175,7 @@ export class ResponsesSearchService {
     const { topicId, authorId } = options;
 
     try {
-      let whereClause = `WHERE r.search_vector @@ plainto_tsquery('english', $1)
-        AND r.status = 'VISIBLE'
-        AND r.deleted_at IS NULL`;
-
-      const params: string[] = [query];
-      let paramIndex = 2;
-
-      if (topicId) {
-        whereClause += ` AND r.topic_id = $${paramIndex}::uuid`;
-        params.push(topicId);
-        paramIndex++;
-      }
-
-      if (authorId) {
-        whereClause += ` AND r.author_id = $${paramIndex}::uuid`;
-        params.push(authorId);
-      }
+      const { whereClause, params } = this.buildWhereClause(query, topicId, authorId);
 
       const result = await this.prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
         `SELECT COUNT(*) as count FROM responses r ${whereClause}`,
@@ -239,5 +188,68 @@ export class ResponsesSearchService {
       this.logger.error(`Response count search failed: ${err.message}`, err.stack);
       throw error;
     }
+  }
+
+  /**
+   * Build the shared WHERE clause and bound parameter list for the ILIKE search.
+   * Values are passed as bound parameters ($1, $2, ...) — never interpolated —
+   * so the query is not vulnerable to SQL injection despite $queryRawUnsafe.
+   */
+  private buildWhereClause(
+    query: string,
+    topicId?: string,
+    authorId?: string,
+  ): { whereClause: string; params: (string | number)[]; paramIndex: number } {
+    const searchPattern = `%${query}%`;
+    let whereClause = `WHERE r.content ILIKE $1
+        AND r.status = 'VISIBLE'
+        AND r.deleted_at IS NULL`;
+
+    const params: (string | number)[] = [searchPattern];
+    let paramIndex = 2;
+
+    if (topicId) {
+      whereClause += ` AND r.topic_id = $${paramIndex}::uuid`;
+      params.push(topicId);
+      paramIndex++;
+    }
+
+    if (authorId) {
+      whereClause += ` AND r.author_id = $${paramIndex}::uuid`;
+      params.push(authorId);
+      paramIndex++;
+    }
+
+    return { whereClause, params, paramIndex };
+  }
+
+  /**
+   * Build a highlighted snippet around the first occurrence of the query.
+   * Replaces the DB-side ts_headline that is no longer available without the
+   * tsvector column: extracts a context window and wraps matches in <mark>.
+   */
+  private buildHighlight(content: string, query: string): string {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      return content.length > 300 ? `${content.substring(0, 300)}…` : content;
+    }
+
+    // Escape regex metacharacters so the raw query is matched literally.
+    const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(escaped, 'gi');
+
+    const matchIndex = content.search(regex);
+    const windowRadius = 100;
+    const start = matchIndex >= 0 ? Math.max(0, matchIndex - windowRadius) : 0;
+    const end =
+      matchIndex >= 0
+        ? Math.min(content.length, matchIndex + trimmed.length + windowRadius)
+        : Math.min(content.length, 300);
+
+    let snippet = content.substring(start, end);
+    if (start > 0) snippet = `…${snippet}`;
+    if (end < content.length) snippet = `${snippet}…`;
+
+    return snippet.replace(regex, (match) => `<mark>${match}</mark>`);
   }
 }

--- a/services/discussion-service/src/topics/topics-search.service.ts
+++ b/services/discussion-service/src/topics/topics-search.service.ts
@@ -95,7 +95,18 @@ export class TopicsSearchService {
     threshold: number = 0.7,
   ): Promise<DuplicateSuggestion[]> {
     try {
-      // Use pg_trgm similarity for fast duplicate detection
+      // Use pg_trgm similarity for fast duplicate detection.
+      //
+      // The `title % $x` / `description % $x` predicates use the pg_trgm `%`
+      // operator, which — unlike `similarity(a, b) > t` — can be answered by the
+      // GIN trigram indexes (discussion_topics_title_trgm_idx /
+      // discussion_topics_description_trgm_idx). It pre-filters candidates using
+      // the index at the default similarity_threshold (0.3), then the explicit
+      // `similarity(...) > threshold` predicates refine to the requested
+      // precision (0.7 / 0.42). Since 0.3 is below both refine thresholds, the
+      // index pre-filter never drops a row the refine step would keep — result
+      // semantics are unchanged, but the scan is now index-backed instead of a
+      // full sequential scan.
       const results = await this.prisma.$queryRaw<
         Array<{
           id: string;
@@ -113,7 +124,8 @@ export class TopicsSearchService {
           similarity(description, ${description}) as desc_similarity
         FROM discussion_topics
         WHERE
-          (similarity(title, ${title}) > ${threshold}
+          (title % ${title} OR description % ${description})
+          AND (similarity(title, ${title}) > ${threshold}
            OR similarity(description, ${description}) > ${threshold * 0.6})
           AND status != 'ARCHIVED'
         ORDER BY

--- a/services/fact-check-service/src/health/health.controller.ts
+++ b/services/fact-check-service/src/health/health.controller.ts
@@ -3,16 +3,56 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Inject, Logger, ServiceUnavailableException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+const SERVICE_NAME = 'fact-check-service';
 
 @Controller('health')
 export class HealthController {
+  private readonly logger = new Logger(HealthController.name);
+
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  /**
+   * Liveness probe — reports only that the process is up. Kept dependency-free
+   * so a transient database blip never causes an orchestrator to kill the pod.
+   */
   @Get()
   check() {
-    return {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-      service: 'fact-check-service',
-    };
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /** Explicit liveness alias (for probes configured against /health/live). */
+  @Get('live')
+  live() {
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /**
+   * Readiness probe — verifies the service can actually serve traffic by
+   * pinging Postgres. Returns 503 when the database is unreachable so
+   * orchestrators stop routing traffic to a service with a dead connection pool
+   * (a gap that liveness-only health checks could not detect post-startup).
+   */
+  @Get('ready')
+  async ready() {
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+      return {
+        status: 'ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'up' },
+      };
+    } catch (error) {
+      this.logger.error(`Readiness check failed: ${(error as Error).message}`);
+      throw new ServiceUnavailableException({
+        status: 'not_ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'down' },
+      });
+    }
   }
 }

--- a/services/fact-check-service/src/main.ts
+++ b/services/fact-check-service/src/main.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
@@ -27,6 +27,20 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api-docs', app, document);
+
+  // Enable request validation with class-transformer (parity with
+  // user-service/discussion-service). Without a global ValidationPipe,
+  // class-validator DTO decorators are never enforced.
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: false,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+    }),
+  );
 
   // Distributed tracing interceptor
   app.useGlobalInterceptors(new TracingInterceptor('fact-check-service'));

--- a/services/moderation-service/src/health/health.controller.ts
+++ b/services/moderation-service/src/health/health.controller.ts
@@ -3,21 +3,73 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Controller, Get, Inject } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Inject,
+  Logger,
+  Optional,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { QueueService } from '../queue/queue.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+const SERVICE_NAME = 'moderation-service';
 
 @Controller('health')
 export class HealthController {
-  constructor(@Inject(QueueService) private readonly queueService?: QueueService) {}
+  private readonly logger = new Logger(HealthController.name);
 
+  constructor(
+    @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Optional() @Inject(QueueService) private readonly queueService?: QueueService,
+  ) {}
+
+  /**
+   * Liveness probe — process is up. Kept dependency-free so a transient
+   * database blip never causes an orchestrator to kill the pod.
+   */
   @Get()
   check() {
     return {
       status: 'ok',
       timestamp: new Date().toISOString(),
-      service: 'moderation-service',
+      service: SERVICE_NAME,
       queue: this.queueService?.getHealthStatus() || { enabled: false },
     };
+  }
+
+  /** Explicit liveness alias (for probes configured against /health/live). */
+  @Get('live')
+  live() {
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /**
+   * Readiness probe — verifies the service can serve traffic by pinging
+   * Postgres. Returns 503 when the database is unreachable so orchestrators
+   * stop routing traffic to a service with a dead connection pool.
+   */
+  @Get('ready')
+  async ready() {
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+      return {
+        status: 'ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'up' },
+        queue: this.queueService?.getHealthStatus() || { enabled: false },
+      };
+    } catch (error) {
+      this.logger.error(`Readiness check failed: ${(error as Error).message}`);
+      throw new ServiceUnavailableException({
+        status: 'not_ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'down' },
+      });
+    }
   }
 
   @Get('queue')

--- a/services/moderation-service/src/main.ts
+++ b/services/moderation-service/src/main.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
@@ -27,6 +27,20 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api-docs', app, document);
+
+  // Enable request validation with class-transformer (parity with
+  // user-service/discussion-service). Without a global ValidationPipe,
+  // class-validator DTO decorators are never enforced.
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: false,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+    }),
+  );
 
   // Distributed tracing interceptor
   app.useGlobalInterceptors(new TracingInterceptor('moderation-service'));

--- a/services/moderation-service/src/services/__tests__/moderation-actions.service.unit.test.ts
+++ b/services/moderation-service/src/services/__tests__/moderation-actions.service.unit.test.ts
@@ -56,6 +56,7 @@ describe('ModerationActionsService', () => {
         findUnique: vi.fn(),
         create: vi.fn(),
         update: vi.fn(),
+        updateMany: vi.fn(),
       },
       appeal: {
         findMany: vi.fn(),
@@ -65,6 +66,9 @@ describe('ModerationActionsService', () => {
       user: {
         update: vi.fn(),
       },
+      // autoLiftExpiredBans wraps per-row updates in a transaction; the mock
+      // simply awaits whatever array of update promises it is handed.
+      $transaction: vi.fn((ops: unknown) => Promise.resolve(ops)),
     } as unknown as PrismaService;
 
     queueService = {
@@ -501,6 +505,55 @@ describe('ModerationActionsService', () => {
       const result = await service.sendCoolingOffPrompt([], 'topic-1', 'Message');
 
       expect(result.sent).toBe(0);
+    });
+  });
+
+  describe('autoLiftExpiredBans (#1295)', () => {
+    it("appends each ban its OWN reasoning, not the first ban's", async () => {
+      const expiredBans = [
+        { id: 'ban-1', reasoning: 'Ban one reason' },
+        { id: 'ban-2', reasoning: 'Ban two reason' },
+        { id: 'ban-3', reasoning: 'Ban three reason' },
+      ];
+      vi.mocked(prismaService.moderationAction.findMany).mockResolvedValue(expiredBans as never);
+      vi.mocked(prismaService.moderationAction.update).mockImplementation(
+        (args) => Promise.resolve(args) as never,
+      );
+
+      const result = await service.autoLiftExpiredBans();
+
+      expect(result).toEqual({ lifted: 3 });
+
+      // Regression guard: the old updateMany applied the FIRST ban's reasoning
+      // to every row. Each row must now be updated individually with its own
+      // reasoning appended.
+      expect(prismaService.moderationAction.update).toHaveBeenCalledTimes(3);
+      expect(prismaService.moderationAction.updateMany).not.toHaveBeenCalled();
+
+      const calls = vi.mocked(prismaService.moderationAction.update).mock.calls;
+      for (const ban of expiredBans) {
+        const call = calls.find((c) => (c[0] as { where: { id: string } }).where.id === ban.id);
+        expect(call, `expected an update for ${ban.id}`).toBeDefined();
+        const data = (call![0] as { data: { status: string; reasoning: string } }).data;
+        expect(data.status).toBe('REVERSED');
+        expect(data.reasoning).toContain(ban.reasoning);
+        expect(data.reasoning).toContain('[AUTOMATICALLY LIFTED');
+        // Must NOT be contaminated with a different ban's reasoning.
+        for (const other of expiredBans) {
+          if (other.id !== ban.id) {
+            expect(data.reasoning).not.toContain(other.reasoning);
+          }
+        }
+      }
+    });
+
+    it('returns { lifted: 0 } and does nothing when no bans are expired', async () => {
+      vi.mocked(prismaService.moderationAction.findMany).mockResolvedValue([] as never);
+
+      const result = await service.autoLiftExpiredBans();
+
+      expect(result).toEqual({ lifted: 0 });
+      expect(prismaService.moderationAction.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/services/moderation-service/src/services/moderation-actions.service.ts
+++ b/services/moderation-service/src/services/moderation-actions.service.ts
@@ -836,21 +836,26 @@ export class ModerationActionsService {
       return { lifted: 0 };
     }
 
-    // Update all expired bans to REVERSED status
-    if (expiredBans.length > 0) {
-      await this.prisma.moderationAction.updateMany({
-        where: {
-          id: {
-            in: expiredBans.map((b) => b.id),
+    // Update each expired ban to REVERSED status individually.
+    //
+    // NOTE: Do NOT use updateMany here. updateMany applies one literal `data`
+    // payload to every matched row, so appending `expiredBans[0].reasoning`
+    // would overwrite EVERY ban's original moderation reasoning with the first
+    // ban's text — permanently corrupting the audit trail across unrelated
+    // users and offenses. Per-row updates inside a single transaction let each
+    // ban keep its own reasoning while remaining atomic.
+    await this.prisma.$transaction(
+      expiredBans.map((ban) =>
+        this.prisma.moderationAction.update({
+          where: { id: ban.id },
+          data: {
+            status: 'REVERSED',
+            liftedAt: now,
+            reasoning: `${ban.reasoning}\n\n[AUTOMATICALLY LIFTED: Temporary ban duration expired]`,
           },
-        },
-        data: {
-          status: 'REVERSED',
-          liftedAt: now,
-          reasoning: `${expiredBans[0]!.reasoning}\n\n[AUTOMATICALLY LIFTED: Temporary ban duration expired]`,
-        },
-      });
-    }
+        }),
+      ),
+    );
 
     return { lifted: expiredBans.length };
   }

--- a/services/notification-service/src/health/health.controller.ts
+++ b/services/notification-service/src/health/health.controller.ts
@@ -3,16 +3,56 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Inject, Logger, ServiceUnavailableException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+const SERVICE_NAME = 'notification-service';
 
 @Controller('health')
 export class HealthController {
+  private readonly logger = new Logger(HealthController.name);
+
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  /**
+   * Liveness probe — reports only that the process is up. Kept dependency-free
+   * so a transient database blip never causes an orchestrator to kill the pod.
+   */
   @Get()
   check() {
-    return {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-      service: 'notification-service',
-    };
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /** Explicit liveness alias (for probes configured against /health/live). */
+  @Get('live')
+  live() {
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /**
+   * Readiness probe — verifies the service can actually serve traffic by
+   * pinging Postgres. Returns 503 when the database is unreachable so
+   * orchestrators stop routing traffic to a service with a dead connection pool
+   * (a gap that liveness-only health checks could not detect post-startup).
+   */
+  @Get('ready')
+  async ready() {
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+      return {
+        status: 'ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'up' },
+      };
+    } catch (error) {
+      this.logger.error(`Readiness check failed: ${(error as Error).message}`);
+      throw new ServiceUnavailableException({
+        status: 'not_ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'down' },
+      });
+    }
   }
 }

--- a/services/notification-service/src/main.ts
+++ b/services/notification-service/src/main.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
@@ -27,6 +27,20 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api-docs', app, document);
+
+  // Enable request validation with class-transformer (parity with
+  // user-service/discussion-service). Without a global ValidationPipe,
+  // class-validator DTO decorators are never enforced.
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: false,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+    }),
+  );
 
   // Distributed tracing interceptor
   app.useGlobalInterceptors(new TracingInterceptor('notification-service'));

--- a/services/recommendation-service/src/health/health.controller.ts
+++ b/services/recommendation-service/src/health/health.controller.ts
@@ -3,16 +3,56 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Inject, Logger, ServiceUnavailableException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+const SERVICE_NAME = 'recommendation-service';
 
 @Controller('health')
 export class HealthController {
+  private readonly logger = new Logger(HealthController.name);
+
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  /**
+   * Liveness probe — reports only that the process is up. Kept dependency-free
+   * so a transient database blip never causes an orchestrator to kill the pod.
+   */
   @Get()
   check() {
-    return {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-      service: 'recommendation-service',
-    };
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /** Explicit liveness alias (for probes configured against /health/live). */
+  @Get('live')
+  live() {
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /**
+   * Readiness probe — verifies the service can actually serve traffic by
+   * pinging Postgres. Returns 503 when the database is unreachable so
+   * orchestrators stop routing traffic to a service with a dead connection pool
+   * (a gap that liveness-only health checks could not detect post-startup).
+   */
+  @Get('ready')
+  async ready() {
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+      return {
+        status: 'ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'up' },
+      };
+    } catch (error) {
+      this.logger.error(`Readiness check failed: ${(error as Error).message}`);
+      throw new ServiceUnavailableException({
+        status: 'not_ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'down' },
+      });
+    }
   }
 }

--- a/services/recommendation-service/src/main.ts
+++ b/services/recommendation-service/src/main.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
@@ -27,6 +27,20 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api-docs', app, document);
+
+  // Enable request validation with class-transformer (parity with
+  // user-service/discussion-service). Without a global ValidationPipe,
+  // class-validator DTO decorators are never enforced.
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: false,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+    }),
+  );
 
   // Distributed tracing interceptor
   app.useGlobalInterceptors(new TracingInterceptor('recommendation-service'));

--- a/services/user-service/src/health/health.controller.ts
+++ b/services/user-service/src/health/health.controller.ts
@@ -3,16 +3,56 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Inject, Logger, ServiceUnavailableException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+const SERVICE_NAME = 'user-service';
 
 @Controller('health')
 export class HealthController {
+  private readonly logger = new Logger(HealthController.name);
+
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  /**
+   * Liveness probe — reports only that the process is up. Kept dependency-free
+   * so a transient database blip never causes an orchestrator to kill the pod.
+   */
   @Get()
   check() {
-    return {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-      service: 'user-service',
-    };
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /** Explicit liveness alias (for probes configured against /health/live). */
+  @Get('live')
+  live() {
+    return { status: 'ok', timestamp: new Date().toISOString(), service: SERVICE_NAME };
+  }
+
+  /**
+   * Readiness probe — verifies the service can actually serve traffic by
+   * pinging Postgres. Returns 503 when the database is unreachable so
+   * orchestrators stop routing traffic to a service with a dead connection pool
+   * (a gap that liveness-only health checks could not detect post-startup).
+   */
+  @Get('ready')
+  async ready() {
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+      return {
+        status: 'ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'up' },
+      };
+    } catch (error) {
+      this.logger.error(`Readiness check failed: ${(error as Error).message}`);
+      throw new ServiceUnavailableException({
+        status: 'not_ready',
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        checks: { database: 'down' },
+      });
+    }
   }
 }


### PR DESCRIPTION
## Summary

Resolves eight backend defects from the 2026-07-10 multi-persona audit. Each fix follows the root cause and recommendation in the corresponding issue.

| Issue | Defect | Fix |
|-------|--------|-----|
| #1290 | Response search queried the dropped `search_vector` column → every search silently returned empty | Rewrote `ResponsesSearchService` to indexed ILIKE (matching `TopicsSearchService`); added an integration test asserting seeded content returns non-empty results so schema drift fails CI loudly |
| #1291 | Topic search/duplicate detection ran unindexed after the trgm index drop | New migration recreates the title/description/content trigram GIN indexes (pg_trgm accelerates `ILIKE '%q%'`); duplicate detection now uses the `%` operator so the index is actually used |
| #1292 | `GET /feed` never forwarded `X-User-Id` → activity feed always 401'd | `ActivityProxyController.getFeed` forwards the middleware-set `X-User-Id`; frontend now calls the real `/feed` gateway path (was `/activity-feed`) |
| #1293 | `import type` on `@Body()` DTOs elided decorator metadata → 400 on every request in tsc-built runtimes | Changed bookmarks + read-state controllers to value imports |
| #1294 | Six services had no global `ValidationPipe` (dead class-validator decorators) | Added the pipe to ai/moderation/notification/fact-check/recommendation/activity; also hardened the activity-feed `limit + 1` string-concatenation 500 |
| #1295 | `autoLiftExpiredBans` used `updateMany`, overwriting every ban's reasoning with the first ban's text | Replaced with per-row updates inside `$transaction`; added regression tests |
| #1296 | Gateway proxy `validateStatus: () => true` defeated retry + circuit breaker for upstream 5xx and returned opaque 500s | `validateStatus: (s) => s < 500` so 5xx flows through retry/breaker; new `ProxyExceptionFilter` maps outages/breaker-open/timeouts to stable 502/503/504 |
| #1297 | Health endpoints were liveness-only (no dependency check) | Added `/health/ready` readiness probes checking Postgres across all backend services (plus `/health/live` aliases) |

## Verification

- `tsc --noEmit` passes for all changed services (api-gateway, discussion, activity, moderation, ai, notification, fact-check, recommendation, user, contact — source clean)
- Unit tests pass: moderation-actions (31, incl. new `autoLiftExpiredBans` regression tests), activity-feed (4)
- Pre-commit hooks (secrets, console, forbidden imports, core unit tests, lint-staged) all passed
- Response-search behaviour is covered by a new integration test (runs in the integration phase against Postgres)

## Notes

- #1290/#1291 follow the team's established ILIKE direction rather than reintroducing the generated `tsvector` column + trigger that caused the original drift; the recreated pg_trgm indexes keep those ILIKE scans index-backed.
- moderation-service request bodies are interfaces (metatype `Object`), so the new `whitelist` pipe safely skips them — no field stripping.

Fixes #1290
Fixes #1291
Fixes #1292
Fixes #1293
Fixes #1294
Fixes #1295
Fixes #1296
Fixes #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)