### PR TITLE
fix(discussion): repair realtime + data layer (#1358–#1364, #1387)

### DIFF
--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -39,6 +39,27 @@ server {
         proxy_read_timeout 7d;
     }
 
+    # WebSocket Proxy for Discussion realtime (typing, reactions, new responses,
+    # topic status). discussion-service runs a separate Socket.io server on a
+    # distinct Engine.IO path (/discussions-ws) so it doesn't collide with
+    # notification-service's /socket.io path. See issue #1359.
+    location /discussions-ws/ {
+        proxy_pass http://discussion-service:3007/discussions-ws/;
+        proxy_http_version 1.1;
+
+        # WebSocket upgrade headers
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # Timeouts for WebSocket (long-lived connections)
+        proxy_connect_timeout 7d;
+        proxy_send_timeout 7d;
+        proxy_read_timeout 7d;
+    }
+
     # SPA fallback - must be last
     # Handles React Router client-side routing
     location / {

--- a/frontend/src/components/discussion-layout/ConversationPanel.tsx
+++ b/frontend/src/components/discussion-layout/ConversationPanel.tsx
@@ -70,7 +70,7 @@ export function ConversationPanel({
   const responseListContainerRef = useRef<HTMLDivElement>(null);
   const { toggleLeftPanelOverlay } = useDiscussionLayout();
   const breakpoint = useBreakpoint();
-  const { subscribe } = useWebSocket();
+  const { subscribe, subscribeToTopic } = useWebSocket();
   const { user } = useAuth();
   const toast = useToast();
 
@@ -106,6 +106,13 @@ export function ConversationPanel({
 
     return () => resizeObserver.disconnect();
   }, []);
+
+  // Join the topic's realtime room so typing/reaction/new-response/status
+  // events for this topic are delivered to the shared connection (issue #1359).
+  useEffect(() => {
+    if (!topic?.id) return undefined;
+    return subscribeToTopic(topic.id);
+  }, [topic?.id, subscribeToTopic]);
 
   // Subscribe to WebSocket messages for new responses
   useEffect(() => {
@@ -198,6 +205,27 @@ export function ConversationPanel({
   const handleDismissStatusChange = useCallback(() => {
     setTopicStatusChange(null);
   }, []);
+
+  // Derive read-only state directly from the fetched topic status so that
+  // archived/locked topics disable posting immediately on load, not only in
+  // response to a live TOPIC_STATUS_CHANGE transition. See issue #1362.
+  const isReadOnly =
+    topic?.status === 'ARCHIVED' ||
+    topic?.status === 'LOCKED' ||
+    topicStatusChange?.newStatus === 'ARCHIVED' ||
+    topicStatusChange?.newStatus === 'LOCKED';
+
+  // Guard against the previous no-op fallback that silently discarded top-level
+  // responses: if a composer is requested but no handler is wired, log loudly
+  // and hide the composer rather than pretending the post succeeded. See #1358.
+  useEffect(() => {
+    if (showComposer && topic && !isReadOnly && !onResponseSubmit) {
+      console.error(
+        'ConversationPanel: showComposer is true but no onResponseSubmit handler was ' +
+          'provided. The top-level composer is hidden to avoid silently discarding responses.',
+      );
+    }
+  }, [showComposer, topic, isReadOnly, onResponseSubmit]);
 
   // Conditional rendering: Empty state when no topic selected
   if (!topic) {
@@ -520,18 +548,30 @@ export function ConversationPanel({
           enableThreading
           height={measuredHeight || 400}
           highlightedResponseIds={highlightedResponseIds}
-          onReplySubmit={handleReplySubmitWithScroll}
+          onReplySubmit={isReadOnly ? undefined : handleReplySubmitWithScroll}
           onPreviewFeedbackChange={onPreviewFeedbackChange}
           compact
         />
       </div>
 
-      {/* Compact Composer (sticky bottom) */}
-      {showComposer && (
+      {/* Read-only notice for archived/locked topics (issue #1362) */}
+      {showComposer && isReadOnly && (
+        <div
+          className="shrink-0 px-4 py-3 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/60 text-center text-sm text-gray-600 dark:text-gray-400"
+          role="status"
+        >
+          This topic is <strong>{(topic.status ?? 'archived').toLowerCase()}</strong> and read-only.
+          You can no longer post responses.
+        </div>
+      )}
+
+      {/* Compact Composer (sticky bottom) — only when we have a real submit
+          handler, so responses are never silently discarded (issue #1358) */}
+      {showComposer && !isReadOnly && onResponseSubmit && (
         <div className="shrink-0 px-4 py-2 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
           <CompactComposer
             topicId={topic.id}
-            onSubmit={onResponseSubmit || (() => Promise.resolve())}
+            onSubmit={onResponseSubmit}
             onPreviewFeedbackChange={onPreviewFeedbackChange}
           />
         </div>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
 import { authService } from '../services/authService';
 import { apiClient } from '../lib/api';
 import { getJWTTimeUntilExpiry } from '../lib/jwt';
@@ -273,14 +273,21 @@ export function AuthProvider({ children }: AuthProviderProps) {
     return () => clearInterval(interval);
   }, [user, logout]);
 
-  const value: AuthContextType = {
-    user,
-    isAuthenticated: !!user,
-    isLoading,
-    login,
-    logout,
-    refreshUserProfile,
-  };
+  // Memoize the context value so it only changes when auth state actually
+  // changes. AuthProvider itself consumes useToast, so without this every toast
+  // would hand AuthProvider a new context identity and cascade a re-render to
+  // every useAuthContext consumer (Header, Sidebar, etc.). See issue #1387.
+  const value: AuthContextType = useMemo(
+    () => ({
+      user,
+      isAuthenticated: !!user,
+      isLoading,
+      login,
+      logout,
+      refreshUserProfile,
+    }),
+    [user, isLoading, login, logout, refreshUserProfile],
+  );
 
   return (
     <AuthContext.Provider value={value}>

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import type { Toast } from '../components/notifications/Toast';
 import { ToastContainer } from '../components/notifications/ToastContainer';
 import { NotificationContext } from './NotificationContextFactory';
@@ -35,10 +35,15 @@ function NotificationProviderComponent({ children }: { children: React.ReactNode
     setToasts([]);
   }, []);
 
+  // Memoize the context value so notification state changes only re-render the
+  // ToastContainer, not every consumer of the notification API. See issue #1387.
+  const value = useMemo(
+    () => ({ addNotification, removeNotification, clearNotifications }),
+    [addNotification, removeNotification, clearNotifications],
+  );
+
   return (
-    <NotificationContext.Provider
-      value={{ addNotification, removeNotification, clearNotifications }}
-    >
+    <NotificationContext.Provider value={value}>
       {children}
       <ToastContainer toasts={toasts} onClose={removeNotification} />
     </NotificationContext.Provider>

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { createContext, useState, useEffect, useCallback } from 'react';
+import React, { createContext, useState, useEffect, useCallback, useMemo } from 'react';
 import type { ReactNode } from 'react';
 import type { ThemeMode, ThemeContextType } from '../types/theme';
 import { useMediaQuery } from '../hooks/useMediaQuery';
@@ -82,12 +82,17 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     });
   }, []);
 
-  const value: ThemeContextType = {
-    mode,
-    isDark,
-    setTheme,
-    toggleTheme,
-  };
+  // Memoize the context value so it only changes when theme state actually
+  // changes, preventing cascading re-renders of every consumer. See issue #1387.
+  const value: ThemeContextType = useMemo(
+    () => ({
+      mode,
+      isDark,
+      setTheme,
+      toggleTheme,
+    }),
+    [mode, isDark, setTheme, toggleTheme],
+  );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import { createContext, useContext, useState, useCallback, useMemo, type ReactNode } from 'react';
 import ToastContainer from '../components/ui/ToastContainer';
 import type { ToastVariant } from '../components/ui/Toast';
 
@@ -139,15 +139,21 @@ export function ToastProvider({
     setToasts([]);
   }, []);
 
-  const value: ToastContextType = {
-    success,
-    error,
-    warning,
-    info,
-    show,
-    dismiss,
-    dismissAll,
-  };
+  // Memoize the context value so toast state changes only re-render the
+  // ToastContainer, not every consumer of the toast API (all callbacks are
+  // stable useCallbacks). See issue #1387.
+  const value: ToastContextType = useMemo(
+    () => ({
+      success,
+      error,
+      warning,
+      info,
+      show,
+      dismiss,
+      dismissAll,
+    }),
+    [success, error, warning, info, show, dismiss, dismissAll],
+  );
 
   return (
     <ToastContext.Provider value={value}>

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -162,8 +162,41 @@ export function useNotifications(): UseNotificationsReturn {
     }
   }, []);
 
+  // Initial fetch on mount
   useEffect(() => {
     fetchNotifications();
+  }, [fetchNotifications]);
+
+  // Keep notifications and the unread badge fresh without a page reload (#1364).
+  // The notification list previously fetched exactly once on mount, so new
+  // reply/mention notifications and the unread count stayed stale for the whole
+  // session. Poll on an interval and refetch whenever the tab regains focus /
+  // becomes visible again, mirroring React Query's refetchInterval +
+  // refetchOnWindowFocus behaviour used elsewhere in the app.
+  useEffect(() => {
+    const POLL_INTERVAL_MS = 30 * 1000; // 30 seconds
+
+    const interval = window.setInterval(() => {
+      // Only poll while the tab is visible to avoid needless background traffic
+      if (document.visibilityState === 'visible') {
+        fetchNotifications();
+      }
+    }, POLL_INTERVAL_MS);
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        fetchNotifications();
+      }
+    };
+
+    window.addEventListener('focus', fetchNotifications);
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      window.clearInterval(interval);
+      window.removeEventListener('focus', fetchNotifications);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
   }, [fetchNotifications]);
 
   const markAsRead = useCallback(

--- a/frontend/src/hooks/useResponses.ts
+++ b/frontend/src/hooks/useResponses.ts
@@ -12,6 +12,7 @@
  * - Real-time refetching options
  */
 
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { responseService } from '../services/responseService';
 import type { ResponseDetail } from '../services/discussionService';
@@ -48,18 +49,26 @@ export interface UseResponsesOptions {
 export function useResponses(discussionId: string, options: UseResponsesOptions = {}) {
   const { enabled = true, buildThreadTree = false, refetchInterval = false } = options;
 
-  return useQuery<ResponseDetail[], Error>({
+  // Always cache the FLAT server response under a single canonical key
+  // (['responses', discussionId]) and derive the threaded shape with `select`.
+  // Previously the queryFn returned either a flat array or a thread tree
+  // depending on the option, while the queryKey ignored the option — so a
+  // threaded consumer and a flat consumer collided on one cache entry and
+  // poisoned each other. Deriving via `select` gives every consumer one shared
+  // network fetch and keeps optimistic flat appends nesting correctly. See #1361.
+  const select = useMemo(
+    () =>
+      buildThreadTree
+        ? (responses: ResponseDetail[]): ResponseDetail[] =>
+            responseService.buildThreadTree(responses)
+        : undefined,
+    [buildThreadTree],
+  );
+
+  return useQuery<ResponseDetail[], Error, ResponseDetail[]>({
     queryKey: ['responses', discussionId],
-    queryFn: async () => {
-      const responses = await responseService.getDiscussionResponses(discussionId);
-
-      // Optionally build thread tree for nested display
-      if (buildThreadTree) {
-        return responseService.buildThreadTree(responses);
-      }
-
-      return responses;
-    },
+    queryFn: () => responseService.getDiscussionResponses(discussionId),
+    select,
     enabled: enabled && !!discussionId,
     staleTime: 1 * 60 * 1000, // 1 minute - responses update frequently
     gcTime: 5 * 60 * 1000, // 5 minutes cache

--- a/frontend/src/hooks/useVotes.ts
+++ b/frontend/src/hooks/useVotes.ts
@@ -3,7 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useEffect, useCallback } from 'react';
+/**
+ * useVotes - React Query hook for managing response votes
+ *
+ * Fetches and caches the vote summary for a single response with optimistic
+ * updates and rollback. Backed by React Query so results are shared across
+ * every ResponseItem for the same response and survive virtualizer
+ * mount/unmount churn instead of refetching on every remount (issue #1363).
+ */
+
+import { useCallback } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { voteService, type VoteSummary, type VoteType } from '../services/voteService';
 
 export interface UseVotesResult {
@@ -16,132 +26,128 @@ export interface UseVotesResult {
   removeVote: () => Promise<void>;
 }
 
+/**
+ * Compute the optimistic vote summary when toggling a vote of `voteType`.
+ * Mirrors the previous behaviour: casting the same vote again clears it.
+ */
+function applyVote(prev: VoteSummary, voteType: VoteType): VoteSummary {
+  const currentUserVote = prev.userVote;
+
+  let upvotes = prev.upvotes;
+  let downvotes = prev.downvotes;
+  let userVote: VoteType | null = voteType;
+
+  if (currentUserVote === 'UPVOTE') {
+    upvotes--;
+  } else if (currentUserVote === 'DOWNVOTE') {
+    downvotes--;
+  }
+
+  if (currentUserVote === voteType) {
+    userVote = null;
+  } else if (voteType === 'UPVOTE') {
+    upvotes++;
+  } else {
+    downvotes++;
+  }
+
+  return { upvotes, downvotes, score: upvotes - downvotes, userVote };
+}
+
+/**
+ * Compute the optimistic vote summary when removing the current user's vote.
+ */
+function applyRemove(prev: VoteSummary): VoteSummary {
+  if (!prev.userVote) return prev;
+
+  let upvotes = prev.upvotes;
+  let downvotes = prev.downvotes;
+
+  if (prev.userVote === 'UPVOTE') {
+    upvotes--;
+  } else {
+    downvotes--;
+  }
+
+  return { upvotes, downvotes, score: upvotes - downvotes, userVote: null };
+}
+
 export function useVotes(responseId: string): UseVotesResult {
-  const [voteSummary, setVoteSummary] = useState<VoteSummary | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isPending, setIsPending] = useState(false);
+  const queryClient = useQueryClient();
+  const queryKey = ['votes', responseId];
 
-  useEffect(() => {
-    let cancelled = false;
+  const query = useQuery<VoteSummary, Error>({
+    queryKey,
+    queryFn: () => voteService.getVoteSummary(responseId),
+    enabled: !!responseId,
+    staleTime: 30 * 1000, // 30 seconds
+    gcTime: 5 * 60 * 1000, // 5 minutes - keep across virtualizer remounts
+  });
 
-    const fetchVotes = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-        const summary = await voteService.getVoteSummary(responseId);
-        if (!cancelled) {
-          setVoteSummary(summary);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Failed to fetch votes');
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
+  type MutationContext = { previous: VoteSummary | undefined };
+
+  const voteMutation = useMutation<unknown, Error, VoteType, MutationContext>({
+    mutationFn: (voteType: VoteType) => voteService.vote(responseId, voteType),
+    onMutate: async (voteType) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<VoteSummary>(queryKey);
+      queryClient.setQueryData<VoteSummary>(queryKey, (prev) =>
+        prev ? applyVote(prev, voteType) : prev,
+      );
+      return { previous };
+    },
+    onError: (_error, _voteType, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(queryKey, context.previous);
       }
-    };
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
 
-    fetchVotes();
+  const removeMutation = useMutation<unknown, Error, void, MutationContext>({
+    mutationFn: () => voteService.removeVote(responseId),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<VoteSummary>(queryKey);
+      queryClient.setQueryData<VoteSummary>(queryKey, (prev) => (prev ? applyRemove(prev) : prev));
+      return { previous };
+    },
+    onError: (_error, _vars, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
 
-    return () => {
-      cancelled = true;
-    };
-  }, [responseId]);
+  const isPending = voteMutation.isPending || removeMutation.isPending;
 
   const castVote = useCallback(
     async (voteType: VoteType) => {
-      if (isPending || !voteSummary) return;
-
-      const previousSummary = voteSummary;
-      const currentUserVote = voteSummary.userVote;
-
-      setIsPending(true);
-      setVoteSummary((prev) => {
-        if (!prev) return prev;
-
-        let newUpvotes = prev.upvotes;
-        let newDownvotes = prev.downvotes;
-        let newUserVote: VoteType | null = voteType;
-
-        if (currentUserVote === 'UPVOTE') {
-          newUpvotes--;
-        } else if (currentUserVote === 'DOWNVOTE') {
-          newDownvotes--;
-        }
-
-        if (currentUserVote === voteType) {
-          newUserVote = null;
-        } else if (voteType === 'UPVOTE') {
-          newUpvotes++;
-        } else {
-          newDownvotes++;
-        }
-
-        return {
-          upvotes: newUpvotes,
-          downvotes: newDownvotes,
-          score: newUpvotes - newDownvotes,
-          userVote: newUserVote,
-        };
-      });
-
-      try {
-        await voteService.vote(responseId, voteType);
-      } catch (err) {
-        setVoteSummary(previousSummary);
-        setError(err instanceof Error ? err.message : 'Failed to vote');
-      } finally {
-        setIsPending(false);
-      }
+      if (isPending || !query.data) return;
+      await voteMutation.mutateAsync(voteType);
     },
-    [responseId, voteSummary, isPending],
+    [isPending, query.data, voteMutation],
   );
 
   const upvote = useCallback(() => castVote('UPVOTE'), [castVote]);
   const downvote = useCallback(() => castVote('DOWNVOTE'), [castVote]);
 
   const removeVote = useCallback(async () => {
-    if (isPending || !voteSummary) return;
+    if (isPending || !query.data?.userVote) return;
+    await removeMutation.mutateAsync();
+  }, [isPending, query.data?.userVote, removeMutation]);
 
-    const previousSummary = voteSummary;
-
-    setIsPending(true);
-    setVoteSummary((prev) => {
-      if (!prev || !prev.userVote) return prev;
-
-      let newUpvotes = prev.upvotes;
-      let newDownvotes = prev.downvotes;
-
-      if (prev.userVote === 'UPVOTE') {
-        newUpvotes--;
-      } else {
-        newDownvotes--;
-      }
-
-      return {
-        upvotes: newUpvotes,
-        downvotes: newDownvotes,
-        score: newUpvotes - newDownvotes,
-        userVote: null,
-      };
-    });
-
-    try {
-      await voteService.removeVote(responseId);
-    } catch (err) {
-      setVoteSummary(previousSummary);
-      setError(err instanceof Error ? err.message : 'Failed to remove vote');
-    } finally {
-      setIsPending(false);
-    }
-  }, [responseId, voteSummary, isPending]);
+  const error =
+    query.error?.message ?? voteMutation.error?.message ?? removeMutation.error?.message ?? null;
 
   return {
-    voteSummary,
-    isLoading,
+    voteSummary: query.data ?? null,
+    isLoading: query.isLoading,
     error,
     isPending,
     upvote,

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useAuthContext } from '../contexts/AuthContext';
-import { authService } from '../services/authService';
+import { discussionRealtime } from '../lib/discussionRealtime';
 
 /**
  * WebSocket message types for real-time updates
@@ -169,6 +169,8 @@ export interface UseWebSocketReturn {
     type: T,
     handler: WebSocketMessageHandler<WebSocketMessageMap[T]>,
   ) => () => void;
+  /** Join a topic room to receive its realtime events (ref-counted) */
+  subscribeToTopic: (topicId: string) => () => void;
   /** Send a message to the server */
   send: (message: WebSocketMessage) => void;
 }
@@ -194,247 +196,55 @@ export interface UseWebSocketReturn {
  * ```
  */
 export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketReturn {
-  const {
-    autoConnect = true,
-    autoReconnect = true,
-    reconnectDelay = 3000,
-    maxReconnectAttempts = 5,
-    heartbeatInterval = 30000,
-  } = options;
+  const { autoConnect = true } = options;
 
-  const { user, isAuthenticated } = useAuthContext();
-  const [state, setState] = useState<WebSocketState>('disconnected');
-  const [error, setError] = useState<string | null>(null);
+  const { isAuthenticated } = useAuthContext();
+  const [state, setState] = useState<WebSocketState>(() => discussionRealtime.getState());
 
-  const wsRef = useRef<WebSocket | null>(null);
-  const reconnectAttemptsRef = useRef(0);
-  const reconnectTimeoutRef = useRef<number | null>(null);
-  const heartbeatIntervalRef = useRef<number | null>(null);
-  const handlersRef = useRef<Map<WebSocketMessageType, Set<WebSocketMessageHandler>>>(new Map());
+  // Mirror the shared connection's state into local component state. The lazy
+  // useState initializer already reads the current state, and acquire() (which
+  // triggers connecting/connected) runs in a later effect, so subscribing here
+  // reliably captures subsequent transitions.
+  useEffect(() => discussionRealtime.onStateChange(setState), []);
 
-  /**
-   * Get WebSocket URL from environment or construct from current location
-   */
-  const getWebSocketUrl = useCallback(() => {
-    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsHost = import.meta.env['VITE_WS_HOST'] || window.location.host;
-    const wsPath = import.meta.env['VITE_WS_PATH'] || '/ws';
+  // Acquire a reference to the single shared connection while mounted and
+  // authenticated. Ref-counting means every consumer shares ONE socket per tab
+  // instead of opening its own (issue #1360). Releasing on unmount closes the
+  // socket only when the last consumer leaves, and never reconnects afterward.
+  useEffect(() => {
+    if (!autoConnect || !isAuthenticated) return undefined;
+    discussionRealtime.acquire();
+    return () => discussionRealtime.release();
+  }, [autoConnect, isAuthenticated]);
 
-    return `${wsProtocol}//${wsHost}${wsPath}`;
-  }, []);
-
-  /**
-   * Start heartbeat to keep connection alive
-   */
-  const startHeartbeat = useCallback(() => {
-    if (heartbeatIntervalRef.current) {
-      clearInterval(heartbeatIntervalRef.current);
-    }
-
-    heartbeatIntervalRef.current = window.setInterval(() => {
-      if (wsRef.current?.readyState === WebSocket.OPEN) {
-        wsRef.current.send(JSON.stringify({ type: 'PING' }));
-      }
-    }, heartbeatInterval);
-  }, [heartbeatInterval]);
-
-  /**
-   * Stop heartbeat
-   */
-  const stopHeartbeat = useCallback(() => {
-    if (heartbeatIntervalRef.current) {
-      clearInterval(heartbeatIntervalRef.current);
-      heartbeatIntervalRef.current = null;
-    }
-  }, []);
-
-  /**
-   * Handle incoming WebSocket message
-   */
-  const handleMessage = useCallback((event: MessageEvent) => {
-    try {
-      const data = JSON.parse(event.data) as { type: string };
-
-      // Ignore PONG responses
-      if (data.type === 'PONG') {
-        return;
-      }
-
-      // Cast to WebSocketMessage after PONG check
-      const message = data as WebSocketMessage;
-
-      // Route message to subscribed handlers
-      const handlers = handlersRef.current.get(message.type);
-      if (handlers) {
-        handlers.forEach((handler) => {
-          try {
-            handler(message);
-          } catch (err) {
-            console.error(`Error in WebSocket handler for ${message.type}:`, err);
-          }
-        });
-      }
-    } catch (err) {
-      console.error('Failed to parse WebSocket message:', err);
-    }
-  }, []);
-
-  /**
-   * Connect to WebSocket server
-   */
-  const connect = useCallback(() => {
-    // Don't connect if already connected or connecting
-    if (wsRef.current?.readyState === WebSocket.OPEN || state === 'connecting') {
-      return;
-    }
-
-    // Don't connect if not authenticated
-    if (!isAuthenticated || !user) {
-      setError('User not authenticated');
-      return;
-    }
-
-    // Get auth token for WebSocket authentication
-    const token = authService.getAuthToken();
-
-    setState('connecting');
-    setError(null);
-
-    try {
-      const wsUrl = getWebSocketUrl();
-      const ws = new WebSocket(wsUrl);
-
-      ws.onopen = () => {
-        setState('connected');
-        setError(null);
-        reconnectAttemptsRef.current = 0;
-        startHeartbeat();
-
-        // Send authentication token
-        if (token) {
-          ws.send(JSON.stringify({ type: 'AUTH', token }));
-        }
-      };
-
-      ws.onmessage = handleMessage;
-
-      ws.onerror = () => {
-        setState('error');
-        setError('WebSocket connection error');
-        stopHeartbeat();
-      };
-
-      ws.onclose = () => {
-        setState('disconnected');
-        stopHeartbeat();
-
-        // Auto-reconnect if enabled and not max attempts
-        if (autoReconnect && reconnectAttemptsRef.current < maxReconnectAttempts) {
-          reconnectAttemptsRef.current += 1;
-          reconnectTimeoutRef.current = window.setTimeout(() => {
-            connect();
-          }, reconnectDelay);
-        }
-      };
-
-      wsRef.current = ws;
-    } catch (err) {
-      setState('error');
-      setError(err instanceof Error ? err.message : 'Failed to connect to WebSocket');
-    }
-  }, [
-    user,
-    isAuthenticated,
-    state,
-    getWebSocketUrl,
-    handleMessage,
-    startHeartbeat,
-    stopHeartbeat,
-    autoReconnect,
-    maxReconnectAttempts,
-    reconnectDelay,
-  ]);
-
-  /**
-   * Disconnect from WebSocket server
-   */
-  const disconnect = useCallback(() => {
-    if (reconnectTimeoutRef.current) {
-      clearTimeout(reconnectTimeoutRef.current);
-      reconnectTimeoutRef.current = null;
-    }
-
-    stopHeartbeat();
-
-    if (wsRef.current) {
-      wsRef.current.close();
-      wsRef.current = null;
-    }
-
-    setState('disconnected');
-    setError(null);
-    reconnectAttemptsRef.current = 0;
-  }, [stopHeartbeat]);
-
-  /**
-   * Subscribe to WebSocket message type
-   * Returns unsubscribe function
-   */
   const subscribe = useCallback(
     <T extends keyof WebSocketMessageMap>(
       type: T,
       handler: WebSocketMessageHandler<WebSocketMessageMap[T]>,
-    ) => {
-      const handlers = handlersRef.current.get(type) || new Set();
-      handlers.add(handler as WebSocketMessageHandler);
-      handlersRef.current.set(type, handlers);
-
-      // Return unsubscribe function
-      return () => {
-        const currentHandlers = handlersRef.current.get(type);
-        if (currentHandlers) {
-          currentHandlers.delete(handler as WebSocketMessageHandler);
-          if (currentHandlers.size === 0) {
-            handlersRef.current.delete(type);
-          }
-        }
-      };
-    },
+    ) => discussionRealtime.subscribe(type, handler),
     [],
   );
 
-  /**
-   * Send message to WebSocket server
-   */
-  const send = useCallback((message: WebSocketMessage) => {
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
-      wsRef.current.send(JSON.stringify(message));
-    } else {
-      console.warn('WebSocket is not connected. Message not sent:', message);
-    }
-  }, []);
+  const subscribeToTopic = useCallback(
+    (topicId: string) => discussionRealtime.subscribeToTopic(topicId),
+    [],
+  );
 
-  /**
-   * Auto-connect on mount if enabled and authenticated
-   */
-  useEffect(() => {
-    if (autoConnect && isAuthenticated) {
-      connect();
-    }
+  const send = useCallback((message: WebSocketMessage) => discussionRealtime.send(message), []);
 
-    return () => {
-      disconnect();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoConnect, isAuthenticated]); // Only depend on autoConnect and isAuthenticated, not connect/disconnect
+  // connect/disconnect are retained for API compatibility; the connection is
+  // managed automatically via ref-counting, so they map to acquire/release.
+  const connect = useCallback(() => discussionRealtime.acquire(), []);
+  const disconnect = useCallback(() => discussionRealtime.release(), []);
 
   return {
     state,
     isConnected: state === 'connected',
-    error,
+    error: state === 'error' ? 'WebSocket connection error' : null,
     connect,
     disconnect,
     subscribe,
+    subscribeToTopic,
     send,
   };
 }

--- a/frontend/src/lib/discussionRealtime.test.ts
+++ b/frontend/src/lib/discussionRealtime.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Unit tests for the shared discussion realtime connection manager.
+ *
+ * Validates the core guarantees behind issues #1359 and #1360:
+ * - A single shared socket is created regardless of how many consumers acquire.
+ * - Backend Socket.io events are translated to the WebSocketMessage contract
+ *   and dispatched to type subscribers.
+ * - Topic-room membership is emitted over the shared socket.
+ * - Teardown happens only when the last consumer releases.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { discussionRealtime } from './discussionRealtime';
+
+interface MockSocket {
+  connected: boolean;
+  on: ReturnType<typeof vi.fn>;
+  emit: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  removeAllListeners: ReturnType<typeof vi.fn>;
+  trigger: (event: string, data: unknown) => void;
+}
+
+function makeMockSocket(): MockSocket {
+  const listeners = new Map<string, (data: unknown) => void>();
+  return {
+    connected: true,
+    on: vi.fn((event: string, cb: (data: unknown) => void) => {
+      listeners.set(event, cb);
+    }),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+    removeAllListeners: vi.fn(),
+    trigger: (event: string, data: unknown) => listeners.get(event)?.(data),
+  };
+}
+
+describe('discussionRealtime manager', () => {
+  let mock: MockSocket;
+
+  beforeEach(() => {
+    mock = makeMockSocket();
+    (window as unknown as { __wsTestMode: boolean }).__wsTestMode = true;
+    (window as unknown as { __testSocket: MockSocket }).__testSocket = mock;
+  });
+
+  afterEach(() => {
+    // Ensure the singleton is torn down between tests
+    while (discussionRealtime.isConnected() || discussionRealtime.getState() !== 'disconnected') {
+      discussionRealtime.release();
+    }
+    // Extra releases are safe (clamped at zero)
+    discussionRealtime.release();
+    delete (window as unknown as { __wsTestMode?: boolean }).__wsTestMode;
+    delete (window as unknown as { __testSocket?: MockSocket }).__testSocket;
+  });
+
+  it('creates only ONE shared socket regardless of acquire count', () => {
+    discussionRealtime.acquire();
+    discussionRealtime.acquire();
+    discussionRealtime.acquire();
+
+    // bindRelayEvents registers exactly one set of listeners for one socket
+    const relayEventCount = 5; // user:typing, reaction:added/removed, response:new, topic:status
+    expect(mock.on).toHaveBeenCalledTimes(relayEventCount);
+
+    discussionRealtime.release();
+    discussionRealtime.release();
+    // Still one consumer left → socket not torn down
+    expect(mock.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('dispatches translated backend events to type subscribers', () => {
+    discussionRealtime.acquire();
+
+    const handler = vi.fn();
+    const unsubscribe = discussionRealtime.subscribe('REACTION_ADDED', handler);
+
+    mock.trigger('reaction:added', {
+      type: 'REACTION_ADDED',
+      payload: { responseId: 'r1', userId: 'u1', userName: 'Alice', emoji: '👍' },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ type: 'REACTION_ADDED' }));
+
+    unsubscribe();
+    mock.trigger('reaction:added', {
+      type: 'REACTION_ADDED',
+      payload: { responseId: 'r1', userId: 'u1', userName: 'Alice', emoji: '👍' },
+    });
+    // No further calls after unsubscribe
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('joins and leaves topic rooms over the shared socket', () => {
+    discussionRealtime.acquire();
+
+    const leave = discussionRealtime.subscribeToTopic('topic-42');
+    expect(mock.emit).toHaveBeenCalledWith('subscribe:topic', { topicId: 'topic-42' });
+
+    leave();
+    expect(mock.emit).toHaveBeenCalledWith('unsubscribe:topic', { topicId: 'topic-42' });
+  });
+
+  it('translates USER_TYPING sends into a user:typing emit', () => {
+    discussionRealtime.acquire();
+
+    discussionRealtime.send({
+      type: 'USER_TYPING',
+      payload: { topicId: 't1', userId: '', userName: '', isTyping: true },
+    });
+
+    expect(mock.emit).toHaveBeenCalledWith('user:typing', {
+      topicId: 't1',
+      userId: '',
+      userName: '',
+      isTyping: true,
+    });
+  });
+});

--- a/frontend/src/lib/discussionRealtime.ts
+++ b/frontend/src/lib/discussionRealtime.ts
@@ -1,0 +1,260 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * discussionRealtime - Single shared Socket.io connection for discussion realtime.
+ *
+ * @remarks
+ * Previously every `useWebSocket()` caller opened its OWN raw `new WebSocket()`
+ * to a `/ws` endpoint that no backend implements (issues #1359, #1360). On a
+ * discussion page that meant ~14-20+ dead sockets per tab (one per ResponseItem
+ * via useReactions, plus Sidebar/ConversationPanel/MetadataPanel/typing), each
+ * with its own heartbeat and reconnect loop, and a disconnect() that could
+ * reconnect *after* unmount.
+ *
+ * This module replaces that with a single, module-scoped, ref-counted Socket.io
+ * connection to the discussion-service `/discussions` namespace (the transport
+ * the backend actually speaks). All hooks share it:
+ * - One socket per browser tab regardless of how many components subscribe.
+ * - Backend Socket.io events (`user:typing`, `reaction:added`, `reaction:removed`,
+ *   `response:new`, `topic:status`) are translated into the existing
+ *   `WebSocketMessage` contract so consumers need no changes.
+ * - Topic-room membership is ref-counted and re-joined automatically on
+ *   reconnect.
+ * - Teardown is intentional: when the last consumer releases, the socket is
+ *   disconnected and never reconnects (Socket.io does not resurrect a socket
+ *   we called `disconnect()` on), eliminating the reconnect-after-unmount leak.
+ */
+
+import { io, type Socket } from 'socket.io-client';
+import type {
+  WebSocketMessage,
+  WebSocketMessageType,
+  WebSocketMessageHandler,
+  WebSocketMessageMap,
+  WebSocketState,
+} from '../hooks/useWebSocket';
+
+type StateListener = (state: WebSocketState) => void;
+
+/**
+ * Backend Socket.io event names emitted into `topic:{id}` rooms. Each carries a
+ * `{ type, payload, timestamp }` envelope matching the WebSocketMessage shape.
+ */
+const RELAY_EVENTS = [
+  'user:typing',
+  'reaction:added',
+  'reaction:removed',
+  'response:new',
+  'topic:status',
+] as const;
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+class DiscussionRealtimeManager {
+  private socket: Socket | null = null;
+  private usingMockSocket = false;
+  private refCount = 0;
+  private state: WebSocketState = 'disconnected';
+
+  private readonly handlers = new Map<WebSocketMessageType, Set<WebSocketMessageHandler>>();
+  private readonly stateListeners = new Set<StateListener>();
+  private readonly topicRefCounts = new Map<string, number>();
+
+  getState(): WebSocketState {
+    return this.state;
+  }
+
+  isConnected(): boolean {
+    return this.state === 'connected';
+  }
+
+  /** Subscribe to connection-state changes. Returns an unsubscribe function. */
+  onStateChange(listener: StateListener): () => void {
+    this.stateListeners.add(listener);
+    return () => {
+      this.stateListeners.delete(listener);
+    };
+  }
+
+  private setState(state: WebSocketState): void {
+    if (this.state === state) return;
+    this.state = state;
+    this.stateListeners.forEach((listener) => listener(state));
+  }
+
+  /** Acquire a reference to the shared connection, connecting on the first one. */
+  acquire(): void {
+    this.refCount += 1;
+    if (this.refCount === 1) {
+      this.connect();
+    }
+  }
+
+  /** Release a reference; the shared connection closes when the count hits zero. */
+  release(): void {
+    this.refCount = Math.max(0, this.refCount - 1);
+    if (this.refCount === 0) {
+      this.disconnect();
+    }
+  }
+
+  private connect(): void {
+    // Single shared connection guard — never create a duplicate socket.
+    if (this.socket) return;
+
+    // E2E mock socket support (mirrors useCommonGroundUpdates)
+    const isTestMode = (window as any).__wsTestMode === true;
+    const mockSocket = (window as any).__testSocket;
+
+    if (isTestMode && mockSocket) {
+      this.socket = mockSocket as Socket;
+      this.usingMockSocket = true;
+      this.bindRelayEvents(this.socket);
+      // Defer state update to avoid cascading renders inside an effect
+      queueMicrotask(() => this.setState('connected'));
+      this.rejoinTopics();
+      return;
+    }
+
+    // Same-origin by default; nginx proxies the discussion-service Socket.io path.
+    const origin = import.meta.env['VITE_DISCUSSION_SERVICE_URL'] || '';
+    const path = import.meta.env['VITE_DISCUSSION_WS_PATH'] || '/discussions-ws';
+
+    this.setState('connecting');
+
+    const socket = io(`${origin}/discussions`, {
+      path,
+      transports: ['websocket', 'polling'],
+      reconnection: true,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 5000,
+      reconnectionAttempts: 5,
+    });
+
+    this.socket = socket;
+    this.usingMockSocket = false;
+
+    socket.on('connect', () => {
+      this.setState('connected');
+      this.rejoinTopics();
+    });
+    socket.on('disconnect', () => this.setState('disconnected'));
+    socket.on('connect_error', () => this.setState('error'));
+
+    this.bindRelayEvents(socket);
+  }
+
+  private bindRelayEvents(socket: Socket): void {
+    RELAY_EVENTS.forEach((event) => {
+      socket.on(event, (data: unknown) => this.dispatch(data));
+    });
+  }
+
+  private dispatch(data: unknown): void {
+    if (!data || typeof data !== 'object') return;
+    const message = data as WebSocketMessage;
+    if (!message.type) return;
+
+    const set = this.handlers.get(message.type);
+    if (!set) return;
+
+    set.forEach((handler) => {
+      try {
+        handler(message);
+      } catch (err) {
+        console.error(`Error in realtime handler for ${message.type}:`, err);
+      }
+    });
+  }
+
+  /** Subscribe to a message type. Returns an unsubscribe function. */
+  subscribe<T extends keyof WebSocketMessageMap>(
+    type: T,
+    handler: WebSocketMessageHandler<WebSocketMessageMap[T]>,
+  ): () => void {
+    const set = this.handlers.get(type) ?? new Set<WebSocketMessageHandler>();
+    set.add(handler as WebSocketMessageHandler);
+    this.handlers.set(type, set);
+
+    return () => {
+      const current = this.handlers.get(type);
+      if (!current) return;
+      current.delete(handler as WebSocketMessageHandler);
+      if (current.size === 0) {
+        this.handlers.delete(type);
+      }
+    };
+  }
+
+  /**
+   * Join a topic room to receive its typing / reaction / new-response / status
+   * events. Ref-counted per topic; the room is left when the last subscriber
+   * for that topic unsubscribes. Returns an unsubscribe function.
+   */
+  subscribeToTopic(topicId: string): () => void {
+    if (!topicId) return () => {};
+
+    const count = this.topicRefCounts.get(topicId) ?? 0;
+    this.topicRefCounts.set(topicId, count + 1);
+    if (count === 0 && this.socket?.connected) {
+      this.socket.emit('subscribe:topic', { topicId });
+    }
+
+    return () => {
+      const current = this.topicRefCounts.get(topicId) ?? 0;
+      if (current <= 1) {
+        this.topicRefCounts.delete(topicId);
+        if (this.socket?.connected) {
+          this.socket.emit('unsubscribe:topic', { topicId });
+        }
+      } else {
+        this.topicRefCounts.set(topicId, current - 1);
+      }
+    };
+  }
+
+  private rejoinTopics(): void {
+    if (!this.socket) return;
+    this.topicRefCounts.forEach((_count, topicId) => {
+      this.socket?.emit('subscribe:topic', { topicId });
+    });
+  }
+
+  /** Send a client-originated message (currently only typing indicators). */
+  send(message: WebSocketMessage): void {
+    if (!this.socket) {
+      console.warn('Discussion realtime socket is not connected. Message not sent:', message);
+      return;
+    }
+
+    switch (message.type) {
+      case 'USER_TYPING':
+        this.socket.emit('user:typing', message.payload);
+        break;
+      default:
+        // All other message types are server-emitted; nothing to send.
+        break;
+    }
+  }
+
+  private disconnect(): void {
+    // Intentional teardown — do NOT let Socket.io reconnect after the last
+    // consumer unmounts (the core of the reconnect-after-unmount leak, #1360).
+    if (this.socket && !this.usingMockSocket) {
+      this.socket.removeAllListeners();
+      this.socket.disconnect();
+    }
+    this.socket = null;
+    this.usingMockSocket = false;
+    this.topicRefCounts.clear();
+    this.setState('disconnected');
+  }
+}
+
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/** The single shared discussion realtime connection for this browser tab. */
+export const discussionRealtime = new DiscussionRealtimeManager();

--- a/frontend/src/pages/Topics/DiscussionPage.tsx
+++ b/frontend/src/pages/Topics/DiscussionPage.tsx
@@ -245,6 +245,44 @@ export function DiscussionPage() {
     }
   }, [queryClient, activeTopicId]);
 
+  // Handle top-level response submission (issue #1358).
+  // Previously DiscussionPage never passed onResponseSubmit, so ConversationPanel
+  // fell back to a no-op that cleared the composer without ever calling the API —
+  // silently discarding the single most important action in the product.
+  const handleResponseSubmit = useCallback(
+    async (response: CreateResponseRequest) => {
+      if (!activeTopic?.id) {
+        toast.error('Cannot post response: no active topic selected');
+        return;
+      }
+
+      try {
+        await responseService.createResponse({
+          discussionId: activeTopic.id,
+          content: response.content,
+          citations: response.citedSources?.map((url) => ({ url })),
+          parentResponseId: response.parentId,
+        });
+
+        // Clear composition state after successful submission
+        handleCompositionStateChange(false);
+
+        // Invalidate responses + discussion metadata to reflect the new response
+        await queryClient.invalidateQueries({ queryKey: ['responses', activeTopic.id] });
+        queryClient.invalidateQueries({ queryKey: ['discussions', activeTopic.id] });
+        queryClient.invalidateQueries({ queryKey: ['discussions'] });
+
+        toast.success('Response posted successfully');
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to post response';
+        toast.error(message);
+        // Re-throw so CompactComposer preserves the user's text instead of clearing it
+        throw error;
+      }
+    },
+    [activeTopic, queryClient, toast, handleCompositionStateChange],
+  );
+
   // Handle inline reply submission (memoized to prevent unnecessary re-renders)
   const handleReplySubmit = useCallback(
     async (response: CreateResponseRequest) => {
@@ -350,6 +388,7 @@ export function DiscussionPage() {
             height={typeof window !== 'undefined' ? window.innerHeight : 800}
             onPreviewFeedbackChange={handlePreviewFeedbackChange}
             onCompositionStateChange={handleCompositionStateChange}
+            onResponseSubmit={handleResponseSubmit}
             onReplySubmit={handleReplySubmit}
             onRefetchResponses={handleRefetchResponses}
           />

--- a/services/discussion-service/src/gateways/discussion.gateway.test.ts
+++ b/services/discussion-service/src/gateways/discussion.gateway.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2025 Tony Stein
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Server } from 'socket.io';
+import { DiscussionGateway } from './discussion.gateway.js';
+
+/**
+ * Verifies the realtime emit surface added for issue #1359: a posted response
+ * (and a topic status change / reaction) must produce a client-visible event
+ * broadcast into the correct `topic:{id}` room.
+ */
+describe('DiscussionGateway realtime emits', () => {
+  let gateway: DiscussionGateway;
+  let emit: ReturnType<typeof vi.fn>;
+  let to: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    gateway = new DiscussionGateway();
+    emit = vi.fn();
+    to = vi.fn().mockReturnValue({ emit });
+    // Inject a mock Socket.io server
+    gateway.server = { to } as unknown as Server;
+  });
+
+  it('emitNewResponse broadcasts NEW_RESPONSE to the topic room', () => {
+    gateway.emitNewResponse({
+      topicId: 'topic-1',
+      responseId: 'resp-1',
+      authorId: 'user-1',
+      authorName: 'Alice',
+    });
+
+    expect(to).toHaveBeenCalledWith('topic:topic-1');
+    expect(emit).toHaveBeenCalledWith(
+      'response:new',
+      expect.objectContaining({
+        type: 'NEW_RESPONSE',
+        payload: expect.objectContaining({
+          topicId: 'topic-1',
+          responseId: 'resp-1',
+          authorId: 'user-1',
+          authorName: 'Alice',
+        }),
+      }),
+    );
+  });
+
+  it('emitTopicStatusChange broadcasts TOPIC_STATUS_CHANGE to the topic room', () => {
+    gateway.emitTopicStatusChange({
+      topicId: 'topic-9',
+      oldStatus: 'ACTIVE',
+      newStatus: 'ARCHIVED',
+    });
+
+    expect(to).toHaveBeenCalledWith('topic:topic-9');
+    expect(emit).toHaveBeenCalledWith(
+      'topic:status',
+      expect.objectContaining({
+        type: 'TOPIC_STATUS_CHANGE',
+        payload: expect.objectContaining({
+          topicId: 'topic-9',
+          oldStatus: 'ACTIVE',
+          newStatus: 'ARCHIVED',
+        }),
+      }),
+    );
+  });
+
+  it('emitReactionAdded broadcasts REACTION_ADDED to the topic room', () => {
+    gateway.emitReactionAdded('topic-2', {
+      responseId: 'resp-2',
+      userId: 'user-2',
+      userName: 'Bob',
+      emoji: '👍',
+    });
+
+    expect(to).toHaveBeenCalledWith('topic:topic-2');
+    expect(emit).toHaveBeenCalledWith(
+      'reaction:added',
+      expect.objectContaining({ type: 'REACTION_ADDED' }),
+    );
+  });
+});

--- a/services/discussion-service/src/gateways/discussion.gateway.ts
+++ b/services/discussion-service/src/gateways/discussion.gateway.ts
@@ -36,6 +36,10 @@ import type {
     credentials: true,
   },
   namespace: '/discussions',
+  // Distinct Engine.IO path so nginx can proxy this Socket.io server separately
+  // from notification-service (which owns the default /socket.io path). Without
+  // this, two Socket.io servers would collide on one nginx location. See #1359.
+  path: '/discussions-ws',
 })
 export class DiscussionGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
@@ -161,6 +165,58 @@ export class DiscussionGateway implements OnGatewayConnection, OnGatewayDisconne
 
     this.logger.log(
       `Broadcasted reaction.removed event for response ${payload.responseId} to room ${room}`,
+    );
+  }
+
+  /**
+   * Broadcast a new-response event to all clients in the topic room.
+   * Called by ResponsesService after a response is created so the client-side
+   * "N new responses" banner and sidebar counters can update in realtime (#1359).
+   *
+   * @param payload - The new response payload
+   */
+  emitNewResponse(payload: {
+    topicId: string;
+    responseId: string;
+    authorId: string;
+    authorName: string;
+    parentId?: string;
+  }): void {
+    const room = `topic:${payload.topicId}`;
+
+    this.server.to(room).emit('response:new', {
+      type: 'NEW_RESPONSE',
+      payload: {
+        ...payload,
+        timestamp: new Date().toISOString(),
+      },
+      timestamp: new Date().toISOString(),
+    });
+
+    this.logger.log(`Broadcasted response.new event for response ${payload.responseId} to ${room}`);
+  }
+
+  /**
+   * Broadcast a topic status change to all clients in the topic room.
+   * Called by TopicStatusService so clients viewing a topic learn it was
+   * archived/locked/activated without reloading the page (#1359, #1362).
+   *
+   * @param payload - The topic status change payload
+   */
+  emitTopicStatusChange(payload: { topicId: string; oldStatus: string; newStatus: string }): void {
+    const room = `topic:${payload.topicId}`;
+
+    this.server.to(room).emit('topic:status', {
+      type: 'TOPIC_STATUS_CHANGE',
+      payload: {
+        ...payload,
+        timestamp: new Date().toISOString(),
+      },
+      timestamp: new Date().toISOString(),
+    });
+
+    this.logger.log(
+      `Broadcasted topic.status event for topic ${payload.topicId} (${payload.oldStatus} -> ${payload.newStatus})`,
     );
   }
 

--- a/services/discussion-service/src/responses/responses.service.ts
+++ b/services/discussion-service/src/responses/responses.service.ts
@@ -24,6 +24,7 @@ import { validateCitationUrl } from '../utils/ssrf-validator.js';
 import { RESPONSE_CONSTRAINTS } from '../constants/index.js';
 import { ResponseThreadingService } from './response-threading.service.js';
 import type { ThreadedResponse } from './response-threading.service.js';
+import { DiscussionGateway } from '../gateways/discussion.gateway.js';
 
 // Re-export ThreadedResponse for consumers
 export type { ThreadedResponse } from './response-threading.service.js';
@@ -39,6 +40,7 @@ export class ResponsesService {
     @Inject(ResponseThreadingService)
     private readonly threadingService: ResponseThreadingService,
     @Optional() private readonly moderationClient?: ModerationClientService,
+    @Optional() @Inject(DiscussionGateway) private readonly discussionGateway?: DiscussionGateway,
   ) {}
 
   /**
@@ -292,6 +294,18 @@ export class ResponsesService {
         },
       },
     });
+
+    // Broadcast a realtime new-response event to clients in the topic room so
+    // the "N new responses" banner and sidebar counters update live (#1359).
+    if (this.discussionGateway && completeResponse) {
+      this.discussionGateway.emitNewResponse({
+        topicId: completeResponse.topicId,
+        responseId: completeResponse.id,
+        authorId: completeResponse.authorId,
+        authorName: completeResponse.author?.displayName || 'Anonymous',
+        parentId: completeResponse.parentId ?? undefined,
+      });
+    }
 
     // Map to ResponseDto
     return this.mapToResponseDto(completeResponse!);

--- a/services/discussion-service/src/topics/topic-status.service.ts
+++ b/services/discussion-service/src/topics/topic-status.service.ts
@@ -3,10 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, NotFoundException, BadRequestException, Inject } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  Inject,
+  Optional,
+} from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
 import { PrismaService } from '../prisma/prisma.service.js';
+import { DiscussionGateway } from '../gateways/discussion.gateway.js';
 import type { TopicResponseDto } from './dto/topic-response.dto.js';
 
 type TopicStatus = 'SEEDING' | 'ACTIVE' | 'ARCHIVED' | 'LOCKED';
@@ -32,6 +39,7 @@ export class TopicStatusService {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    @Optional() @Inject(DiscussionGateway) private readonly discussionGateway?: DiscussionGateway,
   ) {}
 
   /**
@@ -134,6 +142,16 @@ export class TopicStatusService {
 
     // Invalidate caches
     await this.invalidateCaches(topicId);
+
+    // Broadcast the status change to clients viewing this topic so archived/
+    // locked state is reflected live without a page reload (#1359, #1362).
+    if (this.discussionGateway && topic.status !== newStatus) {
+      this.discussionGateway.emitTopicStatusChange({
+        topicId,
+        oldStatus: topic.status,
+        newStatus,
+      });
+    }
 
     return {
       id: updatedTopic.id,


### PR DESCRIPTION
## Summary

Repairs a cluster of eight audit findings centered on the discussion page's realtime and data layer. All fixes keep existing hook/component public APIs stable so consumers and their tests are unaffected.

### Realtime transport (#1359, #1360)
- **Dead transport → real Socket.io.** `useWebSocket` spoke a bespoke `/ws` JSON protocol that no backend implements. It now drives a single, module-scoped, **ref-counted Socket.io connection** to the discussion-service `/discussions` namespace (`frontend/src/lib/discussionRealtime.ts`). Backend events (`user:typing`, `reaction:added/removed`, `response:new`, `topic:status`) are translated into the existing `WebSocketMessage` contract, so `subscribe`/`send`/`isConnected` are unchanged.
- **One socket per tab.** Previously every consumer (Sidebar, ConversationPanel, MetadataPanel, typing, and `useReactions` inside *every* ResponseItem) opened its own socket — ~14-20+ per page. They now share one. Teardown is intentional: when the last consumer releases, the socket disconnects and never reconnects, eliminating the reconnect-after-unmount leak.
- **nginx + gateway path.** discussion-service's Socket.io server gets a distinct Engine.IO path (`/discussions-ws`) and an nginx proxy location, so it no longer collides with notification-service's `/socket.io`.
- **Server emits.** Added `emitNewResponse` / `emitTopicStatusChange` to `DiscussionGateway`, wired into `ResponsesService.createResponse` and `TopicStatusService` (via the existing `@Optional()` gateway-injection pattern). ConversationPanel joins the `topic:{id}` room via new `subscribeToTopic`.
- Tests: `discussion.gateway.test.ts` asserts a posted response / status change broadcasts a client-visible event; `discussionRealtime.test.ts` asserts single-shared-connection + event translation.

### Data layer & UX
- **#1358 (critical):** DiscussionPage now passes a real `onResponseSubmit`; the no-op `|| (() => Promise.resolve())` fallback is removed. Top-level responses are posted instead of silently discarded (the composer is hidden + a dev error logged if no handler is wired).
- **#1361:** `useResponses` caches the **flat** list under one canonical key and derives the thread tree via `select`, so flat and threaded consumers share one cache/fetch and optimistic appends nest correctly.
- **#1362:** Read-only state is derived from `topic.status` (ARCHIVED/LOCKED); the composer and reply affordances are hidden and a persistent notice is shown — correct on direct load, not just live transitions.
- **#1363:** `useVotes` converted to React Query, so per-response vote summaries are cached across virtualizer remounts (no more refetch-on-scroll N+1).
- **#1364:** Notifications now poll (30s, visible-tab only) and refetch on window focus/visibility, so the unread badge stops going stale for the session.
- **#1387:** Toast/Notification/Auth/Theme context values are memoized with `useMemo`, stopping app-wide cascading re-renders (the AuthProvider-consumes-Toast chain in particular).

## Test plan
- [x] `frontend` typecheck passes
- [x] `discussion-service` typecheck passes
- [x] Frontend unit tests (useReactions, useTypingIndicator, discussionRealtime) pass
- [x] discussion-service unit tests pass (173 incl. responses/topic-status/gateway)
- [x] ESLint + Prettier clean on changed files

Fixes #1359
Fixes #1360
Fixes #1363
Fixes #1364
Fixes #1358
Fixes #1361
Fixes #1362
Fixes #1387

🤖 Generated with [Claude Code](https://claude.com/claude-code)