### PR TITLE
fix(auth): repair login, register, verification, reset & token-hardening flows

### DIFF
--- a/frontend/src/components/auth/EmailSignupForm.tsx
+++ b/frontend/src/components/auth/EmailSignupForm.tsx
@@ -6,6 +6,12 @@
 import React, { useState } from 'react';
 import Input from '../ui/Input';
 import Button from '../ui/Button';
+import {
+  PASSWORD_SPECIAL_CHAR_REGEX,
+  PASSWORD_SPECIAL_CHAR_MESSAGE,
+  DISPLAY_NAME_MIN_LENGTH,
+  DISPLAY_NAME_MAX_LENGTH,
+} from '../../schemas/common';
 
 export interface EmailSignupFormData {
   email: string;
@@ -101,16 +107,16 @@ function EmailSignupForm({
     return undefined;
   };
 
-  // Display name validation (3-50 characters)
+  // Display name validation (aligned with backend RegisterDto: 2-50 characters)
   const validateDisplayName = (displayName: string): string | undefined => {
     if (!displayName) {
       return 'Display name is required';
     }
-    if (displayName.length < 3) {
-      return 'Display name must be at least 3 characters';
+    if (displayName.trim().length < DISPLAY_NAME_MIN_LENGTH) {
+      return `Display name must be at least ${DISPLAY_NAME_MIN_LENGTH} characters`;
     }
-    if (displayName.length > 50) {
-      return 'Display name must be at most 50 characters';
+    if (displayName.trim().length > DISPLAY_NAME_MAX_LENGTH) {
+      return `Display name must be at most ${DISPLAY_NAME_MAX_LENGTH} characters`;
     }
     return undefined;
   };
@@ -132,8 +138,8 @@ function EmailSignupForm({
     if (!/[0-9]/.test(password)) {
       return 'Password must contain at least one number';
     }
-    if (!/[^A-Za-z0-9]/.test(password)) {
-      return 'Password must contain at least one special character';
+    if (!PASSWORD_SPECIAL_CHAR_REGEX.test(password)) {
+      return PASSWORD_SPECIAL_CHAR_MESSAGE;
     }
     return undefined;
   };

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -104,9 +104,11 @@ function LoginForm({ onSubmit, isLoading = false, error, className = '' }: Login
           />
 
           <div className="flex items-center justify-between">
-            <label className="flex items-center">
+            <label htmlFor="rememberMe" className="flex items-center">
               <input
                 type="checkbox"
+                id="rememberMe"
+                {...register('rememberMe')}
                 className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 dark:border-gray-600 dark:bg-gray-700 rounded"
               />
               <span className="ml-2 text-sm text-gray-600 dark:text-gray-300">Remember me</span>

--- a/frontend/src/components/auth/RegistrationForm.tsx
+++ b/frontend/src/components/auth/RegistrationForm.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { registrationSchema, type RegistrationFormData } from '../../schemas/auth';
@@ -282,12 +283,12 @@ function RegistrationForm({
 
           <p className="text-sm text-center text-gray-600 dark:text-gray-300">
             Already have an account?{' '}
-            <a
-              href="/"
+            <Link
+              to="/login"
               className="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 font-medium"
             >
               Sign in
-            </a>
+            </Link>
           </p>
         </form>
       </CardBody>

--- a/frontend/src/contexts/LoginModalContext.tsx
+++ b/frontend/src/contexts/LoginModalContext.tsx
@@ -76,7 +76,10 @@ export function LoginModalProvider({ children }: { children: React.ReactNode }) 
     setLoginLoading(true);
 
     try {
-      await login(loginEmail, loginPassword);
+      // Pass the modal's rememberMe state through to AuthContext.login so the
+      // checkbox actually controls token persistence (issue #1332). Without
+      // this, every modal login was forced session-only regardless of the box.
+      await login(loginEmail, loginPassword, rememberMe);
       closeModal();
 
       // Redirect to original page or default to /topics with welcome banner

--- a/frontend/src/pages/Auth/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/Auth/ForgotPasswordPage.tsx
@@ -29,6 +29,7 @@ function ForgotPasswordPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [submittedEmail, setSubmittedEmail] = useState('');
+  const [submitError, setSubmitError] = useState<string>('');
 
   const {
     register,
@@ -40,16 +41,24 @@ function ForgotPasswordPage() {
 
   const onSubmit = async (data: ForgotPasswordFormData) => {
     setIsLoading(true);
+    setSubmitError('');
     try {
+      // Only reach the success screen on a 2xx response. Anti-enumeration is
+      // handled entirely server-side (the endpoint always returns 200 with a
+      // neutral message), so any thrown error here means a genuine failure —
+      // rate limit (429), 5xx, or a network/offline error. Masking those as
+      // success (the previous behaviour) left users waiting for a code that was
+      // never generated (issue #1333).
       await authService.forgotPassword(data.email);
       setSubmittedEmail(data.email);
       setIsSubmitted(true);
       toast.success('If an account exists, a reset code has been sent to your email.');
     } catch {
-      // Still show success to prevent email enumeration
-      setSubmittedEmail(data.email);
-      setIsSubmitted(true);
-      toast.success('If an account exists, a reset code has been sent to your email.');
+      // Neutral, retryable message that does not reveal whether the account
+      // exists — surfaces the real failure without aiding enumeration.
+      const message = "We couldn't process your request. Please try again in a moment.";
+      setSubmitError(message);
+      toast.error(message);
     } finally {
       setIsLoading(false);
     }
@@ -135,6 +144,16 @@ function ForgotPasswordPage() {
 
           <CardBody>
             <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+              {submitError && (
+                <div
+                  className="rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 p-4"
+                  role="alert"
+                  aria-live="polite"
+                >
+                  <p className="text-sm text-red-800 dark:text-red-300">{submitError}</p>
+                </div>
+              )}
+
               <Input
                 label="Email"
                 type="email"

--- a/frontend/src/pages/Auth/LoginPage.tsx
+++ b/frontend/src/pages/Auth/LoginPage.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import LoginForm from '../../components/auth/LoginForm';
 import type { LoginFormData } from '../../components/auth/LoginForm';
-import { authService } from '../../services/authService';
+import { useAuthContext } from '../../contexts/AuthContext';
 
 /**
  * Login page that renders the LoginForm component
@@ -15,6 +15,7 @@ import { authService } from '../../services/authService';
  */
 function LoginPage() {
   const navigate = useNavigate();
+  const { login } = useAuthContext();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>();
 
@@ -23,12 +24,14 @@ function LoginPage() {
     setError(undefined);
 
     try {
-      await authService.login({
-        email: data.email,
-        password: data.password,
-      });
+      // Route through AuthContext so the profile is fetched, isAuthenticated
+      // flips to true, rememberMe/minor storage rules apply, and the "Welcome
+      // back" toast fires — all before we navigate. Calling authService.login
+      // directly here left AuthContext.user null, bouncing the user off any
+      // ProtectedRoute until a hard refresh (issue #1355).
+      await login(data.email, data.password, data.rememberMe);
 
-      // Login successful - redirect to topics page
+      // Login (and profile fetch + state propagation) complete — safe to redirect
       navigate('/topics', { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to sign in. Please try again.');

--- a/frontend/src/pages/Auth/RegisterPage.tsx
+++ b/frontend/src/pages/Auth/RegisterPage.tsx
@@ -15,6 +15,10 @@ interface RegisterResponse {
   displayName: string;
   message: string;
   requiresEmailVerification: boolean;
+  /** Whether parental consent is required (true for minors) */
+  requiresParentalConsent?: boolean;
+  /** Whether the parental-consent email was sent */
+  consentEmailSent?: boolean;
 }
 
 /**
@@ -31,19 +35,29 @@ function RegisterPage() {
     setError(undefined);
 
     try {
+      // Forward ALL collected fields. Previously only email/password/displayName
+      // were sent, silently dropping birthDate/declaredCountry/parentEmail — so a
+      // minor's parental-consent flow (which the backend drives from these
+      // fields) never triggered despite the UI promising a consent email
+      // (issue #1331). Optional fields are omitted when empty so class-validator
+      // @IsOptional rules pass.
       await apiClient.post<RegisterResponse>('/auth/register', {
         email: data.email,
         password: data.password,
         displayName: data.displayName,
+        ...(data.birthDate ? { birthDate: data.birthDate } : {}),
+        ...(data.declaredCountry ? { declaredCountry: data.declaredCountry } : {}),
+        ...(data.parentEmail ? { parentEmail: data.parentEmail } : {}),
       });
 
-      // Registration successful - redirect to landing page
-      // User will need to verify email before logging in
-      navigate('/', {
-        state: {
-          message: 'Registration successful! Please check your email to verify your account.',
-        },
-      });
+      // Store the email so /verify-email (and resend) have a pending target —
+      // without this the verification page dead-ends with "No pending
+      // verification email found" (issue #1331). Mirrors the /signup flow.
+      localStorage.setItem('pendingVerificationEmail', data.email);
+
+      // Send the user straight to the verification step instead of the landing
+      // page (which never rendered the success message anyway).
+      navigate('/verify-email', { replace: true });
     } catch (err) {
       if (err instanceof ApiError) {
         // Handle specific API errors

--- a/frontend/src/pages/Auth/ResetPasswordPage.tsx
+++ b/frontend/src/pages/Auth/ResetPasswordPage.tsx
@@ -13,6 +13,7 @@ import Button from '../../components/ui/Button';
 import Input from '../../components/ui/Input';
 import { authService } from '../../services/authService';
 import { useToast } from '../../contexts/ToastContext';
+import { PASSWORD_SPECIAL_CHAR_REGEX } from '../../schemas/common';
 
 const resetPasswordSchema = z
   .object({
@@ -27,7 +28,9 @@ const resetPasswordSchema = z
       .regex(/[A-Z]/, 'Password must contain an uppercase letter')
       .regex(/[a-z]/, 'Password must contain a lowercase letter')
       .regex(/[0-9]/, 'Password must contain a number')
-      .regex(/[^A-Za-z0-9]/, 'Password must contain a special character'),
+      // Match the backend special-character set so a valid client password is
+      // never rejected server-side with a 400.
+      .regex(PASSWORD_SPECIAL_CHAR_REGEX, 'Password must contain a special character'),
     confirmPassword: z.string(),
   })
   .refine((data) => data.newPassword === data.confirmPassword, {

--- a/frontend/src/pages/EmailVerificationPage.tsx
+++ b/frontend/src/pages/EmailVerificationPage.tsx
@@ -115,11 +115,20 @@ export const EmailVerificationPage: React.FC = () => {
 
       const response = await authService.verifyEmail(codeToVerify);
 
-      // Check onboarding progress and redirect accordingly
-      if (response.onboardingProgress.topicsSelected) {
-        navigate('/home', { replace: true });
+      // The endpoint returns { success, message, emailVerified } — NOT an
+      // AuthResponse. Reading response.onboardingProgress here used to throw a
+      // TypeError that was surfaced as a fake "verification failed" error even
+      // though the account was verified server-side (issue #1330).
+      if (response.success) {
+        // Send verified users to an existing onboarding route. '/home' and
+        // '/onboarding/topics' are not defined in the router (they resolved to
+        // the 404 page), so use '/onboarding/orientation'.
+        navigate('/onboarding/orientation', { replace: true });
       } else {
-        navigate('/onboarding/topics', { replace: true });
+        setIsLoading(false);
+        setError(response.message || 'Verification failed. Please try again.');
+        setCode(['', '', '', '', '', '']);
+        inputRefs.current[0]?.focus();
       }
     } catch (err) {
       setIsLoading(false);

--- a/frontend/src/schemas/auth.ts
+++ b/frontend/src/schemas/auth.ts
@@ -4,7 +4,13 @@
  */
 
 import { z } from 'zod';
-import { emailSchema, passwordSchema, birthDateSchema, countryCodeSchema } from './common';
+import {
+  emailSchema,
+  passwordSchema,
+  displayNameSchema,
+  birthDateSchema,
+  countryCodeSchema,
+} from './common';
 
 /**
  * Authentication Form Validation Schemas
@@ -12,11 +18,19 @@ import { emailSchema, passwordSchema, birthDateSchema, countryCodeSchema } from 
  */
 
 /**
- * Login schema - Email + Password
+ * Login schema - Email + Password + Remember Me
+ *
+ * `rememberMe` controls token persistence: when true tokens stay in
+ * localStorage (survive browser restarts), when false they are moved to
+ * sessionStorage. Defaults to false so unchecked = session-only.
  */
 export const loginSchema = z.object({
   email: emailSchema,
   password: z.string().min(1, 'Password is required'), // Relaxed for login (no format requirements)
+  // Optional (not .default) so the resolver's input and output types match,
+  // keeping useForm<LoginFormData> happy. An unchecked box yields `undefined`,
+  // which AuthContext.login treats as "session-only" (rememberMe = false).
+  rememberMe: z.boolean().optional(),
 });
 
 export type LoginFormData = z.infer<typeof loginSchema>;
@@ -37,12 +51,9 @@ export const parentEmailSchema = z
 export const registrationSchema = z
   .object({
     email: emailSchema,
-    displayName: z
-      .string()
-      .min(3, 'Display name must be at least 3 characters')
-      .max(50, 'Display name must be at most 50 characters')
-      .regex(/^[a-zA-Z0-9\s]+$/, 'Display name can only contain letters, numbers, and spaces')
-      .trim(),
+    // Shared displayName rules (aligned with backend RegisterDto) so names like
+    // "O'Brien" or "José" are not blocked client-side.
+    displayName: displayNameSchema,
     password: passwordSchema,
     confirmPassword: z.string().min(1, 'Please confirm your password'),
     // Child safety fields (optional for Phase 1)

--- a/frontend/src/schemas/common.ts
+++ b/frontend/src/schemas/common.ts
@@ -22,13 +22,26 @@ export const emailSchema = z
   .trim();
 
 /**
+ * Canonical password special-character set.
+ *
+ * Single source of truth shared by every client-side password check so the
+ * frontend never accepts a character the backend RegisterDto
+ * (services/user-service/src/auth/dto/register.dto.ts) would reject with a 400.
+ * Keep this in sync with the class-validator `@Matches` rule on the backend.
+ */
+export const PASSWORD_SPECIAL_CHAR_REGEX = /[!@#$%^&*(),.?":{}|<>]/;
+
+/** Human-readable message used whenever the special-character rule fails. */
+export const PASSWORD_SPECIAL_CHAR_MESSAGE = 'Password must contain at least one special character';
+
+/**
  * Password validation schema
  * Requirements:
  * - Minimum 12 characters
  * - At least one lowercase letter
  * - At least one uppercase letter
  * - At least one number
- * - At least one special character
+ * - At least one special character (see PASSWORD_SPECIAL_CHAR_REGEX)
  */
 export const passwordSchema = z
   .string()
@@ -36,18 +49,29 @@ export const passwordSchema = z
   .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
   .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
   .regex(/[0-9]/, 'Password must contain at least one number')
-  .regex(/[!@#$%^&*(),.?":{}|<>]/, 'Password must contain at least one special character');
+  .regex(PASSWORD_SPECIAL_CHAR_REGEX, PASSWORD_SPECIAL_CHAR_MESSAGE);
 
 /**
  * Display name validation schema
- * Requirements: 3-50 characters, alphanumeric with spaces allowed
+ *
+ * Aligned with the backend RegisterDto (MinLength 2, MaxLength 50, no
+ * character allow-list) so legitimate names such as "O'Brien" or "José" are
+ * not blocked client-side while still passing server validation.
  */
+export const DISPLAY_NAME_MIN_LENGTH = 2;
+export const DISPLAY_NAME_MAX_LENGTH = 50;
+
 export const displayNameSchema = z
   .string()
-  .min(3, 'Display name must be at least 3 characters')
-  .max(50, 'Display name must be at most 50 characters')
-  .regex(/^[a-zA-Z0-9\s]+$/, 'Display name can only contain letters, numbers, and spaces')
-  .trim();
+  .trim()
+  .min(
+    DISPLAY_NAME_MIN_LENGTH,
+    `Display name must be at least ${DISPLAY_NAME_MIN_LENGTH} characters`,
+  )
+  .max(
+    DISPLAY_NAME_MAX_LENGTH,
+    `Display name must be at most ${DISPLAY_NAME_MAX_LENGTH} characters`,
+  );
 
 /**
  * URL validation schema

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -48,6 +48,20 @@ export interface ErrorResponse {
   statusCode: number;
 }
 
+/**
+ * Response returned by POST /auth/verify-email.
+ *
+ * Mirrors the backend VerifyEmailResponseDto
+ * (services/user-service/src/auth/dto/verify-email.dto.ts) — the endpoint does
+ * NOT return an AuthResponse, so consumers must not read tokens or
+ * onboardingProgress off this shape (issue #1330).
+ */
+export interface VerifyEmailResponse {
+  success: boolean;
+  message: string;
+  emailVerified: boolean;
+}
+
 class AuthService {
   /**
    * Sign up a new user with email and password
@@ -153,8 +167,10 @@ class AuthService {
 
   /**
    * Verify email with 6-digit code
+   *
+   * @returns The backend VerifyEmailResponse ({ success, message, emailVerified }).
    */
-  async verifyEmail(code: string): Promise<AuthResponse> {
+  async verifyEmail(code: string): Promise<VerifyEmailResponse> {
     const email = this.getPendingVerificationEmail();
     if (!email) {
       throw new Error('No pending verification email found. Please sign up again.');
@@ -174,7 +190,8 @@ class AuthService {
       throw new Error(error.message || 'Email verification failed');
     }
 
-    // Clear pending email on success
+    // Only clear the pending email once we have a confirmed success response,
+    // so a failed attempt can still be retried without a "sign up again" dead end.
     this.clearPendingVerificationEmail();
 
     return response.json();

--- a/services/api-gateway/src/config/__tests__/security.config.spec.ts
+++ b/services/api-gateway/src/config/__tests__/security.config.spec.ts
@@ -109,11 +109,30 @@ describe('Security Configuration', () => {
       expect(config.referrerPolicy).toEqual({ policy: 'strict-origin-when-cross-origin' });
     });
 
-    it('should disable CSP in non-production', async () => {
+    it('should enable CSP in non-production without upgradeInsecureRequests', async () => {
+      // Issue #1384: CSP must stay enabled in every environment to constrain
+      // the XSS blast radius. Only upgradeInsecureRequests is production-only
+      // (dev is served over plain HTTP).
       process.env['NODE_ENV'] = 'development';
       const { getHelmetConfig: getConfig } = await import('../security.config.js');
       const config = getConfig();
-      expect(config.contentSecurityPolicy).toBe(false);
+      expect(config.contentSecurityPolicy).not.toBe(false);
+      if (config.contentSecurityPolicy && typeof config.contentSecurityPolicy === 'object') {
+        const { directives } = config.contentSecurityPolicy;
+        expect(directives?.['defaultSrc']).toEqual(["'self'"]);
+        expect(directives?.['upgradeInsecureRequests']).toBeUndefined();
+      }
+    });
+
+    it('should enable CSP with upgradeInsecureRequests in production', async () => {
+      process.env['NODE_ENV'] = 'production';
+      const { getHelmetConfig: getConfig } = await import('../security.config.js');
+      const config = getConfig();
+      expect(config.contentSecurityPolicy).not.toBe(false);
+      if (config.contentSecurityPolicy && typeof config.contentSecurityPolicy === 'object') {
+        const { directives } = config.contentSecurityPolicy;
+        expect(directives?.['upgradeInsecureRequests']).toEqual([]);
+      }
     });
 
     it('should enable HSTS in production', async () => {

--- a/services/api-gateway/src/config/security.config.ts
+++ b/services/api-gateway/src/config/security.config.ts
@@ -98,21 +98,24 @@ export function getCorsConfig(): CorsConfig {
 export function getHelmetConfig(): FastifyHelmetOptions {
   return {
     // Content Security Policy
-    contentSecurityPolicy: isProduction
-      ? {
-          directives: {
-            defaultSrc: ["'self'"],
-            scriptSrc: ["'self'"],
-            styleSrc: ["'self'", "'unsafe-inline'"], // Allow inline styles for Swagger UI
-            imgSrc: ["'self'", 'data:', 'https:'],
-            fontSrc: ["'self'"],
-            connectSrc: ["'self'"],
-            frameSrc: ["'none'"],
-            objectSrc: ["'none'"],
-            upgradeInsecureRequests: [],
-          },
-        }
-      : false, // Disable CSP in development for easier debugging
+    //
+    // Keep CSP enabled in ALL environments so the XSS blast radius is
+    // constrained everywhere, including local dev/testing (issue #1384).
+    // Only `upgradeInsecureRequests` is production-only — in dev the gateway is
+    // served over plain HTTP, and upgrading would break local requests.
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'"],
+        styleSrc: ["'self'", "'unsafe-inline'"], // Allow inline styles for Swagger UI
+        imgSrc: ["'self'", 'data:', 'https:'],
+        fontSrc: ["'self'"],
+        connectSrc: ["'self'"],
+        frameSrc: ["'none'"],
+        objectSrc: ["'none'"],
+        ...(isProduction ? { upgradeInsecureRequests: [] } : {}),
+      },
+    },
 
     // Prevent MIME type sniffing
     // X-Content-Type-Options: nosniff

--- a/services/user-service/src/auth/database-auth.service.ts
+++ b/services/user-service/src/auth/database-auth.service.ts
@@ -144,7 +144,7 @@ export class DatabaseAuthService implements IAuthService {
         sub: user.id, // Use actual user ID (UUID) instead of cognitoSub
         token_use: 'refresh',
         iat: now,
-        exp: now + 30 * 24 * 3600, // 30 days
+        exp: now + AUTH_TOKENS.REFRESH_EXPIRES_IN_SECONDS, // 7 days (issue #1384)
       },
       this.jwtSecret,
     );

--- a/services/user-service/src/auth/mock-auth.service.ts
+++ b/services/user-service/src/auth/mock-auth.service.ts
@@ -121,7 +121,7 @@ export class MockAuthService {
         sub: foundUser.sub,
         token_use: 'refresh',
         iat: now,
-        exp: now + 30 * 24 * 3600, // 30 days
+        exp: now + AUTH_TOKENS.REFRESH_EXPIRES_IN_SECONDS, // 7 days (issue #1384)
       },
       this.jwtSecret,
     );

--- a/services/user-service/src/constants/index.ts
+++ b/services/user-service/src/constants/index.ts
@@ -13,6 +13,14 @@
 export const AUTH_TOKENS = {
   /** Default token expiration time in seconds (1 hour) */
   EXPIRES_IN_SECONDS: 3600,
+  /**
+   * Refresh token expiration time in seconds (7 days).
+   *
+   * Shortened from 30 days to reduce the impact of a stolen refresh token
+   * (issue #1384): even if a token is exfiltrated, the window of unauthorized
+   * account access is bounded to one week instead of a month.
+   */
+  REFRESH_EXPIRES_IN_SECONDS: 7 * 24 * 3600,
   /** S3 signed URL expiration time in seconds (1 hour) */
   S3_URL_EXPIRES_IN_SECONDS: 3600,
 } as const;


### PR DESCRIPTION
## Summary

Batch fix for eight interrelated authentication-flow defects surfaced by the 2026-07-10 multi-persona audit. The root cause across most of them is **two parallel auth stacks** that drifted: the `/signup` flow behaves correctly, while `/login` and `/register` diverged. This PR converges the broken paths onto the working one rather than inventing new behavior.

## Changes

| Issue | Fix |
| --- | --- |
| #1355 | `LoginPage` now logs in via `useAuthContext().login(...)` so `isAuthenticated` flips **true** before navigation — no more logged-out header or `ProtectedRoute` bounce until refresh. |
| #1332 | Wired the **"Remember me"** checkbox: registered in `loginSchema`/`LoginForm`, passed through `LoginPage` and the login modal so it actually controls token persistence (localStorage vs sessionStorage). |
| #1357 | `RegistrationForm` "Sign in" uses a react-router `<Link to="/login">` instead of a full-reload `<a href="/">`. |
| #1356 | Single source of truth for the password special-char set (`PASSWORD_SPECIAL_CHAR_REGEX`) and aligned displayName rules (min 2, no ASCII-only restriction) across `EmailSignupForm`, `ResetPasswordPage` and the Zod schemas so client validation matches the backend `RegisterDto` (no surprise 400s; names like `O'Brien`/`José` allowed). |
| #1333 | `ForgotPasswordPage` shows the success screen **only on a 2xx** response and a neutral, retryable error otherwise. Anti-enumeration is handled entirely server-side, so masking 429/5xx/offline as success only hid real failures. |
| #1330 | Typed `authService.verifyEmail` to the real `VerifyEmailResponse` (`{ success, message, emailVerified }`) and navigate to an **existing** route (`/onboarding/orientation`) on success — fixes the `TypeError` that presented every successful verification as a failure and stranded users on retry. |
| #1331 | `RegisterPage` forwards `birthDate`/`declaredCountry`/`parentEmail`, stores `pendingVerificationEmail`, and routes to `/verify-email` so the parental-consent and email-verification flows actually run. |
| #1384 | Keep **CSP enabled in all environments** (only `upgradeInsecureRequests` stays production-only) and shorten the refresh-token lifetime from **30 → 7 days** via a named `AUTH_TOKENS.REFRESH_EXPIRES_IN_SECONDS` constant, bounding the impact of a stolen token. |

## Verification

- `frontend` typecheck: clean
- `frontend` unit tests: **2441 passed** (107 files)
- `api-gateway` security config spec: **19 passed** (incl. new CSP-in-all-envs assertions)
- `user-service` typecheck clean; auth unit tests **85 passed**
- ESLint + Prettier clean on all changed files (pre-commit hooks passed without bypass)

## Closes

Fixes #1384
Fixes #1355
Fixes #1357
Fixes #1356
Fixes #1332
Fixes #1331
Fixes #1333
Fixes #1330

🤖 Generated with [Claude Code](https://claude.com/claude-code)