### PR TITLE
fix(backend): resolve audit batch #1288-#1311 (consent, deletion, perf, indexes, fanout)

### DIFF
--- a/packages/db-models/prisma/migrations/20260710_add_responses_topic_author_index/migration.sql
+++ b/packages/db-models/prisma/migrations/20260710_add_responses_topic_author_index/migration.sql
@@ -1,0 +1,5 @@
+-- Add composite index on responses(topic_id, author_id).
+-- Supports the per-author EXISTS check used to maintain discussion_topics.participant_count
+-- incrementally, replacing a per-write groupBy over all topic responses (issue #1307).
+
+CREATE INDEX IF NOT EXISTS "responses_topic_id_author_id_idx" ON "responses"("topic_id", "author_id");

--- a/packages/db-models/prisma/migrations/20260711_add_trigram_search_indexes/migration.sql
+++ b/packages/db-models/prisma/migrations/20260711_add_trigram_search_indexes/migration.sql
@@ -1,0 +1,24 @@
+-- Add GIN trigram indexes to support infix ILIKE ('%query%') searches that
+-- currently fall back to sequential scans (issue #1310).
+--
+-- - users.display_name / users.email back the @mention autocomplete
+--   (searchUsers ORs infix ILIKE over both columns; an OR needs every branch
+--   indexed to avoid a seq scan).
+-- - discussion_topics.description backs topic recommendations, whose predicate
+--   ORs ILIKE over title AND description; title already has a trigram index,
+--   so indexing description lets the whole OR be index-assisted.
+--
+-- These cannot be expressed in the Prisma schema, so they live in a raw
+-- migration (mirroring the existing discussion_topics_title_trgm_idx).
+
+-- pg_trgm is already enabled by an earlier migration; keep this idempotent.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS "users_display_name_trgm_idx"
+  ON "users" USING GIN ("display_name" gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS "users_email_trgm_idx"
+  ON "users" USING GIN ("email" gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS "discussion_topics_description_trgm_idx"
+  ON "discussion_topics" USING GIN ("description" gin_trgm_ops);

--- a/packages/db-models/prisma/schema.prisma
+++ b/packages/db-models/prisma/schema.prisma
@@ -910,6 +910,9 @@ model Response {
   @@index([authorId])
   @@index([parentId])
   @@index([topicId, createdAt(sort: Desc)])
+  // Composite index supports the per-author EXISTS check used to maintain
+  // participantCount without aggregating every response in the topic.
+  @@index([topicId, authorId])
   @@index([status])
   @@map("responses")
 }

--- a/services/discussion-service/src/reactions/reactions.service.test.ts
+++ b/services/discussion-service/src/reactions/reactions.service.test.ts
@@ -15,6 +15,7 @@ const createMockPrismaService = () => ({
   responseReaction: {
     findUnique: vi.fn(),
     findMany: vi.fn(),
+    groupBy: vi.fn(),
     create: vi.fn(),
     delete: vi.fn(),
   },
@@ -189,48 +190,54 @@ describe('ReactionsService', () => {
     });
   });
 
+  // Route the two distinct findMany shapes the service issues: the preview
+  // fetch uses `include: { user }`, the caller's-own-reactions fetch uses
+  // `select`.
+  const mockReactionQueries = (opts: {
+    grouped?: unknown[];
+    preview?: unknown[];
+    userReactions?: unknown[];
+  }) => {
+    mockPrisma.responseReaction.groupBy.mockResolvedValue(opts.grouped ?? []);
+    mockPrisma.responseReaction.findMany.mockImplementation((args: any) => {
+      if (args?.select) {
+        return Promise.resolve(opts.userReactions ?? []);
+      }
+      return Promise.resolve(opts.preview ?? []);
+    });
+  };
+
+  const previewRow = (emoji: string, userId: string, displayName: string | null) => ({
+    id: `reaction-${userId}`,
+    responseId: 'response-1',
+    userId,
+    emoji,
+    createdAt: new Date(),
+    user: { id: userId, displayName },
+  });
+
   describe('getReactions', () => {
     const responseId = 'response-1';
 
     it('should return grouped reactions with counts', async () => {
-      const createdAt = new Date();
-      mockPrisma.responseReaction.findMany.mockResolvedValue([
-        {
-          id: 'reaction-1',
-          responseId,
-          userId: 'user-1',
-          emoji: '👍',
-          createdAt,
-          user: { id: 'user-1', displayName: 'Alice' },
-        },
-        {
-          id: 'reaction-2',
-          responseId,
-          userId: 'user-2',
-          emoji: '👍',
-          createdAt,
-          user: { id: 'user-2', displayName: 'Bob' },
-        },
-        {
-          id: 'reaction-3',
-          responseId,
-          userId: 'user-3',
-          emoji: '❤️',
-          createdAt,
-          user: { id: 'user-3', displayName: 'Charlie' },
-        },
-      ]);
+      mockReactionQueries({
+        grouped: [
+          { emoji: '👍', _count: { _all: 2 } },
+          { emoji: '❤️', _count: { _all: 1 } },
+        ],
+        preview: [
+          previewRow('👍', 'user-1', 'Alice'),
+          previewRow('👍', 'user-2', 'Bob'),
+          previewRow('❤️', 'user-3', 'Charlie'),
+        ],
+      });
 
       const result = await service.getReactions(responseId);
 
-      expect(mockPrisma.responseReaction.findMany).toHaveBeenCalledWith({
+      expect(mockPrisma.responseReaction.groupBy).toHaveBeenCalledWith({
+        by: ['emoji'],
         where: { responseId },
-        include: {
-          user: {
-            select: { id: true, displayName: true },
-          },
-        },
-        orderBy: { createdAt: 'asc' },
+        _count: { _all: true },
       });
       expect(result.totalCount).toBe(3);
       expect(result.reactions).toHaveLength(2);
@@ -245,25 +252,14 @@ describe('ReactionsService', () => {
     });
 
     it('should indicate userReacted correctly when user has reacted', async () => {
-      const createdAt = new Date();
-      mockPrisma.responseReaction.findMany.mockResolvedValue([
-        {
-          id: 'reaction-1',
-          responseId,
-          userId: 'user-1',
-          emoji: '👍',
-          createdAt,
-          user: { id: 'user-1', displayName: 'Alice' },
-        },
-        {
-          id: 'reaction-2',
-          responseId,
-          userId: 'user-2',
-          emoji: '❤️',
-          createdAt,
-          user: { id: 'user-2', displayName: 'Bob' },
-        },
-      ]);
+      mockReactionQueries({
+        grouped: [
+          { emoji: '👍', _count: { _all: 1 } },
+          { emoji: '❤️', _count: { _all: 1 } },
+        ],
+        preview: [previewRow('👍', 'user-1', 'Alice'), previewRow('❤️', 'user-2', 'Bob')],
+        userReactions: [{ emoji: '👍' }],
+      });
 
       const result = await service.getReactions(responseId, 'user-1');
 
@@ -275,17 +271,10 @@ describe('ReactionsService', () => {
     });
 
     it('should indicate userReacted as false when no userId provided', async () => {
-      const createdAt = new Date();
-      mockPrisma.responseReaction.findMany.mockResolvedValue([
-        {
-          id: 'reaction-1',
-          responseId,
-          userId: 'user-1',
-          emoji: '👍',
-          createdAt,
-          user: { id: 'user-1', displayName: 'Alice' },
-        },
-      ]);
+      mockReactionQueries({
+        grouped: [{ emoji: '👍', _count: { _all: 1 } }],
+        preview: [previewRow('👍', 'user-1', 'Alice')],
+      });
 
       const result = await service.getReactions(responseId);
 
@@ -293,7 +282,7 @@ describe('ReactionsService', () => {
     });
 
     it('should return empty reactions for response with no reactions', async () => {
-      mockPrisma.responseReaction.findMany.mockResolvedValue([]);
+      mockReactionQueries({ grouped: [], preview: [] });
 
       const result = await service.getReactions(responseId);
 
@@ -302,16 +291,13 @@ describe('ReactionsService', () => {
     });
 
     it('should limit users list to first 10 users per emoji', async () => {
-      const createdAt = new Date();
-      const manyReactions = Array.from({ length: 15 }, (_, i) => ({
-        id: `reaction-${i}`,
-        responseId,
-        userId: `user-${i}`,
-        emoji: '👍',
-        createdAt,
-        user: { id: `user-${i}`, displayName: `User ${i}` },
-      }));
-      mockPrisma.responseReaction.findMany.mockResolvedValue(manyReactions);
+      const manyReactions = Array.from({ length: 15 }, (_, i) =>
+        previewRow('👍', `user-${i}`, `User ${i}`),
+      );
+      mockReactionQueries({
+        grouped: [{ emoji: '👍', _count: { _all: 15 } }],
+        preview: manyReactions,
+      });
 
       const result = await service.getReactions(responseId);
 
@@ -322,17 +308,10 @@ describe('ReactionsService', () => {
     });
 
     it('should handle users with null displayName', async () => {
-      const createdAt = new Date();
-      mockPrisma.responseReaction.findMany.mockResolvedValue([
-        {
-          id: 'reaction-1',
-          responseId,
-          userId: 'user-1',
-          emoji: '👍',
-          createdAt,
-          user: { id: 'user-1', displayName: null },
-        },
-      ]);
+      mockReactionQueries({
+        grouped: [{ emoji: '👍', _count: { _all: 1 } }],
+        preview: [previewRow('👍', 'user-1', null)],
+      });
 
       const result = await service.getReactions(responseId);
 
@@ -344,7 +323,7 @@ describe('ReactionsService', () => {
     const responseIds = ['response-1', 'response-2', 'response-3'];
 
     it('should return empty summaries for all requested responses when no reactions exist', async () => {
-      mockPrisma.responseReaction.findMany.mockResolvedValue([]);
+      mockReactionQueries({ grouped: [], preview: [] });
 
       const result = await service.getReactionSummaries(responseIds);
 
@@ -356,49 +335,58 @@ describe('ReactionsService', () => {
       }
     });
 
+    it('should return an empty map without querying for an empty id list', async () => {
+      const result = await service.getReactionSummaries([]);
+
+      expect(result.size).toBe(0);
+      expect(mockPrisma.responseReaction.groupBy).not.toHaveBeenCalled();
+    });
+
     it('should return grouped reactions for multiple responses', async () => {
       const createdAt = new Date();
-      mockPrisma.responseReaction.findMany.mockResolvedValue([
-        {
-          id: 'r1',
-          responseId: 'response-1',
-          userId: 'user-1',
-          emoji: '👍',
-          createdAt,
-          user: { id: 'user-1', displayName: 'Alice' },
-        },
-        {
-          id: 'r2',
-          responseId: 'response-1',
-          userId: 'user-2',
-          emoji: '👍',
-          createdAt,
-          user: { id: 'user-2', displayName: 'Bob' },
-        },
-        {
-          id: 'r3',
-          responseId: 'response-2',
-          userId: 'user-1',
-          emoji: '❤️',
-          createdAt,
-          user: { id: 'user-1', displayName: 'Alice' },
-        },
-      ]);
+      mockReactionQueries({
+        grouped: [
+          { responseId: 'response-1', emoji: '👍', _count: { _all: 2 } },
+          { responseId: 'response-2', emoji: '❤️', _count: { _all: 1 } },
+        ],
+        preview: [
+          {
+            id: 'r1',
+            responseId: 'response-1',
+            userId: 'user-1',
+            emoji: '👍',
+            createdAt,
+            user: { id: 'user-1', displayName: 'Alice' },
+          },
+          {
+            id: 'r2',
+            responseId: 'response-1',
+            userId: 'user-2',
+            emoji: '👍',
+            createdAt,
+            user: { id: 'user-2', displayName: 'Bob' },
+          },
+          {
+            id: 'r3',
+            responseId: 'response-2',
+            userId: 'user-1',
+            emoji: '❤️',
+            createdAt,
+            user: { id: 'user-1', displayName: 'Alice' },
+          },
+        ],
+        userReactions: [
+          { responseId: 'response-1', emoji: '👍' },
+          { responseId: 'response-2', emoji: '❤️' },
+        ],
+      });
 
       const result = await service.getReactionSummaries(responseIds, 'user-1');
 
-      expect(mockPrisma.responseReaction.findMany).toHaveBeenCalledWith({
-        where: {
-          responseId: {
-            in: responseIds,
-          },
-        },
-        include: {
-          user: {
-            select: { id: true, displayName: true },
-          },
-        },
-        orderBy: { createdAt: 'asc' },
+      expect(mockPrisma.responseReaction.groupBy).toHaveBeenCalledWith({
+        by: ['responseId', 'emoji'],
+        where: { responseId: { in: responseIds } },
+        _count: { _all: true },
       });
 
       const response1Summary = result.get('response-1');

--- a/services/discussion-service/src/reactions/reactions.service.ts
+++ b/services/discussion-service/src/reactions/reactions.service.ts
@@ -11,6 +11,15 @@ import type { ReactionDto, ReactionListDto, ReactionSummaryDto } from './dto/rea
 
 @Injectable()
 export class ReactionsService {
+  /** Maximum number of reactor faces surfaced per emoji in a summary. */
+  private static readonly REACTION_PREVIEW_LIMIT = 10;
+  /**
+   * Upper bound on reaction rows fetched to build preview user lists. Exact
+   * counts come from a groupBy aggregation, so this only caps the "who reacted"
+   * preview and prevents materializing an unbounded number of rows.
+   */
+  private static readonly REACTION_PREVIEW_FETCH_LIMIT = 200;
+
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
     @Optional() @Inject(DiscussionGateway) private readonly discussionGateway?: DiscussionGateway,
@@ -137,40 +146,72 @@ export class ReactionsService {
    * @returns Reaction summaries grouped by emoji
    */
   async getReactions(responseId: string, userId?: string): Promise<ReactionListDto> {
-    const reactions = await this.prisma.responseReaction.findMany({
-      where: { responseId },
-      include: {
-        user: {
-          select: { id: true, displayName: true },
-        },
-      },
-      orderBy: { createdAt: 'asc' },
-    });
-
-    // Group by emoji
-    const emojiGroups = new Map<string, { users: { id: string; displayName: string }[] }>();
-    for (const reaction of reactions) {
-      const group = emojiGroups.get(reaction.emoji) || { users: [] };
-      group.users.push({
-        id: reaction.user.id,
-        displayName: reaction.user.displayName || 'Anonymous',
-      });
-      emojiGroups.set(reaction.emoji, group);
-    }
-
-    const summaries: ReactionSummaryDto[] = Array.from(emojiGroups.entries()).map(
-      ([emoji, group]) => ({
-        emoji,
-        count: group.users.length,
-        users: group.users.slice(0, 10), // Limit to first 10 users
-        userReacted: userId ? group.users.some((u) => u.id === userId) : false,
+    // Exact per-emoji counts come from a database aggregation instead of
+    // materializing every reaction row and counting in JS. Preview user lists
+    // are built from a bounded fetch, and the caller's own reactions are
+    // resolved with a targeted query so userReacted stays accurate regardless
+    // of the preview cap.
+    const [grouped, previewReactions, userReactions] = await Promise.all([
+      this.prisma.responseReaction.groupBy({
+        by: ['emoji'],
+        where: { responseId },
+        _count: { _all: true },
       }),
-    );
+      this.prisma.responseReaction.findMany({
+        where: { responseId },
+        include: {
+          user: {
+            select: { id: true, displayName: true },
+          },
+        },
+        orderBy: { createdAt: 'asc' },
+        take: ReactionsService.REACTION_PREVIEW_FETCH_LIMIT,
+      }),
+      userId
+        ? this.prisma.responseReaction.findMany({
+            where: { responseId, userId },
+            select: { emoji: true },
+          })
+        : Promise.resolve([] as { emoji: string }[]),
+    ]);
+
+    const previewByEmoji = this.buildPreviewUsers(previewReactions);
+    const reactedEmojis = new Set(userReactions.map((r) => r.emoji));
+
+    const summaries: ReactionSummaryDto[] = grouped.map((group) => ({
+      emoji: group.emoji,
+      count: group._count._all,
+      users: previewByEmoji.get(group.emoji) ?? [],
+      userReacted: reactedEmojis.has(group.emoji),
+    }));
+
+    const totalCount = grouped.reduce((sum, group) => sum + group._count._all, 0);
 
     return {
       reactions: summaries,
-      totalCount: reactions.length,
+      totalCount,
     };
+  }
+
+  /**
+   * Build capped per-emoji preview user lists from a bounded set of reaction
+   * rows (ordered oldest-first).
+   */
+  private buildPreviewUsers(
+    reactions: { emoji: string; user: { id: string; displayName: string | null } }[],
+  ): Map<string, { id: string; displayName: string }[]> {
+    const previewByEmoji = new Map<string, { id: string; displayName: string }[]>();
+    for (const reaction of reactions) {
+      const users = previewByEmoji.get(reaction.emoji) ?? [];
+      if (users.length < ReactionsService.REACTION_PREVIEW_LIMIT) {
+        users.push({
+          id: reaction.user.id,
+          displayName: reaction.user.displayName || 'Anonymous',
+        });
+        previewByEmoji.set(reaction.emoji, users);
+      }
+    }
+    return previewByEmoji;
   }
 
   /**
@@ -183,20 +224,6 @@ export class ReactionsService {
     responseIds: string[],
     userId?: string,
   ): Promise<Map<string, ReactionListDto>> {
-    const reactions = await this.prisma.responseReaction.findMany({
-      where: {
-        responseId: {
-          in: responseIds,
-        },
-      },
-      include: {
-        user: {
-          select: { id: true, displayName: true },
-        },
-      },
-      orderBy: { createdAt: 'asc' },
-    });
-
     const summariesMap = new Map<string, ReactionListDto>();
 
     // Initialize empty summaries for all responses
@@ -204,41 +231,81 @@ export class ReactionsService {
       summariesMap.set(responseId, { reactions: [], totalCount: 0 });
     }
 
-    // Group reactions by response, then by emoji
-    const responseGroups = new Map<
-      string,
-      Map<string, { users: { id: string; displayName: string }[] }>
-    >();
-
-    for (const reaction of reactions) {
-      if (!responseGroups.has(reaction.responseId)) {
-        responseGroups.set(reaction.responseId, new Map());
-      }
-      const emojiGroups = responseGroups.get(reaction.responseId)!;
-      const group = emojiGroups.get(reaction.emoji) || { users: [] };
-      group.users.push({
-        id: reaction.user.id,
-        displayName: reaction.user.displayName || 'Anonymous',
-      });
-      emojiGroups.set(reaction.emoji, group);
+    if (responseIds.length === 0) {
+      return summariesMap;
     }
 
-    // Build summaries
-    for (const [responseId, emojiGroups] of responseGroups.entries()) {
-      const summaries: ReactionSummaryDto[] = Array.from(emojiGroups.entries()).map(
-        ([emoji, group]) => ({
-          emoji,
-          count: group.users.length,
-          users: group.users.slice(0, 10),
-          userReacted: userId ? group.users.some((u) => u.id === userId) : false,
-        }),
-      );
+    // Aggregate counts per (response, emoji) in the database; build preview user
+    // lists from a bounded fetch and resolve the caller's own reactions with a
+    // single targeted query.
+    const [grouped, previewReactions, userReactions] = await Promise.all([
+      this.prisma.responseReaction.groupBy({
+        by: ['responseId', 'emoji'],
+        where: { responseId: { in: responseIds } },
+        _count: { _all: true },
+      }),
+      this.prisma.responseReaction.findMany({
+        where: { responseId: { in: responseIds } },
+        include: {
+          user: {
+            select: { id: true, displayName: true },
+          },
+        },
+        orderBy: { createdAt: 'asc' },
+        take: ReactionsService.REACTION_PREVIEW_FETCH_LIMIT * responseIds.length,
+      }),
+      userId
+        ? this.prisma.responseReaction.findMany({
+            where: { responseId: { in: responseIds }, userId },
+            select: { responseId: true, emoji: true },
+          })
+        : Promise.resolve([] as { responseId: string; emoji: string }[]),
+    ]);
 
-      const totalCount = Array.from(emojiGroups.values()).reduce(
-        (sum, group) => sum + group.users.length,
-        0,
-      );
+    // Preview users keyed by responseId → emoji.
+    const previewByResponse = new Map<string, Map<string, { id: string; displayName: string }[]>>();
+    for (const reaction of previewReactions) {
+      let emojiMap = previewByResponse.get(reaction.responseId);
+      if (!emojiMap) {
+        emojiMap = new Map();
+        previewByResponse.set(reaction.responseId, emojiMap);
+      }
+      const users = emojiMap.get(reaction.emoji) ?? [];
+      if (users.length < ReactionsService.REACTION_PREVIEW_LIMIT) {
+        users.push({
+          id: reaction.user.id,
+          displayName: reaction.user.displayName || 'Anonymous',
+        });
+        emojiMap.set(reaction.emoji, users);
+      }
+    }
 
+    // Emojis the caller reacted with, keyed by responseId.
+    const reactedByResponse = new Map<string, Set<string>>();
+    for (const reaction of userReactions) {
+      const set = reactedByResponse.get(reaction.responseId) ?? new Set<string>();
+      set.add(reaction.emoji);
+      reactedByResponse.set(reaction.responseId, set);
+    }
+
+    // Group aggregated counts back per response.
+    const countsByResponse = new Map<string, { emoji: string; count: number }[]>();
+    for (const group of grouped) {
+      const entries = countsByResponse.get(group.responseId) ?? [];
+      entries.push({ emoji: group.emoji, count: group._count._all });
+      countsByResponse.set(group.responseId, entries);
+    }
+
+    for (const [responseId, entries] of countsByResponse.entries()) {
+      const emojiPreview = previewByResponse.get(responseId);
+      const reacted = reactedByResponse.get(responseId);
+      const summaries: ReactionSummaryDto[] = entries.map((entry) => ({
+        emoji: entry.emoji,
+        count: entry.count,
+        users: emojiPreview?.get(entry.emoji) ?? [],
+        userReacted: reacted?.has(entry.emoji) ?? false,
+      }));
+      const totalCount = entries.reduce((sum, entry) => sum + entry.count, 0);
       summariesMap.set(responseId, { reactions: summaries, totalCount });
     }
 

--- a/services/discussion-service/src/responses/responses.service.test.ts
+++ b/services/discussion-service/src/responses/responses.service.test.ts
@@ -3,27 +3,36 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ResponsesService } from './responses.service.js';
 import { NotFoundException, BadRequestException, ForbiddenException } from '@nestjs/common';
 
-const createMockPrismaService = () => ({
-  discussionTopic: {
-    findUnique: vi.fn(),
-    update: vi.fn(),
-  },
-  response: {
-    findMany: vi.fn(),
-    findUnique: vi.fn(),
-    create: vi.fn(),
-    update: vi.fn(),
-    delete: vi.fn(),
-    groupBy: vi.fn().mockResolvedValue([{ authorId: 'user-1' }]),
-  },
-  responseProposition: {
-    createMany: vi.fn(),
-    deleteMany: vi.fn(),
-  },
-  user: {
-    findUnique: vi.fn(),
-  },
-});
+const createMockPrismaService = () => {
+  const prisma = {
+    discussionTopic: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    response: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      groupBy: vi.fn().mockResolvedValue([{ authorId: 'user-1' }]),
+    },
+    responseProposition: {
+      createMany: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    user: {
+      findUnique: vi.fn(),
+    },
+    // Interactive transaction runs the callback against the same mock client.
+    $transaction: vi.fn(),
+  };
+  prisma.$transaction.mockImplementation((callback: (tx: typeof prisma) => unknown) =>
+    callback(prisma),
+  );
+  return prisma;
+};
 
 const createMockCommonGroundTrigger = () => ({
   checkAndTrigger: vi.fn().mockResolvedValue(undefined),
@@ -325,17 +334,36 @@ describe('ResponsesService', () => {
       mockPrisma.response.findUnique.mockResolvedValue(mockResponse);
       mockPrisma.discussionTopic.update.mockResolvedValue({});
       mockPrisma.user.findUnique.mockResolvedValue({ isMinor: false });
-      // Mock groupBy to return unique participants
-      mockPrisma.response.groupBy.mockResolvedValue([
-        { authorId: 'user-1' },
-        { authorId: 'user-2' },
-      ]);
+      // First-time author: no prior response exists in the topic, so
+      // participantCount is incremented.
+      mockPrisma.response.findFirst.mockResolvedValue(null);
 
       await service.createResponse('topic-1', 'user-1', validDto);
 
       expect(mockPrisma.discussionTopic.update).toHaveBeenCalledWith({
         where: { id: 'topic-1' },
-        data: { responseCount: { increment: 1 }, participantCount: 2 },
+        data: { responseCount: { increment: 1 }, participantCount: { increment: 1 } },
+      });
+    });
+
+    it('should not increment participant count for a returning author', async () => {
+      const mockResponse = createMockResponse();
+      mockPrisma.discussionTopic.findUnique.mockResolvedValue({
+        id: 'topic-1',
+        status: 'ACTIVE',
+      });
+      mockPrisma.response.create.mockResolvedValue(mockResponse);
+      mockPrisma.response.findUnique.mockResolvedValue(mockResponse);
+      mockPrisma.discussionTopic.update.mockResolvedValue({});
+      mockPrisma.user.findUnique.mockResolvedValue({ isMinor: false });
+      // Returning author: a prior response already exists in the topic.
+      mockPrisma.response.findFirst.mockResolvedValue({ id: 'prior-response' });
+
+      await service.createResponse('topic-1', 'user-1', validDto);
+
+      expect(mockPrisma.discussionTopic.update).toHaveBeenCalledWith({
+        where: { id: 'topic-1' },
+        data: { responseCount: { increment: 1 } },
       });
     });
 

--- a/services/discussion-service/src/responses/responses.service.ts
+++ b/services/discussion-service/src/responses/responses.service.ts
@@ -193,56 +193,69 @@ export class ResponsesService {
     // Set status based on author type: minors get PENDING_REVIEW, adults get VISIBLE
     const responseStatus = author?.isMinor ? 'PENDING_REVIEW' : 'VISIBLE';
 
-    // Create the response
-    const response = await this.prisma.response.create({
-      data: {
-        topicId,
-        authorId,
-        parentId: createResponseDto.parentId ?? null,
-        content: createResponseDto.content.trim(),
-        citedSources: citedSourcesJson,
-        containsOpinion: createResponseDto.containsOpinion ?? false,
-        containsFactualClaims: createResponseDto.containsFactualClaims ?? false,
-        status: responseStatus,
-        revisionCount: 0,
-      },
-      include: {
-        author: {
-          select: {
-            id: true,
-            displayName: true,
-            avatarUrl: true,
-            email: true,
-            verificationLevel: true,
+    // Create the response, its proposition links, and the topic stat updates
+    // atomically so responseCount and participantCount cannot drift if an
+    // intermediate step fails.
+    const response = await this.prisma.$transaction(async (tx) => {
+      const created = await tx.response.create({
+        data: {
+          topicId,
+          authorId,
+          parentId: createResponseDto.parentId ?? null,
+          content: createResponseDto.content.trim(),
+          citedSources: citedSourcesJson,
+          containsOpinion: createResponseDto.containsOpinion ?? false,
+          containsFactualClaims: createResponseDto.containsFactualClaims ?? false,
+          status: responseStatus,
+          revisionCount: 0,
+        },
+        include: {
+          author: {
+            select: {
+              id: true,
+              displayName: true,
+              avatarUrl: true,
+              email: true,
+              verificationLevel: true,
+            },
           },
         },
-      },
-    });
-
-    // Handle proposition associations if provided
-    if (createResponseDto.propositionIds && createResponseDto.propositionIds.length > 0) {
-      // Create ResponseProposition junction records
-      await this.prisma.responseProposition.createMany({
-        data: createResponseDto.propositionIds.map((propositionId) => ({
-          responseId: response.id,
-          propositionId,
-        })),
-        skipDuplicates: true,
       });
-    }
 
-    // Count unique participants and update topic stats
-    const uniqueParticipants = await this.prisma.response.groupBy({
-      by: ['authorId'],
-      where: { topicId },
-    });
+      // Handle proposition associations if provided
+      if (createResponseDto.propositionIds && createResponseDto.propositionIds.length > 0) {
+        // Create ResponseProposition junction records
+        await tx.responseProposition.createMany({
+          data: createResponseDto.propositionIds.map((propositionId) => ({
+            responseId: created.id,
+            propositionId,
+          })),
+          skipDuplicates: true,
+        });
+      }
 
-    await this.prisma.discussionTopic.update({
-      where: { id: topicId },
-      data: {
-        responseCount: { increment: 1 },
-        participantCount: uniqueParticipants.length,
-      },
+      // Only first-time authors increment participantCount. This EXISTS-style
+      // lookup (backed by the composite (topicId, authorId) index) avoids
+      // re-aggregating every response in the topic on each write, which grew
+      // O(responses) with topic size under the previous groupBy approach.
+      const priorResponse = await tx.response.findFirst({
+        where: {
+          topicId,
+          authorId,
+          id: { not: created.id },
+        },
+        select: { id: true },
+      });
+
+      await tx.discussionTopic.update({
+        where: { id: topicId },
+        data: {
+          responseCount: { increment: 1 },
+          ...(priorResponse ? {} : { participantCount: { increment: 1 } }),
+        },
+      });
+
+      return created;
     });
 
     // Check and trigger common ground analysis if needed

--- a/services/discussion-service/src/topics/topics-analytics.service.ts
+++ b/services/discussion-service/src/topics/topics-analytics.service.ts
@@ -330,49 +330,26 @@ export class TopicsAnalyticsService {
     const nextDay = new Date(targetDate);
     nextDay.setDate(nextDay.getDate() + 1);
 
-    // Get all participants who responded on target date
-    const participantsOnDate = await this.prisma.response.findMany({
+    // Compute every author's first-ever response timestamp in the topic with a
+    // single set-based aggregation, then count those whose first response falls
+    // within the target day. This replaces the previous N+1 pattern (one
+    // findFirst per participant). An author whose global-min response is in
+    // [targetDate, nextDay) necessarily made their first response that day.
+    const firstResponses = await this.prisma.response.groupBy({
+      by: ['authorId'],
       where: {
         topicId,
-        createdAt: {
-          gte: targetDate,
-          lt: nextDay,
-        },
         status: 'VISIBLE',
       },
-      select: {
-        authorId: true,
+      _min: {
+        createdAt: true,
       },
-      distinct: ['authorId'],
     });
 
-    // For each participant, check if this was their first response
-    let newCount = 0;
-    for (const p of participantsOnDate) {
-      const firstResponse = await this.prisma.response.findFirst({
-        where: {
-          topicId,
-          authorId: p.authorId,
-          status: 'VISIBLE',
-        },
-        orderBy: {
-          createdAt: 'asc',
-        },
-        select: {
-          createdAt: true,
-        },
-      });
-
-      if (
-        firstResponse &&
-        firstResponse.createdAt >= targetDate &&
-        firstResponse.createdAt < nextDay
-      ) {
-        newCount++;
-      }
-    }
-
-    return newCount;
+    return firstResponses.filter((group) => {
+      const firstAt = group._min.createdAt;
+      return firstAt !== null && firstAt >= targetDate && firstAt < nextDay;
+    }).length;
   }
 
   /**

--- a/services/discussion-service/src/votes/votes.service.test.ts
+++ b/services/discussion-service/src/votes/votes.service.test.ts
@@ -10,6 +10,7 @@ const createMockPrismaService = () => ({
   vote: {
     findUnique: vi.fn(),
     findMany: vi.fn(),
+    groupBy: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
@@ -130,7 +131,7 @@ describe('VotesService', () => {
 
   describe('getVoteSummary', () => {
     it('should return empty summary for response with no votes', async () => {
-      mockPrisma.vote.findMany.mockResolvedValue([]);
+      mockPrisma.vote.groupBy.mockResolvedValue([]);
 
       const result = await service.getVoteSummary('response-1');
 
@@ -143,11 +144,9 @@ describe('VotesService', () => {
     });
 
     it('should calculate vote counts correctly', async () => {
-      mockPrisma.vote.findMany.mockResolvedValue([
-        { voteType: 'UPVOTE', userId: 'user-1' },
-        { voteType: 'UPVOTE', userId: 'user-2' },
-        { voteType: 'UPVOTE', userId: 'user-3' },
-        { voteType: 'DOWNVOTE', userId: 'user-4' },
+      mockPrisma.vote.groupBy.mockResolvedValue([
+        { voteType: 'UPVOTE', _count: { _all: 3 } },
+        { voteType: 'DOWNVOTE', _count: { _all: 1 } },
       ]);
 
       const result = await service.getVoteSummary('response-1');
@@ -158,18 +157,24 @@ describe('VotesService', () => {
     });
 
     it('should return userVote when userId is provided and user voted', async () => {
-      mockPrisma.vote.findMany.mockResolvedValue([
-        { voteType: 'UPVOTE', userId: 'user-1' },
-        { voteType: 'DOWNVOTE', userId: 'user-2' },
+      mockPrisma.vote.groupBy.mockResolvedValue([
+        { voteType: 'UPVOTE', _count: { _all: 1 } },
+        { voteType: 'DOWNVOTE', _count: { _all: 1 } },
       ]);
+      mockPrisma.vote.findUnique.mockResolvedValue({ voteType: 'DOWNVOTE' });
 
       const result = await service.getVoteSummary('response-1', 'user-2');
 
       expect(result.userVote).toBe('DOWNVOTE');
+      expect(mockPrisma.vote.findUnique).toHaveBeenCalledWith({
+        where: { userId_responseId: { userId: 'user-2', responseId: 'response-1' } },
+        select: { voteType: true },
+      });
     });
 
     it('should return null userVote when user has not voted', async () => {
-      mockPrisma.vote.findMany.mockResolvedValue([{ voteType: 'UPVOTE', userId: 'user-1' }]);
+      mockPrisma.vote.groupBy.mockResolvedValue([{ voteType: 'UPVOTE', _count: { _all: 1 } }]);
+      mockPrisma.vote.findUnique.mockResolvedValue(null);
 
       const result = await service.getVoteSummary('response-1', 'user-2');
 
@@ -177,11 +182,9 @@ describe('VotesService', () => {
     });
 
     it('should handle negative score correctly', async () => {
-      mockPrisma.vote.findMany.mockResolvedValue([
-        { voteType: 'DOWNVOTE', userId: 'user-1' },
-        { voteType: 'DOWNVOTE', userId: 'user-2' },
-        { voteType: 'DOWNVOTE', userId: 'user-3' },
-        { voteType: 'UPVOTE', userId: 'user-4' },
+      mockPrisma.vote.groupBy.mockResolvedValue([
+        { voteType: 'DOWNVOTE', _count: { _all: 3 } },
+        { voteType: 'UPVOTE', _count: { _all: 1 } },
       ]);
 
       const result = await service.getVoteSummary('response-1');
@@ -192,10 +195,9 @@ describe('VotesService', () => {
 
   describe('getVoteSummaries', () => {
     it('should return summaries for multiple responses', async () => {
-      mockPrisma.vote.findMany.mockResolvedValue([
-        { responseId: 'response-1', voteType: 'UPVOTE', userId: 'user-1' },
-        { responseId: 'response-1', voteType: 'UPVOTE', userId: 'user-2' },
-        { responseId: 'response-2', voteType: 'DOWNVOTE', userId: 'user-1' },
+      mockPrisma.vote.groupBy.mockResolvedValue([
+        { responseId: 'response-1', voteType: 'UPVOTE', _count: { _all: 2 } },
+        { responseId: 'response-2', voteType: 'DOWNVOTE', _count: { _all: 1 } },
       ]);
 
       const result = await service.getVoteSummaries(['response-1', 'response-2']);
@@ -215,19 +217,27 @@ describe('VotesService', () => {
     });
 
     it('should include userVote for each response when userId provided', async () => {
+      mockPrisma.vote.groupBy.mockResolvedValue([
+        { responseId: 'response-1', voteType: 'UPVOTE', _count: { _all: 1 } },
+        { responseId: 'response-2', voteType: 'DOWNVOTE', _count: { _all: 1 } },
+      ]);
       mockPrisma.vote.findMany.mockResolvedValue([
-        { responseId: 'response-1', voteType: 'UPVOTE', userId: 'user-1' },
-        { responseId: 'response-2', voteType: 'DOWNVOTE', userId: 'user-1' },
+        { responseId: 'response-1', voteType: 'UPVOTE' },
+        { responseId: 'response-2', voteType: 'DOWNVOTE' },
       ]);
 
       const result = await service.getVoteSummaries(['response-1', 'response-2'], 'user-1');
 
       expect(result.get('response-1')?.userVote).toBe('UPVOTE');
       expect(result.get('response-2')?.userVote).toBe('DOWNVOTE');
+      expect(mockPrisma.vote.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1', responseId: { in: ['response-1', 'response-2'] } },
+        select: { responseId: true, voteType: true },
+      });
     });
 
     it('should initialize summary for responses with no votes', async () => {
-      mockPrisma.vote.findMany.mockResolvedValue([]);
+      mockPrisma.vote.groupBy.mockResolvedValue([]);
 
       const result = await service.getVoteSummaries(['response-1', 'response-2']);
 
@@ -245,9 +255,16 @@ describe('VotesService', () => {
       });
     });
 
+    it('should return an empty map without querying for an empty id list', async () => {
+      const result = await service.getVoteSummaries([]);
+
+      expect(result.size).toBe(0);
+      expect(mockPrisma.vote.groupBy).not.toHaveBeenCalled();
+    });
+
     it('should handle mixed responses with and without votes', async () => {
-      mockPrisma.vote.findMany.mockResolvedValue([
-        { responseId: 'response-1', voteType: 'UPVOTE', userId: 'user-1' },
+      mockPrisma.vote.groupBy.mockResolvedValue([
+        { responseId: 'response-1', voteType: 'UPVOTE', _count: { _all: 1 } },
       ]);
 
       const result = await service.getVoteSummaries(['response-1', 'response-2', 'response-3']);

--- a/services/discussion-service/src/votes/votes.service.ts
+++ b/services/discussion-service/src/votes/votes.service.ts
@@ -81,27 +81,38 @@ export class VotesService {
    * Get vote summary for a response
    */
   async getVoteSummary(responseId: string, userId?: string): Promise<VoteSummaryDto> {
-    const votes = await this.prisma.vote.findMany({
-      where: { responseId },
-    });
+    // Aggregate counts in the database rather than materializing every vote row
+    // and counting in JS. The caller's own vote is fetched with a single
+    // indexed lookup on the (userId, responseId) unique key.
+    const [grouped, userVoteRow] = await Promise.all([
+      this.prisma.vote.groupBy({
+        by: ['voteType'],
+        where: { responseId },
+        _count: { _all: true },
+      }),
+      userId
+        ? this.prisma.vote.findUnique({
+            where: { userId_responseId: { userId, responseId } },
+            select: { voteType: true },
+          })
+        : Promise.resolve(null),
+    ]);
 
-    const upvotes = votes.filter((v: { voteType: string }) => v.voteType === 'UPVOTE').length;
-    const downvotes = votes.filter((v: { voteType: string }) => v.voteType === 'DOWNVOTE').length;
-    const score = upvotes - downvotes;
-
-    let userVote: 'UPVOTE' | 'DOWNVOTE' | null = null;
-    if (userId) {
-      const vote = votes.find((v: { userId: string }) => v.userId === userId);
-      if (vote) {
-        userVote = vote.voteType as 'UPVOTE' | 'DOWNVOTE';
+    let upvotes = 0;
+    let downvotes = 0;
+    for (const group of grouped) {
+      if (group.voteType === 'UPVOTE') {
+        upvotes = group._count._all;
+      } else if (group.voteType === 'DOWNVOTE') {
+        downvotes = group._count._all;
       }
     }
 
     return {
       upvotes,
       downvotes,
-      score,
-      userVote,
+      score: upvotes - downvotes,
+      userVote: (userVoteRow?.voteType as 'UPVOTE' | 'DOWNVOTE' | undefined) ?? null,
     };
   }
 
@@ -112,43 +123,52 @@ export class VotesService {
     responseIds: string[],
     userId?: string,
   ): Promise<Map<string, VoteSummaryDto>> {
-    const votes = await this.prisma.vote.findMany({
-      where: {
-        responseId: {
-          in: responseIds,
-        },
-      },
-    });
-
     const summariesMap = new Map<string, VoteSummaryDto>();
 
-    // Initialize summaries for all responses
+    // Initialize empty summaries so every requested id is present in the result.
     for (const responseId of responseIds) {
-      const responseVotes = votes.filter(
-        (v: { responseId: string }) => v.responseId === responseId,
-      );
-      const upvotes = responseVotes.filter(
-        (v: { voteType: string }) => v.voteType === 'UPVOTE',
-      ).length;
-      const downvotes = responseVotes.filter(
-        (v: { voteType: string }) => v.voteType === 'DOWNVOTE',
-      ).length;
-      const score = upvotes - downvotes;
+      summariesMap.set(responseId, { upvotes: 0, downvotes: 0, score: 0, userVote: null });
+    }
 
-      let userVote: 'UPVOTE' | 'DOWNVOTE' | null = null;
-      if (userId) {
-        const vote = responseVotes.find((v: { userId: string }) => v.userId === userId);
-        if (vote) {
-          userVote = vote.voteType as 'UPVOTE' | 'DOWNVOTE';
-        }
+    if (responseIds.length === 0) {
+      return summariesMap;
+    }
+
+    // One grouped aggregation for all responses (instead of fetching every vote
+    // row and filtering per response in a loop, which was O(responses × votes)),
+    // plus a single targeted lookup for the caller's own votes.
+    const [grouped, userVotes] = await Promise.all([
+      this.prisma.vote.groupBy({
+        by: ['responseId', 'voteType'],
+        where: { responseId: { in: responseIds } },
+        _count: { _all: true },
+      }),
+      userId
+        ? this.prisma.vote.findMany({
+            where: { userId, responseId: { in: responseIds } },
+            select: { responseId: true, voteType: true },
+          })
+        : Promise.resolve([] as { responseId: string; voteType: string }[]),
+    ]);
+
+    for (const group of grouped) {
+      const summary = summariesMap.get(group.responseId);
+      if (!summary) {
+        continue;
       }
+      if (group.voteType === 'UPVOTE') {
+        summary.upvotes = group._count._all;
+      } else if (group.voteType === 'DOWNVOTE') {
+        summary.downvotes = group._count._all;
+      }
+      summary.score = summary.upvotes - summary.downvotes;
+    }
 
-      summariesMap.set(responseId, {
-        upvotes,
-        downvotes,
-        score,
-        userVote,
-      });
+    for (const vote of userVotes) {
+      const summary = summariesMap.get(vote.responseId);
+      if (summary) {
+        summary.userVote = vote.voteType as 'UPVOTE' | 'DOWNVOTE';
+      }
     }
 
     return summariesMap;

--- a/services/notification-service/src/constants/index.ts
+++ b/services/notification-service/src/constants/index.ts
@@ -54,6 +54,8 @@ export const QUERY_LIMITS = {
   SLA_BREACH: 500,
   /** Limit for common ground notification queries */
   COMMON_GROUND: 1000,
+  /** Limit for reading back a batch of mention notifications */
+  MENTIONS: 1000,
   /** Limit for parent digest queries */
   PARENT_DIGEST: 10000,
   /** Limit for digest topic queries */

--- a/services/notification-service/src/handlers/common-ground-notification.handler.ts
+++ b/services/notification-service/src/handlers/common-ground-notification.handler.ts
@@ -20,12 +20,64 @@ import type {
 @Injectable()
 export class CommonGroundNotificationHandler {
   private readonly logger = new Logger(CommonGroundNotificationHandler.name);
+  /**
+   * Maximum number of notification deliveries processed concurrently. A single
+   * common-ground event fans out to every topic participant, so unbounded
+   * concurrency would launch thousands of simultaneous DB queries and SES/FCM
+   * calls, exhausting the Prisma connection pool and risking provider throttling.
+   */
+  private static readonly DELIVERY_CONCURRENCY = 10;
 
   constructor(
     private readonly prisma: PrismaService,
     private readonly notificationGateway: NotificationGateway,
     private readonly deliveryService: NotificationDeliveryService,
   ) {}
+
+  /**
+   * Deliver notifications to recipients via email/push with bounded concurrency.
+   *
+   * @param recipientIds - Recipient user IDs, aligned by index with notificationIds
+   * @param notificationIds - Created notification IDs (empty string = skip)
+   * @param content - Shared notification content
+   */
+  private async deliverToRecipients(
+    recipientIds: string[],
+    notificationIds: string[],
+    content: { type: string; title: string; body: string; actionUrl: string },
+  ): Promise<void> {
+    const jobs: Array<() => Promise<void>> = [];
+    for (let i = 0; i < recipientIds.length; i++) {
+      const userId = recipientIds[i]!;
+      const notificationId = notificationIds[i];
+      if (!notificationId) {
+        continue;
+      }
+      jobs.push(async () => {
+        try {
+          await this.deliveryService.deliverNotification(userId, {
+            id: notificationId,
+            ...content,
+          });
+        } catch (err) {
+          this.logger.error(`Failed to deliver notification ${notificationId}: ${err}`);
+        }
+      });
+    }
+
+    // Run a fixed pool of workers that pull jobs off a shared cursor, capping
+    // in-flight deliveries at DELIVERY_CONCURRENCY regardless of topic size.
+    let cursor = 0;
+    const workerCount = Math.min(CommonGroundNotificationHandler.DELIVERY_CONCURRENCY, jobs.length);
+    const workers = Array.from({ length: workerCount }, async () => {
+      while (cursor < jobs.length) {
+        const jobIndex = cursor;
+        cursor += 1;
+        await jobs[jobIndex]!();
+      }
+    });
+    await Promise.all(workers);
+  }
 
   /**
    * Handle common-ground.generated event
@@ -96,28 +148,17 @@ export class CommonGroundNotificationHandler {
         `Created ${recipientIds.length} notifications for common-ground.generated event`,
       );
 
-      // Deliver notifications via email/push based on user preferences
-      for (let i = 0; i < recipientIds.length; i++) {
-        const userId = recipientIds[i]!;
-        const notificationId = notificationIds[i];
-        if (notificationId) {
-          // Fire and forget - don't block on delivery
-          this.deliveryService
-            .deliverNotification(userId, {
-              id: notificationId,
-              type: 'common_ground',
-              title,
-              body,
-              actionUrl,
-            })
-            .catch((err) => {
-              this.logger.error(`Failed to deliver notification ${notificationId}: ${err}`);
-            });
-        }
-      }
-
-      // Emit WebSocket event for real-time delivery
+      // Emit WebSocket event for real-time delivery first so the in-app channel
+      // stays prompt regardless of email/push fanout duration.
       this.notificationGateway.emitCommonGroundGenerated(event);
+
+      // Deliver via email/push with bounded concurrency.
+      await this.deliverToRecipients(recipientIds, notificationIds, {
+        type: 'common_ground',
+        title,
+        body,
+        actionUrl,
+      });
     } catch (error) {
       this.logger.error(
         `Failed to handle common-ground.generated event: ${error instanceof Error ? error.message : String(error)}`,
@@ -190,28 +231,17 @@ export class CommonGroundNotificationHandler {
         `Created ${recipientIds.length} notifications for common-ground.updated event`,
       );
 
-      // Deliver notifications via email/push based on user preferences
-      for (let i = 0; i < recipientIds.length; i++) {
-        const userId = recipientIds[i]!;
-        const notificationId = notificationIds[i];
-        if (notificationId) {
-          // Fire and forget - don't block on delivery
-          this.deliveryService
-            .deliverNotification(userId, {
-              id: notificationId,
-              type: 'common_ground',
-              title,
-              body,
-              actionUrl,
-            })
-            .catch((err) => {
-              this.logger.error(`Failed to deliver notification ${notificationId}: ${err}`);
-            });
-        }
-      }
-
-      // Emit WebSocket event for real-time delivery
+      // Emit WebSocket event for real-time delivery first so the in-app channel
+      // stays prompt regardless of email/push fanout duration.
       this.notificationGateway.emitCommonGroundUpdated(event);
+
+      // Deliver via email/push with bounded concurrency.
+      await this.deliverToRecipients(recipientIds, notificationIds, {
+        type: 'common_ground',
+        title,
+        body,
+        actionUrl,
+      });
     } catch (error) {
       this.logger.error(
         `Failed to handle common-ground.updated event: ${error instanceof Error ? error.message : String(error)}`,

--- a/services/notification-service/src/handlers/mention-notification.handler.test.ts
+++ b/services/notification-service/src/handlers/mention-notification.handler.test.ts
@@ -17,6 +17,8 @@ const createMockPrismaService = () => ({
   },
   notification: {
     create: vi.fn().mockResolvedValue({ id: 'notification-123' }),
+    createMany: vi.fn().mockResolvedValue({ count: 0 }),
+    findMany: vi.fn().mockResolvedValue([]),
   },
 });
 
@@ -209,6 +211,16 @@ describe('MentionNotificationHandler', () => {
           content: '@[Alice](user-1) and @[Bob](user-2), thoughts?',
         }),
       );
+
+      // Notifications are batch-inserted with a single createMany, not N creates.
+      expect(mockPrisma.notification.createMany).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.notification.create).not.toHaveBeenCalled();
+      expect(mockPrisma.notification.createMany).toHaveBeenCalledWith({
+        data: expect.arrayContaining([
+          expect.objectContaining({ userId: 'user-1', type: 'mention' }),
+          expect.objectContaining({ userId: 'user-2', type: 'mention' }),
+        ]),
+      });
 
       expect(mockGateway.emitToUser).toHaveBeenCalledTimes(2);
       expect(mockGateway.emitToUser).toHaveBeenCalledWith(

--- a/services/notification-service/src/handlers/mention-notification.handler.ts
+++ b/services/notification-service/src/handlers/mention-notification.handler.ts
@@ -219,26 +219,42 @@ export class MentionNotificationHandler {
   }): Promise<string[]> {
     const { recipientIds, type, title, body, actionUrl, metadata } = params;
 
+    if (recipientIds.length === 0) {
+      return [];
+    }
+
     this.logger.log(`Creating ${recipientIds.length} notification(s) of type "${type}"`);
 
-    // Create notifications individually to get IDs back
-    const notifications = await Promise.all(
-      recipientIds.map((userId) =>
-        this.prisma.notification.create({
-          data: {
-            userId,
-            type,
-            title,
-            body,
-            actionUrl,
-            metadata: metadata as Prisma.InputJsonValue,
-            isRead: false,
-          },
-          select: { id: true },
-        }),
-      ),
-    );
+    // Batch insert (single INSERT) instead of N individual creates, then read
+    // the rows back to recover their generated IDs — the same pattern used by
+    // the common-ground handler.
+    const createdAt = new Date();
+    await this.prisma.notification.createMany({
+      data: recipientIds.map((userId) => ({
+        userId,
+        type,
+        title,
+        body,
+        actionUrl,
+        metadata: metadata as Prisma.InputJsonValue,
+        isRead: false,
+        createdAt,
+      })),
+    });
 
-    return notifications.map((n) => n.id);
+    // Query back the batch we just inserted (matched by userId set + type +
+    // exact createdAt) to map IDs back to recipients in order.
+    const notifications = await this.prisma.notification.findMany({
+      where: {
+        userId: { in: recipientIds },
+        type,
+        createdAt,
+      },
+      select: { id: true, userId: true },
+      take: QUERY_LIMITS.MENTIONS,
+    });
+
+    const idByUserId = new Map(notifications.map((n) => [n.userId, n.id]));
+    return recipientIds.map((userId) => idByUserId.get(userId) ?? '');
   }
 }

--- a/services/user-service/src/compliance/__tests__/data-deletion.service.test.ts
+++ b/services/user-service/src/compliance/__tests__/data-deletion.service.test.ts
@@ -34,10 +34,26 @@ describe('DataDeletionService', () => {
       updateMany: ReturnType<typeof vi.fn>;
       deleteMany: ReturnType<typeof vi.fn>;
     };
+    videoUpload: {
+      findMany: ReturnType<typeof vi.fn>;
+      deleteMany: ReturnType<typeof vi.fn>;
+    };
+    verificationRecord: {
+      deleteMany: ReturnType<typeof vi.fn>;
+    };
+    verificationToken: {
+      deleteMany: ReturnType<typeof vi.fn>;
+    };
+    activityEvent: {
+      deleteMany: ReturnType<typeof vi.fn>;
+    };
     $transaction: ReturnType<typeof vi.fn>;
   };
   let mockAuditService: {
     logAction: ReturnType<typeof vi.fn>;
+  };
+  let mockS3Service: {
+    deleteObject: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -64,6 +80,19 @@ describe('DataDeletionService', () => {
         updateMany: vi.fn(),
         deleteMany: vi.fn(),
       },
+      videoUpload: {
+        findMany: vi.fn().mockResolvedValue([]),
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      verificationRecord: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      verificationToken: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      activityEvent: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
       $transaction: vi.fn((callback) => callback(mockPrisma)),
     };
 
@@ -71,9 +100,14 @@ describe('DataDeletionService', () => {
       logAction: vi.fn().mockResolvedValue({}),
     };
 
+    mockS3Service = {
+      deleteObject: vi.fn().mockResolvedValue(undefined),
+    };
+
     service = new DataDeletionService(
       mockPrisma as unknown as PrismaService,
       mockAuditService as unknown as ComplianceAuditService,
+      mockS3Service as unknown as import('../../services/s3.service.js').S3Service,
     );
   });
 
@@ -250,6 +284,73 @@ describe('DataDeletionService', () => {
 
       expect(result.success).toBe(true);
       expect(result.deletionLog).toBeDefined();
+    });
+
+    it('should null all PII columns and delete verification + activity data', async () => {
+      const requestId = 'request-123';
+      const userId = 'user-123';
+
+      mockPrisma.dataDeletionRequest.findUnique.mockResolvedValue({
+        id: requestId,
+        userId,
+        requestedBy: 'PARENT',
+        scheduledFor: new Date(),
+        status: DeletionStatus.PENDING,
+      });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: userId,
+        email: 'child@example.com',
+        displayName: 'Test Child',
+      });
+      mockPrisma.response.count.mockResolvedValue(0);
+      mockPrisma.discussionTopic.findMany.mockResolvedValue([]);
+      mockPrisma.$transaction.mockImplementation(async (callback) =>
+        typeof callback === 'function' ? callback(mockPrisma) : Promise.all(callback),
+      );
+      mockPrisma.dataDeletionRequest.update.mockResolvedValue({});
+      mockPrisma.parentalConsent.delete.mockResolvedValue({});
+      mockPrisma.user.update.mockResolvedValue({});
+
+      // Verification videos exist in S3.
+      mockPrisma.videoUpload.findMany.mockResolvedValue([
+        { s3Key: 'videos/user-123/a.webm' },
+        { s3Key: 'videos/user-123/b.webm' },
+      ]);
+      mockPrisma.videoUpload.deleteMany.mockResolvedValue({ count: 2 });
+      mockPrisma.verificationRecord.deleteMany.mockResolvedValue({ count: 3 });
+      mockPrisma.verificationToken.deleteMany.mockResolvedValue({ count: 1 });
+      mockPrisma.activityEvent.deleteMany.mockResolvedValue({ count: 7 });
+
+      const result = await service.executeDeletion(requestId);
+
+      // PII columns beyond the original set are now scrubbed.
+      const userUpdateData = mockPrisma.user.update.mock.calls[0]![0].data;
+      expect(userUpdateData).toMatchObject({
+        emailHash: null,
+        parentPhone: null,
+        bio: null,
+        avatarUrl: null,
+        avatarS3Key: null,
+        accountStatus: 'DELETED',
+      });
+
+      // Related records are deleted by userId.
+      expect(mockPrisma.videoUpload.deleteMany).toHaveBeenCalledWith({ where: { userId } });
+      expect(mockPrisma.verificationRecord.deleteMany).toHaveBeenCalledWith({ where: { userId } });
+      expect(mockPrisma.verificationToken.deleteMany).toHaveBeenCalledWith({ where: { userId } });
+      expect(mockPrisma.activityEvent.deleteMany).toHaveBeenCalledWith({ where: { userId } });
+
+      // S3 verification videos are deleted after the DB commit.
+      expect(mockS3Service.deleteObject).toHaveBeenCalledTimes(2);
+      expect(mockS3Service.deleteObject).toHaveBeenCalledWith('videos/user-123/a.webm');
+
+      expect(result.deletionLog).toMatchObject({
+        verificationRecordsDeleted: 3,
+        videoUploadsDeleted: 2,
+        videoObjectsDeleted: 2,
+        verificationTokensDeleted: 1,
+        activityEventsDeleted: 7,
+      });
     });
 
     it('should mark request as FAILED if deletion fails', async () => {

--- a/services/user-service/src/compliance/__tests__/parental-consent-dashboard.test.ts
+++ b/services/user-service/src/compliance/__tests__/parental-consent-dashboard.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { NotFoundException } from '@nestjs/common';
+import { NotFoundException, ForbiddenException } from '@nestjs/common';
 import { ParentalConsentService } from '../parental-consent.service.js';
 
 // Mock data factory
@@ -155,6 +155,31 @@ describe('ParentalConsentService - Child Activity & Consent Withdrawal', () => {
 
       expect(result.childDisplayName).toBe('Anonymous User');
     });
+
+    it('should throw ForbiddenException for an expired token', async () => {
+      const expiredConsent = createMockConsentRecord({
+        tokenExpiresAt: new Date('2024-01-01'),
+      });
+      mockPrisma.parentalConsent.findUnique.mockResolvedValue(expiredConsent);
+
+      await expect(service.getChildActivitySummary('valid-token-abc123')).rejects.toThrow(
+        ForbiddenException,
+      );
+      // Must not fall through to loading the child's activity.
+      expect(mockPrisma.response.count).not.toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException for an already-withdrawn token', async () => {
+      const withdrawnConsent = createMockConsentRecord({
+        withdrawnAt: new Date('2025-02-01'),
+      });
+      mockPrisma.parentalConsent.findUnique.mockResolvedValue(withdrawnConsent);
+
+      await expect(service.getChildActivitySummary('valid-token-abc123')).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockPrisma.response.count).not.toHaveBeenCalled();
+    });
   });
 
   describe('withdrawConsentByToken', () => {
@@ -178,6 +203,31 @@ describe('ParentalConsentService - Child Activity & Consent Withdrawal', () => {
       await expect(service.withdrawConsentByToken('invalid-token')).rejects.toThrow(
         NotFoundException,
       );
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException for an expired token', async () => {
+      const expiredConsent = createMockConsentRecord({
+        tokenExpiresAt: new Date('2024-01-01'),
+      });
+      mockPrisma.parentalConsent.findUnique.mockResolvedValue(expiredConsent);
+
+      await expect(service.withdrawConsentByToken('valid-token-abc123')).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('should be idempotent: reject an already-withdrawn token without re-triggering deletion', async () => {
+      const withdrawnConsent = createMockConsentRecord({
+        withdrawnAt: new Date('2025-02-01'),
+      });
+      mockPrisma.parentalConsent.findUnique.mockResolvedValue(withdrawnConsent);
+
+      await expect(service.withdrawConsentByToken('valid-token-abc123')).rejects.toThrow(
+        ForbiddenException,
+      );
+      // A second withdrawal must not re-run the transaction or deletion request.
       expect(mockPrisma.$transaction).not.toHaveBeenCalled();
     });
   });

--- a/services/user-service/src/compliance/compliance.module.ts
+++ b/services/user-service/src/compliance/compliance.module.ts
@@ -19,6 +19,8 @@ import { ParentalDashboardController } from './parental-dashboard.controller.js'
 import { ComplianceController } from './compliance.controller.js';
 import { AdminGuard } from './guards/admin.guard.js';
 import { EmailService } from '../services/email.service.js';
+import { S3Service } from '../services/s3.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
 import { PrismaModule } from '../prisma/prisma.module.js';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard.js';
 import { GeoModule } from '../geo/index.js';
@@ -56,18 +58,24 @@ import { GeoModule } from '../geo/index.js';
     ParentalConsentService,
     ComplianceAuditService,
     ComplianceReportService,
-    DataDeletionService,
     DataDeletionJob,
     AgeReverificationJob,
     EmailService,
+    S3Service,
     AdminGuard,
-    // Factory provider that explicitly injects dependencies
-    // This bypasses NestJS's reflection-based DI which can hang with @Optional() decorators
+    // Factory providers that explicitly inject dependencies.
+    // This bypasses NestJS's reflection-based DI which can hang with @Optional() decorators.
     {
       provide: JwtAuthGuard,
       useFactory: (jwtService: JwtService, configService: ConfigService) =>
         new JwtAuthGuard(jwtService, configService),
       inject: [JwtService, ConfigService],
+    },
+    {
+      provide: DataDeletionService,
+      useFactory: (prisma: PrismaService, audit: ComplianceAuditService, s3Service: S3Service) =>
+        new DataDeletionService(prisma, audit, s3Service),
+      inject: [PrismaService, ComplianceAuditService, S3Service],
     },
   ],
   exports: [

--- a/services/user-service/src/compliance/data-deletion.service.ts
+++ b/services/user-service/src/compliance/data-deletion.service.ts
@@ -3,13 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, Optional, Inject } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { ComplianceAuditService } from './compliance-audit.service.js';
+import { S3Service } from '../services/s3.service.js';
 import {
   DeletionStatus,
   ComplianceAction,
   AccountStatus,
+  Prisma,
   type DataDeletionRequest,
 } from '@prisma/client';
 
@@ -42,6 +44,11 @@ export interface DeletionLog {
   topicsDeleted: number;
   topicsTransferred: number;
   parentalConsentDeleted: boolean;
+  verificationRecordsDeleted: number;
+  videoUploadsDeleted: number;
+  videoObjectsDeleted: number;
+  verificationTokensDeleted: number;
+  activityEventsDeleted: number;
   userAnonymized: boolean;
   retainedRecords: string[];
   completedAt: string;
@@ -97,6 +104,10 @@ export class DataDeletionService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly auditService: ComplianceAuditService,
+    // Optional so unit tests and environments without object storage configured
+    // still construct the service; S3 object cleanup is skipped (and logged)
+    // when it is not provided.
+    @Optional() @Inject(S3Service) private readonly s3Service?: S3Service,
   ) {}
 
   /**
@@ -166,6 +177,41 @@ export class DataDeletionService {
   }
 
   /**
+   * Best-effort deletion of S3 objects (e.g. identity-verification videos).
+   *
+   * @param keys - S3 object keys to delete
+   * @param userId - The owning user (for logging)
+   * @returns The number of objects successfully deleted
+   *
+   * @remarks
+   * Never throws: object storage is not transactional, so a failure here must
+   * not roll back an already-committed database deletion. Failures are logged
+   * for follow-up.
+   */
+  private async deleteS3Objects(keys: string[], userId: string): Promise<number> {
+    if (!this.s3Service) {
+      this.logger.warn(
+        `S3Service unavailable; ${keys.length} verification video object(s) for user ${userId} were not removed from storage`,
+      );
+      return 0;
+    }
+
+    let deleted = 0;
+    for (const key of keys) {
+      try {
+        await this.s3Service.deleteObject(key);
+        deleted += 1;
+      } catch (error) {
+        this.logger.error(
+          `Failed to delete S3 object ${key} for user ${userId}`,
+          error instanceof Error ? error.stack : String(error),
+        );
+      }
+    }
+    return deleted;
+  }
+
+  /**
    * Execute data deletion for a specific request
    *
    * @param requestId - The ID of the deletion request to execute
@@ -196,10 +242,19 @@ export class DataDeletionService {
       topicsDeleted: 0,
       topicsTransferred: 0,
       parentalConsentDeleted: false,
+      verificationRecordsDeleted: 0,
+      videoUploadsDeleted: 0,
+      videoObjectsDeleted: 0,
+      verificationTokensDeleted: 0,
+      activityEventsDeleted: 0,
       userAnonymized: false,
       retainedRecords: ['ComplianceAuditLog', 'SafetyReports'],
       completedAt: '',
     };
+
+    // S3 keys of verification videos, captured inside the transaction so the
+    // objects can be deleted from object storage after the DB commit.
+    let videoS3Keys: string[] = [];
 
     try {
       // Mark as in progress
@@ -266,11 +321,47 @@ export class DataDeletionService {
           this.logger.debug(`No parental consent record found for user ${request.userId}`);
         }
 
-        // 4. Anonymize user record (keep ID for referential integrity)
+        // 4. Delete identity-verification data. The user row is anonymized in
+        //    place (not hard-deleted), so onDelete: Cascade never fires — these
+        //    rows must be removed explicitly or they retain PII (phone numbers,
+        //    S3 video keys, potentially of minors).
+        const videoUploads = await tx.videoUpload.findMany({
+          where: { userId: request.userId },
+          select: { s3Key: true },
+          take: 10000,
+        });
+        videoS3Keys = videoUploads.map((v) => v.s3Key);
+
+        const videoUploadsDeleted = await tx.videoUpload.deleteMany({
+          where: { userId: request.userId },
+        });
+        deletionLog.videoUploadsDeleted = videoUploadsDeleted.count;
+
+        const verificationRecordsDeleted = await tx.verificationRecord.deleteMany({
+          where: { userId: request.userId },
+        });
+        deletionLog.verificationRecordsDeleted = verificationRecordsDeleted.count;
+
+        const verificationTokensDeleted = await tx.verificationToken.deleteMany({
+          where: { userId: request.userId },
+        });
+        deletionLog.verificationTokensDeleted = verificationTokensDeleted.count;
+
+        // 5. Delete the user's activity feed events (contain denormalized PII).
+        const activityEventsDeleted = await tx.activityEvent.deleteMany({
+          where: { userId: request.userId },
+        });
+        deletionLog.activityEventsDeleted = activityEventsDeleted.count;
+
+        // 6. Anonymize user record (keep ID for referential integrity). Null out
+        //    every remaining PII column — including emailHash (used for contact
+        //    discovery, so a "deleted" user would otherwise stay findable),
+        //    parentPhone, bio, and avatar references.
         await tx.user.update({
           where: { id: request.userId },
           data: {
             email: `deleted-${request.userId}@deleted.reasonbridge.org`,
+            emailHash: null,
             displayName: '[Deleted User]',
             passwordHash: null,
             phoneNumber: null,
@@ -278,11 +369,23 @@ export class DataDeletionService {
             emailVerified: false,
             birthDate: null,
             parentEmail: null,
+            parentPhone: null,
+            bio: null,
+            avatarUrl: null,
+            avatarS3Key: null,
+            avatarUrls: Prisma.DbNull,
             accountStatus: AccountStatus.DELETED,
           },
         });
         deletionLog.userAnonymized = true;
       });
+
+      // Best-effort deletion of verification-video objects from S3. Done after
+      // the DB commit (S3 is not transactional); failures are logged but must
+      // not roll back the completed database deletion.
+      if (videoS3Keys.length > 0) {
+        deletionLog.videoObjectsDeleted = await this.deleteS3Objects(videoS3Keys, request.userId);
+      }
 
       // Mark as completed
       deletionLog.completedAt = new Date().toISOString();

--- a/services/user-service/src/compliance/parental-consent.service.ts
+++ b/services/user-service/src/compliance/parental-consent.service.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { randomBytes } from 'crypto';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { EmailService } from '../services/email.service.js';
@@ -334,6 +334,37 @@ export class ParentalConsentService {
   }
 
   /**
+   * Validate that a consent token is still usable for the unauthenticated
+   * dashboard/withdrawal endpoints.
+   *
+   * @param consent - The consent record loaded by token
+   * @throws {ForbiddenException} When the token has already been withdrawn
+   * @throws {ForbiddenException} When the token has expired
+   *
+   * @remarks
+   * The consent token is a bearer credential embedded in an emailed URL. Without
+   * these checks a leaked link (forwarded email, browser history, proxy logs)
+   * could be replayed indefinitely — including re-triggering an irreversible
+   * data-deletion request. This mirrors the expiry/single-use validation already
+   * enforced by {@link verifyConsent}.
+   */
+  private assertConsentTokenUsable(consent: {
+    userId: string;
+    tokenExpiresAt: Date;
+    withdrawnAt: Date | null;
+  }): void {
+    if (consent.withdrawnAt) {
+      this.logger.warn(`Consent token already withdrawn for user ${consent.userId}`);
+      throw new ForbiddenException('Parental consent has already been withdrawn');
+    }
+
+    if (consent.tokenExpiresAt < new Date()) {
+      this.logger.warn(`Consent token expired for user ${consent.userId}`);
+      throw new ForbiddenException('Consent token has expired. Please request a new one.');
+    }
+  }
+
+  /**
    * Get child's activity summary by consent token
    *
    * @param token - The consent token from the parental consent email
@@ -363,6 +394,10 @@ export class ParentalConsentService {
     if (!consent) {
       throw new NotFoundException('Invalid consent token');
     }
+
+    // A leaked dashboard link must not work forever: reject expired or
+    // already-withdrawn tokens, mirroring verifyConsent's validation.
+    this.assertConsentTokenUsable(consent);
 
     // Get activity statistics for the child
     const [topicsParticipated, responsesPosted] = await Promise.all([
@@ -420,6 +455,10 @@ export class ParentalConsentService {
     if (!consent) {
       throw new NotFoundException('Invalid consent token');
     }
+
+    // Reject expired tokens and make withdrawal idempotent: an already-withdrawn
+    // token must not re-trigger a data-deletion request (issue #1288).
+    this.assertConsentTokenUsable(consent);
 
     this.logger.log(`Withdrawing parental consent via token for user ${consent.userId}`);
 

--- a/services/user-service/src/expertise/__tests__/expertise.service.test.ts
+++ b/services/user-service/src/expertise/__tests__/expertise.service.test.ts
@@ -453,10 +453,9 @@ describe('ExpertiseService', () => {
       mockPrisma.user.findUnique.mockResolvedValue(mockUser);
       mockPrisma.tag.findUnique.mockResolvedValue(mockTag);
       mockPrisma.response.count.mockResolvedValue(25); // Category response count
-      mockPrisma.response.findMany.mockResolvedValue([
-        { id: 'resp-1', createdAt: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000) },
-        { id: 'resp-2', createdAt: new Date(Date.now() - 80 * 24 * 60 * 60 * 1000) },
-      ]);
+      mockPrisma.response.findFirst.mockResolvedValue({
+        createdAt: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000),
+      });
       mockPrisma.vote.groupBy.mockResolvedValue([
         { voteType: 'UPVOTE', _count: { id: 15 } },
         { voteType: 'DOWNVOTE', _count: { id: 5 } },
@@ -521,9 +520,9 @@ describe('ExpertiseService', () => {
       mockPrisma.user.findUnique.mockResolvedValue(mockUser);
       mockPrisma.tag.findUnique.mockResolvedValue(mockTag);
       mockPrisma.response.count.mockResolvedValue(10);
-      mockPrisma.response.findMany.mockResolvedValue([
-        { id: 'resp-1', createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) },
-      ]);
+      mockPrisma.response.findFirst.mockResolvedValue({
+        createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+      });
       mockPrisma.vote.groupBy.mockResolvedValue([]);
       mockPrisma.feedback.groupBy.mockResolvedValue([]);
       mockPrisma.domainCredential.findMany.mockResolvedValue(mockCredentials);
@@ -548,7 +547,7 @@ describe('ExpertiseService', () => {
       mockPrisma.user.findUnique.mockResolvedValue(mockUser);
       mockPrisma.tag.findUnique.mockResolvedValue(mockTag);
       mockPrisma.response.count.mockResolvedValue(10);
-      mockPrisma.response.findMany.mockResolvedValue([{ id: 'resp-1', createdAt: new Date() }]);
+      mockPrisma.response.findFirst.mockResolvedValue({ createdAt: new Date() });
       mockPrisma.vote.groupBy.mockResolvedValue([]);
       mockPrisma.feedback.groupBy.mockResolvedValue([]);
       mockPrisma.domainCredential.findMany.mockResolvedValue([]);
@@ -586,8 +585,8 @@ describe('ExpertiseService', () => {
       mockPrisma.user.findUnique.mockResolvedValue(mockUser);
       mockPrisma.tag.findUnique.mockResolvedValue(mockTag);
       mockPrisma.response.count.mockResolvedValue(0);
-      mockPrisma.response.findMany.mockResolvedValue([]);
-      // Note: vote and feedback groupBy won't be called when no responses exist
+      mockPrisma.response.findFirst.mockResolvedValue(null);
+      // Aggregations run against the relation filter and return empty groups.
       mockPrisma.vote.groupBy.mockResolvedValue([]);
       mockPrisma.feedback.groupBy.mockResolvedValue([]);
       mockPrisma.domainCredential.findMany.mockResolvedValue([]);
@@ -612,9 +611,9 @@ describe('ExpertiseService', () => {
       mockPrisma.user.findUnique.mockResolvedValue(mockUser);
       mockPrisma.tag.findUnique.mockResolvedValue(mockTag);
       mockPrisma.response.count.mockResolvedValue(50); // Max engagement
-      mockPrisma.response.findMany.mockResolvedValue([
-        { id: 'resp-1', createdAt: new Date(Date.now() - 180 * 24 * 60 * 60 * 1000) }, // Max tenure
-      ]);
+      mockPrisma.response.findFirst.mockResolvedValue({
+        createdAt: new Date(Date.now() - 180 * 24 * 60 * 60 * 1000), // Max tenure
+      });
       mockPrisma.vote.groupBy.mockResolvedValue([
         { voteType: 'UPVOTE', _count: { id: 100 } },
         { voteType: 'DOWNVOTE', _count: { id: 10 } },

--- a/services/user-service/src/expertise/expertise.service.ts
+++ b/services/user-service/src/expertise/expertise.service.ts
@@ -229,38 +229,41 @@ export class ExpertiseService {
     userId: string,
     tagId: string,
   ): Promise<{ avgQualityScore: number; firstResponseDate: Date | null }> {
-    // Get all response IDs for this user in topics with the specified tag
-    const responses = await this.prisma.response.findMany({
-      where: {
-        authorId: userId,
-        topic: {
-          tags: {
-            some: { tagId },
-          },
+    // Match this user's responses in topics carrying the given tag. This filter
+    // is applied through the `response` relation in the aggregations below so
+    // the database performs the join, instead of pulling up to
+    // QUERY_LIMITS.EXPERTISE_METRICS (10k) response IDs into the app and
+    // shipping them back as a SQL IN-list.
+    const responseWhere: Prisma.ResponseWhereInput = {
+      authorId: userId,
+      topic: {
+        tags: {
+          some: { tagId },
         },
       },
-      orderBy: { createdAt: 'asc' },
-      select: { id: true, createdAt: true },
-      take: QUERY_LIMITS.EXPERTISE_METRICS,
-    });
+    };
 
-    if (responses.length === 0) {
+    // The earliest response date only needs one indexed row, and the quality
+    // score aggregates set-based over the same filter — both run in parallel.
+    const [firstResponse, avgQualityScore] = await Promise.all([
+      this.prisma.response.findFirst({
+        where: responseWhere,
+        orderBy: { createdAt: 'asc' },
+        select: { createdAt: true },
+      }),
+      this.calculateQualityScore(responseWhere),
+    ]);
+
+    if (!firstResponse) {
       return {
         avgQualityScore: 0.5, // Neutral default for users with no responses
         firstResponseDate: null,
       };
     }
 
-    const responseIds = responses.map((r) => r.id);
-    // Safe to use ! since we already checked responses.length > 0 above
-    const firstResponseDate = responses[0]!.createdAt;
-
-    // Calculate quality score from votes and feedback
-    const avgQualityScore = await this.calculateQualityScore(responseIds);
-
     return {
       avgQualityScore,
-      firstResponseDate,
+      firstResponseDate: firstResponse.createdAt,
     };
   }
 
@@ -273,24 +276,35 @@ export class ExpertiseService {
    *
    * If no data is available for a signal, it defaults to 0.5 (neutral).
    *
-   * @param responseIds - IDs of responses to calculate quality for
+   * @param responseWhere - Filter selecting the responses to score, applied
+   *   through the `response` relation so the aggregation joins in the database
    * @returns Quality score between 0 and 1
    */
-  private async calculateQualityScore(responseIds: string[]): Promise<number> {
-    if (responseIds.length === 0) {
-      return 0.5;
-    }
-
-    // Get vote counts
-    const voteCounts = await this.prisma.vote.groupBy({
-      by: ['voteType'],
-      where: {
-        responseId: { in: responseIds },
-      },
-      _count: {
-        id: true,
-      },
-    });
+  private async calculateQualityScore(responseWhere: Prisma.ResponseWhereInput): Promise<number> {
+    // Run vote and feedback aggregations in parallel, joining to the matching
+    // responses via the relation filter. Empty groups fall through to the
+    // neutral 0.5 defaults below.
+    const [voteCounts, feedbackCounts] = await Promise.all([
+      this.prisma.vote.groupBy({
+        by: ['voteType'],
+        where: {
+          response: responseWhere,
+        },
+        _count: {
+          id: true,
+        },
+      }),
+      this.prisma.feedback.groupBy({
+        by: ['userHelpfulRating'],
+        where: {
+          response: responseWhere,
+          userHelpfulRating: { not: null },
+        },
+        _count: {
+          id: true,
+        },
+      }),
+    ]);
 
     let upvotes = 0;
     let downvotes = 0;
@@ -301,18 +315,6 @@ export class ExpertiseService {
         downvotes = vc._count.id;
       }
     }
-
-    // Get feedback helpfulness ratings
-    const feedbackCounts = await this.prisma.feedback.groupBy({
-      by: ['userHelpfulRating'],
-      where: {
-        responseId: { in: responseIds },
-        userHelpfulRating: { not: null },
-      },
-      _count: {
-        id: true,
-      },
-    });
 
     let helpful = 0;
     let notHelpful = 0;

--- a/services/user-service/src/ranking/ranking-cron.service.ts
+++ b/services/user-service/src/ranking/ranking-cron.service.ts
@@ -46,6 +46,12 @@ export interface RecalculationResult {
 export class RankingCronService {
   private readonly logger = new Logger(RankingCronService.name);
   private readonly BATCH_SIZE = 100;
+  /**
+   * Maximum number of user recalculations run concurrently within a batch.
+   * Bounds the load on the Prisma connection pool and downstream database while
+   * still parallelizing the otherwise strictly-sequential per-user work.
+   */
+  private readonly CONCURRENCY = 10;
   private isRunning = false;
   private lastRecalculation: RecalculationResult | null = null;
 
@@ -133,17 +139,28 @@ export class RankingCronService {
           break;
         }
 
-        // Process each user in the batch
-        for (const user of users) {
-          try {
-            await this.rankingService.recalculateUserRank(user.id);
-            processed++;
-          } catch (error) {
-            errors++;
-            this.logger.error(
-              `Failed to recalculate rank for user ${user.id}: ${error instanceof Error ? error.message : 'Unknown error'}`,
-            );
-          }
+        // Process the batch with bounded concurrency instead of one user at a
+        // time, so a batch of N users issues at most CONCURRENCY sets of
+        // queries in flight rather than serializing every round-trip.
+        for (let offset = 0; offset < users.length; offset += this.CONCURRENCY) {
+          const chunk = users.slice(offset, offset + this.CONCURRENCY);
+          const results = await Promise.allSettled(
+            chunk.map((user) => this.rankingService.recalculateUserRank(user.id)),
+          );
+
+          results.forEach((result, index) => {
+            if (result.status === 'fulfilled') {
+              processed++;
+            } else {
+              errors++;
+              const reason = result.reason;
+              this.logger.error(
+                `Failed to recalculate rank for user ${chunk[index]?.id}: ${
+                  reason instanceof Error ? reason.message : 'Unknown error'
+                }`,
+              );
+            }
+          });
         }
 
         // Update cursor for next batch

--- a/services/user-service/src/ranking/ranking.service.ts
+++ b/services/user-service/src/ranking/ranking.service.ts
@@ -240,31 +240,23 @@ export class RankingService {
    * If no data is available for a signal, it defaults to 0.5 (neutral).
    *
    * Uses parallel queries for votes and feedback to reduce latency by ~33%
-   * (2 sequential queries instead of 3).
+   * (2 sequential queries instead of 3). Both queries filter through the
+   * `response` relation (`response: { authorId }`) so the database performs the
+   * join, rather than fetching up to 10k response IDs into the application and
+   * shipping them back as a large SQL IN-list.
    *
    * @param userId - The user's unique identifier
    * @returns Quality score between 0 and 1
    */
   private async calculateQualityScore(userId: string): Promise<number> {
-    // Get response IDs for this user (required for subsequent queries)
-    const responses = await this.prisma.response.findMany({
-      where: { authorId: userId },
-      select: { id: true },
-      take: 10000, // Limit to prevent unbounded results while allowing accurate metrics
-    });
-
-    if (responses.length === 0) {
-      return 0.5; // Neutral default for users with no responses
-    }
-
-    const responseIds = responses.map((r) => r.id);
-
-    // Run vote and feedback queries in parallel (both depend on responseIds)
+    // Run vote and feedback aggregations in parallel, joining to the user's
+    // responses in the database. Users with no responses simply produce empty
+    // groups, which fall through to the neutral 0.5 defaults below.
     const [voteCounts, feedbackCounts] = await Promise.all([
       this.prisma.vote.groupBy({
         by: ['voteType'],
         where: {
-          responseId: { in: responseIds },
+          response: { authorId: userId },
         },
         _count: {
           id: true,
@@ -273,7 +265,7 @@ export class RankingService {
       this.prisma.feedback.groupBy({
         by: ['userHelpfulRating'],
         where: {
-          responseId: { in: responseIds },
+          response: { authorId: userId },
           userHelpfulRating: { not: null },
         },
         _count: {

--- a/services/user-service/src/services/s3.service.ts
+++ b/services/user-service/src/services/s3.service.ts
@@ -106,6 +106,26 @@ export class S3Service {
   }
 
   /**
+   * Delete an arbitrary object from the bucket by key.
+   *
+   * @param key - S3 object key
+   * @throws {Error} When the delete request fails
+   *
+   * @remarks
+   * A general-purpose primitive used, for example, to remove identity
+   * verification videos during GDPR/COPPA data deletion.
+   */
+  async deleteObject(key: string): Promise<void> {
+    const command = new DeleteObjectCommand({
+      Bucket: this.bucket,
+      Key: key,
+    });
+
+    await this.s3Client.send(command);
+    this.logger.log(`S3 object deleted successfully: ${key}`);
+  }
+
+  /**
    * Delete avatar from S3
    * @param key - S3 object key
    */


### PR DESCRIPTION
## Summary

Resolves a batch of backend audit findings spanning privacy/security, performance, and query-planning across the discussion, user, and notification services.

### Security / Privacy
- **#1288 — Parental consent token replay.** The unauthenticated dashboard (`GET child/:token`) and withdrawal (`POST withdraw/:token`) endpoints only checked token *existence*. Added `assertConsentTokenUsable()` enforcing `tokenExpiresAt` and rejecting already-withdrawn tokens (mirroring `verifyConsent`), so a leaked link can no longer be replayed indefinitely or re-trigger an irreversible data-deletion request. Withdrawal is now idempotent.
- **#1289 — GDPR/COPPA deletion left PII behind.** `executeDeletion` now nulls `emailHash` (which kept "deleted" users discoverable via contact matching), `parentPhone`, `bio`, `avatarUrl`, `avatarS3Key`, `avatarUrls`, and hard-deletes `VerificationRecord`, `VideoUpload` (plus the identity-verification videos in S3 via a new `S3Service.deleteObject`), `VerificationToken`, and `ActivityEvent` rows. Because the user row is anonymized in place, `onDelete: Cascade` never fired — these are now removed explicitly. `DeletionLog`/`retainedRecords` report accurately. `DataDeletionService` is wired via a factory provider to keep DI predictable.

### Performance
- **#1306 — N+1 in `countNewParticipants`.** Replaced the per-author `findFirst` loop with a single `groupBy _min(createdAt)`.
- **#1307 — participantCount recomputed per write.** Replaced the full `groupBy` over all topic responses with an indexed EXISTS check that increments `participantCount` only for first-time authors, wrapped with the response create in a `$transaction` to prevent drift. Added composite index `responses(topic_id, author_id)`.
- **#1308 — Unbounded vote/reaction aggregation.** Vote and reaction summaries now aggregate in the database (`groupBy` + `_count`) with a targeted lookup for the caller's own vote/reactions and bounded reaction previews, instead of fetching every row and counting in JS.
- **#1309 — Nightly ranking recompute.** Ranking and expertise quality scores now aggregate through a `response` relation filter (`response: { authorId }`) instead of shipping up-to-10k response-ID IN-lists; the ranking cron processes users with bounded concurrency.

### Query planning
- **#1310 — Leading-wildcard ILIKE with no supporting index.** Added GIN `pg_trgm` indexes on `users.display_name`, `users.email`, and `discussion_topics.description` so `@mention` autocomplete and topic recommendations stop sequential-scanning.
- **#1311 — Notification fanout.** Common-ground delivery now runs with bounded concurrency (worker pool, cap 10) so a large-topic event can't launch thousands of simultaneous DB/SES/FCM calls; mention notifications are batch-inserted via `createMany` + read-back.

## Testing
- `discussion-service`: votes, reactions, responses, topics-analytics unit suites pass; all three services typecheck clean.
- `user-service`: compliance (incl. new consent + deletion assertions), ranking, expertise suites pass (171 + 169).
- `notification-service`: mention handler suite passes; common-ground handler suite verified passing (it is excluded from the default CI run for unrelated Prisma-resolution reasons).
- `prisma validate` passes; new raw SQL migrations added for the composite and trigram indexes.

Fixes #1288
Fixes #1289
Fixes #1306
Fixes #1307
Fixes #1308
Fixes #1309
Fixes #1310
Fixes #1311

🤖 Generated with [Claude Code](https://claude.com/claude-code)