### PR TITLE
Fix delete-merged-branch workflow for slash-containing branch names

### DIFF
--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -13,15 +13,17 @@ concurrency:
 
 jobs:
   delete-branch:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
+      # gh api is used instead of octokit/request-action because the latter
+      # percent-encodes `/` in path placeholders, so branch names containing
+      # slashes (feature/x, ccswitch/y) hit a nonexistent ref and the delete
+      # 404s. Refs may legitimately contain slashes in the URL path.
       - name: Delete head branch
-        uses: octokit/request-action@v2.x
-        with:
-          route: DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
-          branch: ${{ github.event.pull_request.head.ref }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${HEAD_REF}" \
+            || echo "Branch already deleted or protected — nothing to do"


### PR DESCRIPTION
## Summary

Both runs of the `delete-merged-branch` workflow to date have failed with `Reference does not exist`: `octokit/request-action` percent-encodes `/` in the `{branch}` placeholder, so any head branch containing a slash (`feature/x`, `ccswitch/y`) resolves to a nonexistent ref.

- Replace the action with a `gh api -X DELETE` call that keeps the ref inline in the URL path (refs legitimately contain slashes there)
- Skip fork PRs (their head refs can't be deleted from this repo anyway)
- Tolerate already-deleted branches instead of failing the run

Verified with `actionlint`. (PR #1420's branch, which this workflow failed to delete, was cleaned up manually.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)